### PR TITLE
Conform to PEP8 style guide

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+ignore = E402,E501
+exclude = .git,__pycache__,build,data,piper/piper.py

--- a/piper.in
+++ b/piper.in
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 
-import sys
-import signal
-import os
-import locale
 import gettext
+import gi
+import locale
+import os
+import signal
+import sys
 
 from piper import piper
 
-import gi
 gi.require_version('Gio', '2.0')
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gio, Gtk
@@ -23,8 +23,9 @@ if os.path.exists(os.path.join(srcdir, 'meson.build')):
 else:
     pkgdatadir = '@pkgdatadir@'
 
+
 def install_excepthook():
-    """ Make sure we exit when an unhandled exception occurs. """
+    """Make sure we exit when an unhandled exception occurs."""
     old_hook = sys.excepthook
 
     def new_hook(etype, evalue, etb):
@@ -33,6 +34,7 @@ def install_excepthook():
             Gtk.main_quit()
         sys.exit()
     sys.excepthook = new_hook
+
 
 if __name__ == "__main__":
     install_excepthook()


### PR DESCRIPTION
No functional changes, just formatting. Style options are debatable; I don't really have any preference but it's good to have a standard for the code IMO. I went for PEP8 because it's the most used one. Checking for conformance should be done using the `flake8` tool and the configuration given in this commit, i.e. PEP8 specifies docstrings to be of 72 characters wide but since it passes flake8 it's ok.

E402 and E501 are ignored because we don't care (that much) about line length, and GObject Introspection requires us to import things as we currently do.

piper/piper.py has not been fixed as it is going to be removed eventually, when all its relevant bits have found a place in the new code.