### PR TITLE
Add error codes to the ratbagd bindings, plus commit method

### DIFF
--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -92,11 +92,13 @@ class _RatbagdDBus(GObject.GObject):
         # Calls a method synchronously on the bus, using the given method name,
         # type signature and values. Returns the returned result, or None.
         val = GLib.Variant("({})".format(type), value)
-        res = self._proxy.call_sync(method, val,
-                                    Gio.DBusCallFlags.NO_AUTO_START, 500, None)
-        if res is not None:
+        try:
+            res = self._proxy.call_sync(method, val,
+                                        Gio.DBusCallFlags.NO_AUTO_START,
+                                        500, None)
             return res.unpack()
-        return res
+        except GLib.Error:
+            return None
 
 
 class Ratbagd(_RatbagdDBus):

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -96,7 +96,7 @@ class _RatbagdDBus(GObject.GObject):
             res = self._proxy.call_sync(method, val,
                                         Gio.DBusCallFlags.NO_AUTO_START,
                                         500, None)
-            return res.unpack()
+            return res.unpack()[0]  # Result is always a tuple
         except GLib.Error:
             return None
 

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -75,7 +75,7 @@ class _RatbagdDBus(GObject.GObject):
                                                  object_path,
                                                  "org.freedesktop.ratbag1.{}".format(interface),
                                                  None)
-        except GLib.GError:
+        except GLib.Error:
             raise RatbagdDBusUnavailable()
 
         if self._proxy.get_name_owner() is None:

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -189,6 +189,10 @@ class RatbagdDevice(_RatbagdDBus):
         """
         return self.dbus_call("GetProfileByIndex", "u", index)
 
+    def commit(self):
+        """Commits all changes made to the device."""
+        return self.dbus_call("Commit", "")
+
     def __eq__(self, other):
         return other and self._objpath == other._objpath
 

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -21,7 +21,34 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
+from enum import IntEnum
 from gi.repository import Gio, GLib, GObject
+
+
+class RatbagErrorCode(IntEnum):
+    RATBAG_SUCCESS = 0
+
+    """An error occured on the device. Either the device is not a libratbag
+    device or communication with the device failed."""
+    RATBAG_ERROR_DEVICE = -1000
+
+    """Insufficient capabilities. This error occurs when a requested change is
+    beyond the device's capabilities."""
+    RATBAG_ERROR_CAPABILITY = -1001
+
+    """Invalid value or value range. The provided value or value range is
+    outside of the legal or supported range."""
+    RATBAG_ERROR_VALUE = -1002
+
+    """A low-level system error has occured, e.g. a failure to access files
+    that should be there. This error is usually unrecoverable and libratbag will
+    print a log message with details about the error."""
+    RATBAG_ERROR_SYSTEM = -1003
+
+    """Implementation bug, either in libratbag or in the caller. This error is
+    usually unrecoverable and libratbag will print a log message with details
+    about the error."""
+    RATBAG_ERROR_IMPLEMENTATION = -1004
 
 
 class RatbagdDBusUnavailable(BaseException):


### PR DESCRIPTION
A quick PR that adds two things: a `Commit` method on `RatbagdDevice`, and libratbag's error codes so that Piper can easily test return values of the DBus method calls.

I've though about adding exceptions as well (i.e. `RatbagdErrorDevice(BaseException)`) but this gets nasty real quick; either every method call in the binding needs to do an `if/else` to raise the proper exception, or `_dbus_call` does this but then has the possibility of raising *all* exceptions which isn't nice from an API point of view.