### PR TITLE
Add resolutions page

### DIFF
--- a/data/piper.gresource.xml
+++ b/data/piper.gresource.xml
@@ -5,6 +5,7 @@
 
         <file preprocess="xml-stripblanks">aboutDialog.ui</file>
         <file preprocess="xml-stripblanks">resolutionRow.ui</file>
+        <file preprocess="xml-stripblanks">resolutionsPage.ui</file>
         <file preprocess="xml-stripblanks">window.ui</file>
 	<!-- Using this alias, GtkApplication will automatically pick it up for us. -->
         <file alias="gtk/menus.ui" preprocess="xml-stripblanks">menus.ui</file>

--- a/data/piper.gresource.xml
+++ b/data/piper.gresource.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <gresources>
-	<gresource prefix="/org/freedesktop/Piper">
-		<file preprocess="xml-stripblanks">aboutDialog.ui</file>
-		<file>404.svg</file>
-		<!-- Using this alias, GtkApplication will automatically pick it up for us. -->
-		<file alias="gtk/menus.ui" preprocess="xml-stripblanks">menus.ui</file>
-	</gresource>
+     <gresource prefix="/org/freedesktop/Piper">
+        <file>404.svg</file>
+
+        <file preprocess="xml-stripblanks">aboutDialog.ui</file>
+        <file preprocess="xml-stripblanks">window.ui</file>
+	<!-- Using this alias, GtkApplication will automatically pick it up for us. -->
+        <file alias="gtk/menus.ui" preprocess="xml-stripblanks">menus.ui</file>
+    </gresource>
 </gresources>

--- a/data/piper.gresource.xml
+++ b/data/piper.gresource.xml
@@ -4,6 +4,7 @@
         <file>404.svg</file>
 
         <file preprocess="xml-stripblanks">aboutDialog.ui</file>
+        <file preprocess="xml-stripblanks">resolutionRow.ui</file>
         <file preprocess="xml-stripblanks">window.ui</file>
 	<!-- Using this alias, GtkApplication will automatically pick it up for us. -->
         <file alias="gtk/menus.ui" preprocess="xml-stripblanks">menus.ui</file>

--- a/data/resolutionRow.ui
+++ b/data/resolutionRow.ui
@@ -107,6 +107,7 @@
                             <property name="round_digits">0</property>
                             <property name="digits">0</property>
                             <property name="value_pos">bottom</property>
+                            <signal name="scroll-event" handler="_on_scroll_event" swapped="no"/>
                             <signal name="value-changed" handler="_on_value_changed" swapped="no"/>
                           </object>
                         </child>
@@ -152,6 +153,7 @@
                             <property name="round_digits">0</property>
                             <property name="digits">0</property>
                             <property name="value_pos">bottom</property>
+                            <signal name="scroll-event" handler="_on_scroll_event" swapped="no"/>
                             <signal name="value-changed" handler="_on_value_changed" swapped="no"/>
                           </object>
                         </child>

--- a/data/resolutionRow.ui
+++ b/data/resolutionRow.ui
@@ -1,0 +1,193 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.18"/>
+  <template class="ResolutionRow" parent="GtkListBoxRow">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkBox">
+            <property name="can_focus">False</property>
+            <property name="border_width">12</property>
+            <child>
+              <object class="GtkLabel" id="index_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="valign">baseline</property>
+                <property name="single_line_mode">True</property>
+                <property name="track_visited_links">False</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkLabel" id="title_label">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="justify">center</property>
+                <property name="track_visited_links">False</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="delete_button">
+                <property name="can_focus">False</property>
+                <property name="receives_default">False</property>
+                <property name="relief">none</property>
+                <signal name="clicked" handler="_on_delete_button_clicked" swapped="no"/>
+                <child>
+                  <object class="GtkImage">
+                    <property name="can_focus">False</property>
+                    <property name="icon_name">edit-delete-symbolic</property>
+                    <property name="icon_size">1</property>
+                  </object>
+                </child>
+                <style>
+                  <class name="image-button"/>
+                  <class name="circular"/>
+                </style>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkRevealer" id="revealer">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="no_show_all">True</property>
+                <property name="border_width">20</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <object class="GtkAlignment">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="top_padding">12</property>
+                        <property name="bottom_padding">12</property>
+                        <property name="left_padding">12</property>
+                        <property name="right_padding">12</property>
+                        <child>
+                          <object class="GtkScale" id="scale_x">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="round_digits">0</property>
+                            <property name="digits">0</property>
+                            <property name="value_pos">bottom</property>
+                            <signal name="value-changed" handler="_on_value_changed" swapped="no"/>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel" id="label_x">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">X resolution</property>
+                        <property name="track_visited_links">False</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame" id="frame_y">
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <object class="GtkAlignment">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="top_padding">12</property>
+                        <property name="left_padding">12</property>
+                        <property name="right_padding">12</property>
+                        <child>
+                          <object class="GtkScale" id="scale_y">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="round_digits">0</property>
+                            <property name="digits">0</property>
+                            <property name="value_pos">bottom</property>
+                            <signal name="value-changed" handler="_on_value_changed" swapped="no"/>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Y resolution</property>
+                        <property name="track_visited_links">False</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/resolutionRow.ui
+++ b/data/resolutionRow.ui
@@ -99,7 +99,9 @@
                         <property name="can_focus">True</property>
                         <property name="round_digits">0</property>
                         <property name="digits">0</property>
+                        <property name="draw_value">False</property>
                         <property name="value_pos">bottom</property>
+                        <signal name="change-value" handler="_on_change_value" swapped="no"/>
                         <signal name="scroll-event" handler="_on_scroll_event" swapped="no"/>
                         <signal name="value-changed" handler="_on_value_changed" swapped="no"/>
                       </object>

--- a/data/resolutionRow.ui
+++ b/data/resolutionRow.ui
@@ -80,105 +80,45 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkBox">
+              <object class="GtkFrame">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="no_show_all">True</property>
-                <property name="border_width">20</property>
-                <property name="orientation">vertical</property>
+                <property name="label_xalign">0</property>
+                <property name="shadow_type">none</property>
                 <child>
-                  <object class="GtkFrame">
+                  <object class="GtkAlignment">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="top_padding">12</property>
+                    <property name="bottom_padding">12</property>
+                    <property name="left_padding">12</property>
+                    <property name="right_padding">12</property>
                     <child>
-                      <object class="GtkAlignment">
+                      <object class="GtkScale" id="scale">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="top_padding">12</property>
-                        <property name="bottom_padding">12</property>
-                        <property name="left_padding">12</property>
-                        <property name="right_padding">12</property>
-                        <child>
-                          <object class="GtkScale" id="scale_x">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="round_digits">0</property>
-                            <property name="digits">0</property>
-                            <property name="value_pos">bottom</property>
-                            <signal name="scroll-event" handler="_on_scroll_event" swapped="no"/>
-                            <signal name="value-changed" handler="_on_value_changed" swapped="no"/>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child type="label">
-                      <object class="GtkLabel" id="label_x">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">X resolution</property>
-                        <property name="track_visited_links">False</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                        <style>
-                          <class name="dim-label"/>
-                        </style>
+                        <property name="can_focus">True</property>
+                        <property name="round_digits">0</property>
+                        <property name="digits">0</property>
+                        <property name="value_pos">bottom</property>
+                        <signal name="scroll-event" handler="_on_scroll_event" swapped="no"/>
+                        <signal name="value-changed" handler="_on_value_changed" swapped="no"/>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
-                <child>
-                  <object class="GtkFrame" id="frame_y">
+                <child type="label">
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
-                    <child>
-                      <object class="GtkAlignment">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="top_padding">12</property>
-                        <property name="left_padding">12</property>
-                        <property name="right_padding">12</property>
-                        <child>
-                          <object class="GtkScale" id="scale_y">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="round_digits">0</property>
-                            <property name="digits">0</property>
-                            <property name="value_pos">bottom</property>
-                            <signal name="scroll-event" handler="_on_scroll_event" swapped="no"/>
-                            <signal name="value-changed" handler="_on_value_changed" swapped="no"/>
-                          </object>
-                        </child>
-                      </object>
-                    </child>
-                    <child type="label">
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Y resolution</property>
-                        <property name="track_visited_links">False</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                        <style>
-                          <class name="dim-label"/>
-                        </style>
-                      </object>
-                    </child>
+                    <property name="label" translatable="yes">Resolution</property>
+                    <property name="track_visited_links">False</property>
+                    <attributes>
+                      <attribute name="weight" value="bold"/>
+                    </attributes>
+                    <style>
+                      <class name="dim-label"/>
+                    </style>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
             </child>

--- a/data/resolutionsPage.ui
+++ b/data/resolutionsPage.ui
@@ -1,0 +1,230 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="ResolutionsPage" parent="GtkBox">
+    <property name="visible">True</property>
+    <property name="can_focus">False</property>
+    <child>
+      <placeholder/>
+    </child>
+    <child>
+      <object class="GtkBox">
+        <property name="width_request">400</property>
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="border_width">20</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkFrame">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <property name="shadow_type">none</property>
+            <child>
+              <object class="GtkAlignment">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="top_padding">12</property>
+                <property name="bottom_padding">12</property>
+                <property name="left_padding">12</property>
+                <property name="right_padding">12</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="halign">center</property>
+                    <property name="spacing">20</property>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">end</property>
+                        <property name="label" translatable="yes">Report rate</property>
+                        <property name="justify">right</property>
+                        <property name="track_visited_links">False</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkButtonBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="homogeneous">True</property>
+                        <property name="layout_style">expand</property>
+                        <child>
+                          <object class="GtkRadioButton" id="rate_500">
+                            <property name="label" translatable="yes">500</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="draw_indicator">False</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="rate_1000">
+                            <property name="label" translatable="yes">1000</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">False</property>
+                            <property name="group">rate_500</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Hz</property>
+                        <property name="track_visited_links">False</property>
+                        <style>
+                          <class name="dim-label"/>
+                        </style>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">2</property>
+                      </packing>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Sensitivity</property>
+                <property name="track_visited_links">False</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkFrame">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="label_xalign">0</property>
+            <property name="shadow_type">none</property>
+            <child>
+              <object class="GtkAlignment">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="top_padding">12</property>
+                <property name="bottom_padding">12</property>
+                <property name="left_padding">12</property>
+                <property name="right_padding">12</property>
+                <child>
+                  <object class="GtkScrolledWindow">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">in</property>
+                    <property name="propagate_natural_width">True</property>
+                    <property name="propagate_natural_height">True</property>
+                    <child>
+                      <object class="GtkViewport">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkListBox" id="listbox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="selection_mode">none</property>
+                            <signal name="row-activated" handler="_on_row_activated" swapped="no"/>
+                            <child>
+                              <object class="GtkListBoxRow" id="add_resolution_row">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <child>
+                                  <object class="GtkBox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="hexpand">True</property>
+                                    <property name="border_width">6</property>
+                                    <child type="center">
+                                      <object class="GtkImage">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="icon_name">list-add-symbolic</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+            </child>
+            <child type="label">
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="label" translatable="yes">Resolutions</property>
+                <property name="track_visited_links">False</property>
+                <attributes>
+                  <attribute name="weight" value="bold"/>
+                </attributes>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="pack_type">end</property>
+        <property name="position">1</property>
+      </packing>
+    </child>
+  </template>
+</interface>

--- a/data/window.ui
+++ b/data/window.ui
@@ -11,7 +11,244 @@
         <property name="transition_duration">400</property>
         <property name="transition_type">slide-left-right</property>
         <child>
-          <placeholder/>
+          <object class="GtkBox" id="box_resolutions">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="width_request">400</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="border_width">20</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <object class="GtkAlignment">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="top_padding">12</property>
+                        <property name="bottom_padding">12</property>
+                        <property name="left_padding">12</property>
+                        <property name="right_padding">12</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="halign">center</property>
+                            <property name="spacing">20</property>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">end</property>
+                                <property name="label" translatable="yes">Report rate</property>
+                                <property name="justify">right</property>
+                                <property name="track_visited_links">False</property>
+                                <style>
+                                  <class name="dim-label"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButtonBox">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="homogeneous">True</property>
+                                <property name="layout_style">expand</property>
+                                <child>
+                                  <object class="GtkToggleButton">
+                                    <property name="label" translatable="yes">500</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton">
+                                    <property name="label" translatable="yes">1000</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkToggleButton">
+                                    <property name="label" translatable="yes">1500</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="receives_default">True</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">2</property>
+                                  </packing>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">start</property>
+                                <property name="label" translatable="yes">Hz</property>
+                                <property name="track_visited_links">False</property>
+                                <style>
+                                  <class name="dim-label"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="position">2</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Sensitivity</property>
+                        <property name="track_visited_links">False</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <object class="GtkAlignment">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="top_padding">12</property>
+                        <property name="bottom_padding">12</property>
+                        <property name="left_padding">12</property>
+                        <property name="right_padding">12</property>
+                        <child>
+                          <object class="GtkScrolledWindow">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="shadow_type">in</property>
+                            <property name="propagate_natural_width">True</property>
+                            <property name="propagate_natural_height">True</property>
+                            <child>
+                              <object class="GtkViewport">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <child>
+                                  <object class="GtkListBox" id="listbox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="selection_mode">none</property>
+                                    <signal name="row-activated" handler="_on_row_activated" swapped="no"/>
+                                    <child>
+                                      <object class="GtkListBoxRow" id="add_resolution_row">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <child>
+                                          <object class="GtkBox">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="border_width">6</property>
+                                            <child type="center">
+                                              <object class="GtkImage">
+                                                <property name="visible">True</property>
+                                                <property name="can_focus">False</property>
+                                                <property name="icon_name">list-add-symbolic</property>
+                                              </object>
+                                              <packing>
+                                                <property name="expand">False</property>
+                                                <property name="fill">True</property>
+                                                <property name="position">0</property>
+                                              </packing>
+                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Resolutions</property>
+                        <property name="track_visited_links">False</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                        </attributes>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="name">resolutions</property>
+            <property name="title" translatable="yes">Resolutions</property>
+          </packing>
         </child>
       </object>
     </child>
@@ -26,6 +263,24 @@
             <property name="can_focus">False</property>
             <property name="stack">stack</property>
           </object>
+        </child>
+        <child>
+          <object class="GtkButton">
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+            <signal name="clicked" handler="_on_save_button_clicked" swapped="no"/>
+            <child>
+              <object class="GtkImage">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="icon_name">document-save-symbolic</property>
+              </object>
+            </child>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+          </packing>
         </child>
       </object>
     </child>

--- a/data/window.ui
+++ b/data/window.ui
@@ -11,200 +11,206 @@
         <property name="transition_duration">400</property>
         <property name="transition_type">slide-left-right</property>
         <child>
-          <object class="GtkBox" id="box_resolutions">
+          <object class="GtkOverlay">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <placeholder/>
-            </child>
-            <child>
-              <object class="GtkBox">
-                <property name="width_request">400</property>
+              <object class="GtkBox" id="box_resolutions">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="border_width">20</property>
-                <property name="orientation">vertical</property>
                 <child>
-                  <object class="GtkFrame">
+                  <placeholder/>
+                </child>
+                <child>
+                  <object class="GtkBox">
+                    <property name="width_request">400</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
+                    <property name="border_width">20</property>
+                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkAlignment">
+                      <object class="GtkFrame">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="top_padding">12</property>
-                        <property name="bottom_padding">12</property>
-                        <property name="left_padding">12</property>
-                        <property name="right_padding">12</property>
+                        <property name="label_xalign">0</property>
+                        <property name="shadow_type">none</property>
                         <child>
-                          <object class="GtkBox">
+                          <object class="GtkAlignment">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="halign">center</property>
-                            <property name="spacing">20</property>
+                            <property name="top_padding">12</property>
+                            <property name="bottom_padding">12</property>
+                            <property name="left_padding">12</property>
+                            <property name="right_padding">12</property>
                             <child>
-                              <object class="GtkLabel">
+                              <object class="GtkBox">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="halign">end</property>
-                                <property name="label" translatable="yes">Report rate</property>
-                                <property name="justify">right</property>
-                                <property name="track_visited_links">False</property>
-                                <style>
-                                  <class name="dim-label"/>
-                                </style>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButtonBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="homogeneous">True</property>
-                                <property name="layout_style">expand</property>
+                                <property name="halign">center</property>
+                                <property name="spacing">20</property>
                                 <child>
-                                  <object class="GtkToggleButton">
-                                    <property name="label" translatable="yes">500</property>
+                                  <object class="GtkLabel">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">end</property>
+                                    <property name="label" translatable="yes">Report rate</property>
+                                    <property name="justify">right</property>
+                                    <property name="track_visited_links">False</property>
+                                    <style>
+                                      <class name="dim-label"/>
+                                    </style>
                                   </object>
                                   <packing>
-                                    <property name="expand">True</property>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkButtonBox">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="homogeneous">True</property>
+                                    <property name="layout_style">expand</property>
+                                    <child>
+                                      <object class="GtkToggleButton">
+                                        <property name="label" translatable="yes">500</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkToggleButton">
+                                        <property name="label" translatable="yes">1000</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkToggleButton">
+                                        <property name="label" translatable="yes">1500</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">True</property>
+                                        <property name="position">2</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkLabel">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="halign">start</property>
+                                    <property name="label" translatable="yes">Hz</property>
+                                    <property name="track_visited_links">False</property>
+                                    <style>
+                                      <class name="dim-label"/>
+                                    </style>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
                                     <property name="fill">True</property>
                                     <property name="position">2</property>
                                   </packing>
                                 </child>
-                                <child>
-                                  <object class="GtkToggleButton">
-                                    <property name="label" translatable="yes">1000</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkToggleButton">
-                                    <property name="label" translatable="yes">1500</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkLabel">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="halign">start</property>
-                                <property name="label" translatable="yes">Hz</property>
-                                <property name="track_visited_links">False</property>
-                                <style>
-                                  <class name="dim-label"/>
-                                </style>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">True</property>
-                                <property name="position">2</property>
-                              </packing>
                             </child>
                           </object>
                         </child>
-                      </object>
-                    </child>
-                    <child type="label">
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Sensitivity</property>
-                        <property name="track_visited_links">False</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
-                    </child>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkFrame">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <property name="shadow_type">none</property>
-                    <child>
-                      <object class="GtkAlignment">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="top_padding">12</property>
-                        <property name="bottom_padding">12</property>
-                        <property name="left_padding">12</property>
-                        <property name="right_padding">12</property>
-                        <child>
-                          <object class="GtkScrolledWindow">
+                        <child type="label">
+                          <object class="GtkLabel">
                             <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="shadow_type">in</property>
-                            <property name="propagate_natural_width">True</property>
-                            <property name="propagate_natural_height">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Sensitivity</property>
+                            <property name="track_visited_links">False</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                        </child>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkFrame">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label_xalign">0</property>
+                        <property name="shadow_type">none</property>
+                        <child>
+                          <object class="GtkAlignment">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="top_padding">12</property>
+                            <property name="bottom_padding">12</property>
+                            <property name="left_padding">12</property>
+                            <property name="right_padding">12</property>
                             <child>
-                              <object class="GtkViewport">
+                              <object class="GtkScrolledWindow">
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
+                                <property name="can_focus">True</property>
+                                <property name="shadow_type">in</property>
+                                <property name="propagate_natural_width">True</property>
+                                <property name="propagate_natural_height">True</property>
                                 <child>
-                                  <object class="GtkListBox" id="listbox">
+                                  <object class="GtkViewport">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="selection_mode">none</property>
-                                    <signal name="row-activated" handler="_on_row_activated" swapped="no"/>
                                     <child>
-                                      <object class="GtkListBoxRow" id="add_resolution_row">
+                                      <object class="GtkListBox" id="listbox">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="selection_mode">none</property>
+                                        <signal name="row-activated" handler="_on_row_activated" swapped="no"/>
                                         <child>
-                                          <object class="GtkBox">
+                                          <object class="GtkListBoxRow" id="add_resolution_row">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="hexpand">True</property>
-                                            <property name="border_width">6</property>
-                                            <child type="center">
-                                              <object class="GtkImage">
+                                            <property name="can_focus">True</property>
+                                            <child>
+                                              <object class="GtkBox">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
-                                                <property name="icon_name">list-add-symbolic</property>
+                                                <property name="hexpand">True</property>
+                                                <property name="border_width">6</property>
+                                                <child type="center">
+                                                  <object class="GtkImage">
+                                                    <property name="visible">True</property>
+                                                    <property name="can_focus">False</property>
+                                                    <property name="icon_name">list-add-symbolic</property>
+                                                  </object>
+                                                  <packing>
+                                                    <property name="expand">False</property>
+                                                    <property name="fill">True</property>
+                                                    <property name="position">0</property>
+                                                  </packing>
+                                                </child>
                                               </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">0</property>
-                                              </packing>
                                             </child>
                                           </object>
                                         </child>
@@ -216,33 +222,106 @@
                             </child>
                           </object>
                         </child>
+                        <child type="label">
+                          <object class="GtkLabel">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="label" translatable="yes">Resolutions</property>
+                            <property name="track_visited_links">False</property>
+                            <attributes>
+                              <attribute name="weight" value="bold"/>
+                            </attributes>
+                          </object>
+                        </child>
                       </object>
-                    </child>
-                    <child type="label">
-                      <object class="GtkLabel">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Resolutions</property>
-                        <property name="track_visited_links">False</property>
-                        <attributes>
-                          <attribute name="weight" value="bold"/>
-                        </attributes>
-                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
                     </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
                     <property name="fill">True</property>
+                    <property name="pack_type">end</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
-                <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="pack_type">end</property>
-                <property name="position">1</property>
+                <property name="index">-1</property>
               </packing>
+            </child>
+            <child type="overlay">
+              <object class="GtkRevealer" id="notification_commit">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">start</property>
+                <property name="transition_duration">100</property>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <child>
+                      <object class="GtkBox">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkLabel" id="notification_commit_label">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="margin_right">30</property>
+                            <property name="margin_end">30</property>
+                            <property name="label" translatable="yes">Failed to commit changes to the device</property>
+                            <property name="ellipsize">middle</property>
+                            <property name="max_width_chars">50</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">0</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="notification_commit_close">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="focus_on_click">False</property>
+                            <property name="receives_default">True</property>
+                            <property name="relief">none</property>
+                            <signal name="clicked" handler="_on_notification_commit_close_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkImage">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="icon_name">window-close-symbolic</property>
+                                <property name="icon_size">2</property>
+                              </object>
+                            </child>
+                            <style>
+                              <class name="image-button"/>
+                            </style>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">True</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label_item">
+                      <placeholder/>
+                    </child>
+                    <style>
+                      <class name="app-notification"/>
+                    </style>
+                  </object>
+                </child>
+              </object>
             </child>
           </object>
           <packing>

--- a/data/window.ui
+++ b/data/window.ui
@@ -5,142 +5,34 @@
   <template class="ApplicationWindow" parent="GtkApplicationWindow">
     <property name="can_focus">False</property>
     <child>
-      <object class="GtkStack" id="stack">
+      <object class="GtkOverlay">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
-        <property name="transition_duration">400</property>
-        <property name="transition_type">slide-left-right</property>
-        <child>
-          <object class="GtkOverlay">
+        <child type="overlay">
+          <object class="GtkRevealer" id="notification_commit">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="valign">start</property>
+            <property name="transition_duration">100</property>
             <child>
-              <object class="GtkBox" id="box_resolutions">
+              <object class="GtkFrame">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <child>
-                  <placeholder/>
-                </child>
+                <property name="label_xalign">0</property>
                 <child>
                   <object class="GtkBox">
-                    <property name="width_request">400</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="border_width">20</property>
-                    <property name="orientation">vertical</property>
                     <child>
-                      <object class="GtkFrame">
+                      <object class="GtkLabel" id="notification_commit_label">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
-                        <child>
-                          <object class="GtkAlignment">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="top_padding">12</property>
-                            <property name="bottom_padding">12</property>
-                            <property name="left_padding">12</property>
-                            <property name="right_padding">12</property>
-                            <child>
-                              <object class="GtkBox">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="halign">center</property>
-                                <property name="spacing">20</property>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">end</property>
-                                    <property name="label" translatable="yes">Report rate</property>
-                                    <property name="justify">right</property>
-                                    <property name="track_visited_links">False</property>
-                                    <style>
-                                      <class name="dim-label"/>
-                                    </style>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButtonBox">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="homogeneous">True</property>
-                                    <property name="layout_style">expand</property>
-                                    <child>
-                                      <object class="GtkRadioButton" id="rate_500">
-                                        <property name="label" translatable="yes">500</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="draw_indicator">False</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkRadioButton" id="rate_1000">
-                                        <property name="label" translatable="yes">1000</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">False</property>
-                                        <property name="active">True</property>
-                                        <property name="draw_indicator">False</property>
-                                        <property name="group">rate_500</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="halign">start</property>
-                                    <property name="label" translatable="yes">Hz</property>
-                                    <property name="track_visited_links">False</property>
-                                    <style>
-                                      <class name="dim-label"/>
-                                    </style>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
-                              </object>
-                            </child>
-                          </object>
-                        </child>
-                        <child type="label">
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Sensitivity</property>
-                            <property name="track_visited_links">False</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                        </child>
+                        <property name="margin_right">30</property>
+                        <property name="margin_end">30</property>
+                        <property name="label" translatable="yes">Failed to commit changes to the device</property>
+                        <property name="ellipsize">middle</property>
+                        <property name="max_width_chars">50</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -149,81 +41,24 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkFrame">
+                      <object class="GtkButton" id="notification_commit_close">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="label_xalign">0</property>
-                        <property name="shadow_type">none</property>
+                        <property name="can_focus">True</property>
+                        <property name="focus_on_click">False</property>
+                        <property name="receives_default">True</property>
+                        <property name="relief">none</property>
+                        <signal name="clicked" handler="_on_notification_commit_close_clicked" swapped="no"/>
                         <child>
-                          <object class="GtkAlignment">
+                          <object class="GtkImage">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="top_padding">12</property>
-                            <property name="bottom_padding">12</property>
-                            <property name="left_padding">12</property>
-                            <property name="right_padding">12</property>
-                            <child>
-                              <object class="GtkScrolledWindow">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="shadow_type">in</property>
-                                <property name="propagate_natural_width">True</property>
-                                <property name="propagate_natural_height">True</property>
-                                <child>
-                                  <object class="GtkViewport">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <child>
-                                      <object class="GtkListBox" id="listbox">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="selection_mode">none</property>
-                                        <signal name="row-activated" handler="_on_row_activated" swapped="no"/>
-                                        <child>
-                                          <object class="GtkListBoxRow" id="add_resolution_row">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <child>
-                                              <object class="GtkBox">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="hexpand">True</property>
-                                                <property name="border_width">6</property>
-                                                <child type="center">
-                                                  <object class="GtkImage">
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">False</property>
-                                                    <property name="icon_name">list-add-symbolic</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">True</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                              </object>
-                                            </child>
-                                          </object>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                            </child>
+                            <property name="icon_name">window-close-symbolic</property>
+                            <property name="icon_size">2</property>
                           </object>
                         </child>
-                        <child type="label">
-                          <object class="GtkLabel">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Resolutions</property>
-                            <property name="track_visited_links">False</property>
-                            <attributes>
-                              <attribute name="weight" value="bold"/>
-                            </attributes>
-                          </object>
-                        </child>
+                        <style>
+                          <class name="image-button"/>
+                        </style>
                       </object>
                       <packing>
                         <property name="expand">False</property>
@@ -232,92 +67,29 @@
                       </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="pack_type">end</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
-              </object>
-              <packing>
-                <property name="index">-1</property>
-              </packing>
-            </child>
-            <child type="overlay">
-              <object class="GtkRevealer" id="notification_commit">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="halign">center</property>
-                <property name="valign">start</property>
-                <property name="transition_duration">100</property>
-                <child>
-                  <object class="GtkFrame">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="label_xalign">0</property>
-                    <child>
-                      <object class="GtkBox">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <child>
-                          <object class="GtkLabel" id="notification_commit_label">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="margin_right">30</property>
-                            <property name="margin_end">30</property>
-                            <property name="label" translatable="yes">Failed to commit changes to the device</property>
-                            <property name="ellipsize">middle</property>
-                            <property name="max_width_chars">50</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkButton" id="notification_commit_close">
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="focus_on_click">False</property>
-                            <property name="receives_default">True</property>
-                            <property name="relief">none</property>
-                            <signal name="clicked" handler="_on_notification_commit_close_clicked" swapped="no"/>
-                            <child>
-                              <object class="GtkImage">
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="icon_name">window-close-symbolic</property>
-                                <property name="icon_size">2</property>
-                              </object>
-                            </child>
-                            <style>
-                              <class name="image-button"/>
-                            </style>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                    <child type="label_item">
-                      <placeholder/>
-                    </child>
-                    <style>
-                      <class name="app-notification"/>
-                    </style>
-                  </object>
+                <child type="label_item">
+                  <placeholder/>
                 </child>
+                <style>
+                  <class name="app-notification"/>
+                </style>
               </object>
             </child>
           </object>
+        </child>
+        <child>
+          <object class="GtkStack" id="stack">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="transition_duration">400</property>
+            <property name="transition_type">slide-left-right</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
           <packing>
-            <property name="name">resolutions</property>
-            <property name="title" translatable="yes">Resolutions</property>
+            <property name="index">-1</property>
           </packing>
         </child>
       </object>
@@ -328,7 +100,7 @@
         <property name="can_focus">False</property>
         <property name="show_close_button">True</property>
         <child type="title">
-          <object class="GtkStackSwitcher" id="stackswitcher">
+          <object class="GtkStackSwitcher">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="stack">stack</property>

--- a/data/window.ui
+++ b/data/window.ui
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="ApplicationWindow" parent="GtkApplicationWindow">
+    <property name="can_focus">False</property>
+    <child>
+      <object class="GtkStack" id="stack">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="transition_duration">400</property>
+        <property name="transition_type">slide-left-right</property>
+        <child>
+          <placeholder/>
+        </child>
+      </object>
+    </child>
+    <child type="titlebar">
+      <object class="GtkHeaderBar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="show_close_button">True</property>
+        <child type="title">
+          <object class="GtkStackSwitcher" id="stackswitcher">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stack">stack</property>
+          </object>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/data/window.ui
+++ b/data/window.ui
@@ -73,42 +73,33 @@
                                     <property name="homogeneous">True</property>
                                     <property name="layout_style">expand</property>
                                     <child>
-                                      <object class="GtkToggleButton">
+                                      <object class="GtkRadioButton" id="rate_500">
                                         <property name="label" translatable="yes">500</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
-                                        <property name="receives_default">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="draw_indicator">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">True</property>
                                         <property name="fill">True</property>
-                                        <property name="position">2</property>
+                                        <property name="position">0</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkToggleButton">
+                                      <object class="GtkRadioButton" id="rate_1000">
                                         <property name="label" translatable="yes">1000</property>
                                         <property name="visible">True</property>
                                         <property name="can_focus">True</property>
-                                        <property name="receives_default">True</property>
+                                        <property name="receives_default">False</property>
+                                        <property name="active">True</property>
+                                        <property name="draw_indicator">False</property>
+                                        <property name="group">rate_500</property>
                                       </object>
                                       <packing>
                                         <property name="expand">True</property>
                                         <property name="fill">True</property>
-                                        <property name="position">2</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkToggleButton">
-                                        <property name="label" translatable="yes">1500</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="receives_default">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">2</property>
+                                        <property name="position">1</property>
                                       </packing>
                                     </child>
                                   </object>

--- a/piper.in
+++ b/piper.in
@@ -1,20 +1,14 @@
 #!/usr/bin/env python3
 
-import gettext
 import gi
-import locale
 import os
-import signal
-import sys
-
 import piper
-from piper.application import Application
+import sys
 
 gi.require_version('Gio', '2.0')
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gio, Gtk
 
-localedir = '@localedir@'
 srcdir = os.path.abspath(os.path.join(os.path.dirname(piper.__file__), '..'))
 if os.path.exists(os.path.join(srcdir, 'meson.build')):
     print('Running from source tree, using local files')
@@ -23,6 +17,8 @@ if os.path.exists(os.path.join(srcdir, 'meson.build')):
         os.environ['GSETTINGS_SCHEMA_DIR'] = pkgdatadir
 else:
     pkgdatadir = '@pkgdatadir@'
+resource = Gio.resource_load(os.path.join(pkgdatadir, 'piper.gresource'))
+Gio.Resource._register(resource)
 
 
 def install_excepthook():
@@ -38,15 +34,18 @@ def install_excepthook():
 
 
 if __name__ == "__main__":
+    import gettext
+    import locale
+    import signal
+    from piper.application import Application
+
     install_excepthook()
 
+    localedir = '@localedir@'
     locale.bindtextdomain('piper', localedir)
     locale.textdomain('piper')
     gettext.bindtextdomain('piper', localedir)
     gettext.textdomain('piper')
-
-    resource = Gio.resource_load(os.path.join(pkgdatadir, 'piper.gresource'))
-    Gio.Resource._register(resource)
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)
     exit_status = Application().run(sys.argv)

--- a/piper/gi_composites.py
+++ b/piper/gi_composites.py
@@ -1,0 +1,269 @@
+#
+# Copyright (C) 2015 Dustin Spicuzza <dustin@virtualroadside.com>
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public
+# License along with this library; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301
+# USA
+
+from os.path import abspath, join
+
+import inspect
+import warnings
+
+from gi.repository import Gio
+from gi.repository import GLib
+from gi.repository import GObject
+from gi.repository import Gtk
+
+__all__ = ['GtkTemplate']
+
+
+class GtkTemplateWarning(UserWarning):
+    pass
+
+
+def _connect_func(builder, obj, signal_name, handler_name,
+                  connect_object, flags, cls):
+    '''Handles GtkBuilder signal connect events'''
+
+    if connect_object is None:
+        extra = ()
+    else:
+        extra = (connect_object,)
+
+    # The handler name refers to an attribute on the template instance,
+    # so ask GtkBuilder for the template instance
+    template_inst = builder.get_object(cls.__gtype_name__)
+
+    if template_inst is None:  # This should never happen
+        errmsg = "Internal error: cannot find template instance! obj: %s; " \
+                 "signal: %s; handler: %s; connect_obj: %s; class: %s" % \
+                 (obj, signal_name, handler_name, connect_object, cls)
+        warnings.warn(errmsg, GtkTemplateWarning)
+        return
+
+    handler = getattr(template_inst, handler_name)
+
+    if flags == GObject.ConnectFlags.AFTER:
+        obj.connect_after(signal_name, handler, *extra)
+    else:
+        obj.connect(signal_name, handler, *extra)
+
+    template_inst.__connected_template_signals__.add(handler_name)
+
+
+def _register_template(cls, template_bytes):
+    '''Registers the template for the widget and hooks init_template'''
+
+    # This implementation won't work if there are nested templates, but
+    # we can't do that anyways due to PyGObject limitations so it's ok
+
+    if not hasattr(cls, 'set_template'):
+        raise TypeError("Requires PyGObject 3.13.2 or greater")
+
+    cls.set_template(template_bytes)
+
+    bound_methods = set()
+    bound_widgets = set()
+
+    # Walk the class, find marked callbacks and child attributes
+    for name in dir(cls):
+        o = getattr(cls, name, None)
+
+        if inspect.ismethod(o):
+            if hasattr(o, '_gtk_callback'):
+                bound_methods.add(name)
+                # Don't need to call this, as connect_func always gets called
+                # cls.bind_template_callback_full(name, o)
+        elif isinstance(o, _Child):
+            cls.bind_template_child_full(name, True, 0)
+            bound_widgets.add(name)
+
+    # Have to setup a special connect function to connect at template init
+    # because the methods are not bound yet
+    cls.set_connect_func(_connect_func, cls)
+
+    cls.__gtemplate_methods__ = bound_methods
+    cls.__gtemplate_widgets__ = bound_widgets
+
+    base_init_template = cls.init_template
+    cls.init_template = lambda s: _init_template(s, cls, base_init_template)
+
+
+def _init_template(self, cls, base_init_template):
+    '''This would be better as an override for Gtk.Widget'''
+
+    # TODO: could disallow using a metaclass.. but this is good enough
+    # .. if you disagree, feel free to fix it and issue a PR :)
+    if self.__class__ is not cls:
+        raise TypeError("Inheritance from classes with @GtkTemplate decorators "
+                        "is not allowed at this time")
+
+    connected_signals = set()
+    self.__connected_template_signals__ = connected_signals
+
+    base_init_template(self)
+
+    for name in self.__gtemplate_widgets__:
+        widget = self.get_template_child(cls, name)
+        self.__dict__[name] = widget
+
+        if widget is None:
+            # Bug: if you bind a template child, and one of them was
+            #      not present, then the whole template is broken (and
+            #      it's not currently possible for us to know which
+            #      one is broken either -- but the stderr should show
+            #      something useful with a Gtk-CRITICAL message)
+            raise AttributeError("A missing child widget was set using "
+                                 "GtkTemplate.Child and the entire "
+                                 "template is now broken (widgets: %s)" %
+                                 ', '.join(self.__gtemplate_widgets__))
+
+    for name in self.__gtemplate_methods__.difference(connected_signals):
+        errmsg = ("Signal '%s' was declared with @GtkTemplate.Callback " +
+                  "but was not present in template") % name
+        warnings.warn(errmsg, GtkTemplateWarning)
+
+
+# TODO: Make it easier for IDE to introspect this
+class _Child(object):
+    '''
+        Assign this to an attribute in your class definition and it will
+        be replaced with a widget defined in the UI file when init_template
+        is called
+    '''
+
+    __slots__ = []
+
+    @staticmethod
+    def widgets(count):
+        '''
+            Allows declaring multiple widgets with less typing::
+
+                button    \
+                label1    \
+                label2    = GtkTemplate.Child.widgets(3)
+        '''
+        return [_Child() for _ in range(count)]
+
+
+class _GtkTemplate(object):
+    '''
+        Use this class decorator to signify that a class is a composite
+        widget which will receive widgets and connect to signals as
+        defined in a UI template. You must call init_template to
+        cause the widgets/signals to be initialized from the template::
+
+            @GtkTemplate(ui='foo.ui')
+            class Foo(Gtk.Box):
+
+                def __init__(self):
+                    super(Foo, self).__init__()
+                    self.init_template()
+
+        The 'ui' parameter can either be a file path or a GResource resource
+        path::
+
+            @GtkTemplate(ui='/org/example/foo.ui')
+            class Foo(Gtk.Box):
+                pass
+
+        To connect a signal to a method on your instance, do::
+
+            @GtkTemplate.Callback
+            def on_thing_happened(self, widget):
+                pass
+
+        To create a child attribute that is retrieved from your template,
+        add this to your class definition::
+
+            @GtkTemplate(ui='foo.ui')
+            class Foo(Gtk.Box):
+
+                widget = GtkTemplate.Child()
+
+
+        Note: This is implemented as a class decorator, but if it were
+        included with PyGI I suspect it might be better to do this
+        in the GObject metaclass (or similar) so that init_template
+        can be called automatically instead of forcing the user to do it.
+
+        .. note:: Due to limitations in PyGObject, you may not inherit from
+                  python objects that use the GtkTemplate decorator.
+    '''
+
+    __ui_path__ = None
+
+    @staticmethod
+    def Callback(f):
+        '''
+            Decorator that designates a method to be attached to a signal from
+            the template
+        '''
+        f._gtk_callback = True
+        return f
+
+    Child = _Child
+
+    @staticmethod
+    def set_ui_path(*path):
+        '''
+            If using file paths instead of resources, call this *before*
+            loading anything that uses GtkTemplate, or it will fail to load
+            your template file
+
+            :param path: one or more path elements, will be joined together
+                         to create the final path
+
+            TODO: Alternatively, could wait until first class instantiation
+                  before registering templates? Would need a metaclass...
+        '''
+        _GtkTemplate.__ui_path__ = abspath(join(*path))
+
+    def __init__(self, ui):
+        self.ui = ui
+
+    def __call__(self, cls):
+        if not issubclass(cls, Gtk.Widget):
+            raise TypeError("Can only use @GtkTemplate on Widgets")
+
+        # Nested templates don't work
+        if hasattr(cls, '__gtemplate_methods__'):
+            raise TypeError("Cannot nest template classes")
+
+        # Load the template either from a resource path or a file
+        # - Prefer the resource path first
+
+        try:
+            template_bytes = Gio.resources_lookup_data(self.ui, Gio.ResourceLookupFlags.NONE)
+        except GLib.GError:
+            ui = self.ui
+            if isinstance(ui, (list, tuple)):
+                ui = join(ui)
+
+            if _GtkTemplate.__ui_path__ is not None:
+                ui = join(_GtkTemplate.__ui_path__, ui)
+
+            with open(ui, 'rb') as fp:
+                template_bytes = GLib.Bytes.new(fp.read())
+
+        _register_template(cls, template_bytes)
+        return cls
+
+
+# Future shim support if this makes it into PyGI?
+# if hasattr(Gtk, 'GtkTemplate'):
+#     GtkTemplate = lambda c: c
+# else:
+GtkTemplate = _GtkTemplate

--- a/piper/mousemap.py
+++ b/piper/mousemap.py
@@ -39,6 +39,7 @@ class _MouseMapChild:
         self._is_left = is_left
         self._svg_id = svg_id
         self._svg_leader = svg_id + "-leader"
+        self._svg_path = svg_id + "-path"
 
     @property
     def widget(self):
@@ -56,6 +57,12 @@ class _MouseMapChild:
         # The identifier of the leader SVG element with which this child's
         # widget is paired.
         return self._svg_leader
+
+    @property
+    def svg_path(self):
+        # The identifier of the SVG element's path with which this child's
+        # widget is paired.
+        return self._svg_path
 
     @property
     def is_left(self):
@@ -391,4 +398,6 @@ class MouseMap(Gtk.Container):
             self._handle.render_cairo_sub(highlight_context,
                                           self._highlight_element)
             cr.mask_surface(highlight_surface, 0, 0)
-        self._handle.render_cairo_sub(cr, id=self._layer)
+        for child in self._children:
+            self._handle.render_cairo_sub(cr, id=child.svg_path)
+            self._handle.render_cairo_sub(cr, id=child.svg_leader)

--- a/piper/mousemap.py
+++ b/piper/mousemap.py
@@ -106,7 +106,8 @@ class MouseMap(Gtk.Container):
             raise ValueError("Layer cannot be None")
         if ratbagd_device is None:
             raise ValueError("Device cannot be None")
-        if not os.path.isfile(ratbagd_device.svg_path):
+        svg_path = ratbagd_device.get_svg("gnome")
+        if not os.path.isfile(svg_path):
             raise ValueError("Device has no image or its path is invalid")
 
         Gtk.Container.__init__(self, *args, **kwargs)
@@ -118,8 +119,8 @@ class MouseMap(Gtk.Container):
         self._children = []
         self._highlight_element = None
 
-        self._handle = Rsvg.Handle.new_from_file(ratbagd_device.svg_path)
-        self._svg_data = etree.parse(ratbagd_device.svg_path)
+        self._handle = Rsvg.Handle.new_from_file(svg_path)
+        self._svg_data = etree.parse(svg_path)
 
         # TODO: remove this when we're out of the transition to toned down SVGs
         device = self._handle.has_sub("#Device")

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -123,6 +123,7 @@ class Ratbagd(_RatbagdDBus):
         result = self._dbus_property("Devices")
         if result is not None:
             self._devices = [RatbagdDevice(objpath) for objpath in result]
+        self._themes = self._dbus_property("Themes")
 
     def _on_g_signal(self, proxy, sender, signal, params):
         params = params.unpack()
@@ -135,6 +136,12 @@ class Ratbagd(_RatbagdDBus):
     def devices(self):
         """A list of RatbagdDevice objects supported by ratbagd."""
         return self._devices
+
+    @GObject.Property
+    def themes(self):
+        """A list of theme names. The theme 'default' is guaranteed to be
+        available."""
+        return self._themes
 
 
 class RatbagdDevice(_RatbagdDBus):
@@ -159,8 +166,6 @@ class RatbagdDevice(_RatbagdDBus):
         self._devnode = self._dbus_property("Id")
         self._caps = self._dbus_property("Capabilities")
         self._name = self._dbus_property("Name")
-        self._svg = self._dbus_property("Svg")
-        self._svg_path = self._dbus_property("SvgPath")
 
         self._profiles = []
         self._active_profile = -1
@@ -190,17 +195,6 @@ class RatbagdDevice(_RatbagdDBus):
         return self._name
 
     @GObject.Property
-    def svg(self):
-        """The SVG file name. This function returns the file name only, not the
-        absolute path to the file."""
-        return self._svg
-
-    @GObject.Property
-    def svg_path(self):
-        """The full, absolute path to the SVG."""
-        return self._svg_path
-
-    @GObject.Property
     def profiles(self):
         """A list of RatbagdProfile objects provided by this device."""
         return self._profiles
@@ -212,6 +206,17 @@ class RatbagdDevice(_RatbagdDBus):
         if self._active_profile == -1:
             return None
         return self._profiles[self._active_profile]
+
+    def get_svg(self, theme):
+        """Gets the full path to the SVG for the given theme, or the empty
+        string if none is available.
+
+        The theme must be one of org.freedesktop.ratbag1.Manager.Themes. The
+        theme 'default' is guaranteed to be available.
+
+        @param theme The theme from which to retrieve the SVG, as str
+        """
+        return self._dbus_call("GetSvg", "s", theme)
 
     def get_profile_by_index(self, index):
         """Returns the profile found at the given index, or None if no profile

--- a/piper/resolutionrow.py
+++ b/piper/resolutionrow.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2017 Jente Hidskes <hjdskes@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from .gi_composites import GtkTemplate
+from .ratbagd import RatbagdResolution
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+
+@GtkTemplate(ui="/org/freedesktop/Piper/resolutionRow.ui")
+class ResolutionRow(Gtk.ListBoxRow):
+    """A Gtk.ListBoxRow subclass containing the widgets to configure a
+    resolution."""
+
+    __gtype_name__ = "ResolutionRow"
+
+    index_label = GtkTemplate.Child()
+    title_label = GtkTemplate.Child()
+    revealer = GtkTemplate.Child()
+    frame_y = GtkTemplate.Child()
+    label_x = GtkTemplate.Child()
+    scale_x = GtkTemplate.Child()
+    scale_y = GtkTemplate.Child()
+
+    def __init__(self, ratbagd_resolution, *args, **kwargs):
+        Gtk.ListBoxRow.__init__(self, *args, **kwargs)
+        self.init_template()
+        self._resolution = ratbagd_resolution
+        self._separate_xy = RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION in \
+            ratbagd_resolution.capabilities
+        self._handler = self._resolution.connect("notify::resolution",
+                                                 self._on_resolution_changed)
+        self._init_values()
+
+    def _init_values(self):
+        # Initializes the scales and the title label and sets the Y resolution
+        # configuration visible if it's supported by the device.
+        (xres, yres) = self._resolution.resolution
+        minres = self._resolution.min_res
+        maxres = self._resolution.max_res
+
+        self.index_label.set_text("Resolution {}".format(self._resolution.index))
+
+        self.scale_x.props.adjustment = Gtk.Adjustment(xres, minres, maxres)
+        self.scale_x.set_value(xres)
+        if self._separate_xy:
+            self.scale_y.props.adjustment = Gtk.Adjustment(yres, minres, maxres)
+            self.scale_y.set_value(yres)
+            self.frame_y.set_visible(True)
+        else:
+            self.label_x.set_text("Resolution")
+
+    @GtkTemplate.Callback
+    def _on_delete_button_clicked(self, button):
+        print("TODO: RatbagdProfile needs a way to delete resolutions")
+
+    @GtkTemplate.Callback
+    def _on_value_changed(self, scale):
+        # The scale has been moved, update RatbagdResolution's resolution and
+        # the title label.
+        xres = int(self.scale_x.get_value())
+        yres = int(self.scale_y.get_value())
+
+        # Freeze the notify::resolution signal from firing to prevent Piper from
+        # ending up in an infinite update loop.
+        with self._resolution.handler_block(self._handler):
+            self._resolution.resolution = (xres, yres)
+
+        if self._separate_xy:
+            title = "{} DPI (X), {} DPI (Y)".format(xres, yres)
+        else:
+            title = "{} DPI".format(xres)
+        self.title_label.set_text(title)
+
+    def _on_resolution_changed(self, obj, pspec):
+        # RatbagdResolution's resolution has changed, update the scales.
+        (xres, yres) = self._resolution.resolution
+        self.scale_x.set_value(xres)
+        self.scale_y.set_value(yres)
+
+    def toggle_revealer(self):
+        """Toggles the revealer to show or hide the configuration widgets."""
+        reveal = not self.revealer.get_reveal_child()
+        self.revealer.set_reveal_child(reveal)

--- a/piper/resolutionrow.py
+++ b/piper/resolutionrow.py
@@ -19,7 +19,7 @@ from .ratbagd import RatbagdResolution
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gtk
+from gi.repository import GObject, Gtk
 
 
 @GtkTemplate(ui="/org/freedesktop/Piper/resolutionRow.ui")
@@ -86,6 +86,12 @@ class ResolutionRow(Gtk.ListBoxRow):
         else:
             title = "{} DPI".format(xres)
         self.title_label.set_text(title)
+
+    @GtkTemplate.Callback
+    def _on_scroll_event(self, widget, event):
+        # Prevent a scroll in the list to get caught by the scale
+        GObject.signal_stop_emission_by_name(widget, "scroll-event")
+        return False
 
     def _on_resolution_changed(self, obj, pspec):
         # RatbagdResolution's resolution has changed, update the scales.

--- a/piper/resolutionrow.py
+++ b/piper/resolutionrow.py
@@ -32,10 +32,7 @@ class ResolutionRow(Gtk.ListBoxRow):
     index_label = GtkTemplate.Child()
     title_label = GtkTemplate.Child()
     revealer = GtkTemplate.Child()
-    frame_y = GtkTemplate.Child()
-    label_x = GtkTemplate.Child()
-    scale_x = GtkTemplate.Child()
-    scale_y = GtkTemplate.Child()
+    scale = GtkTemplate.Child()
 
     def __init__(self, ratbagd_resolution, *args, **kwargs):
         Gtk.ListBoxRow.__init__(self, *args, **kwargs)
@@ -50,20 +47,14 @@ class ResolutionRow(Gtk.ListBoxRow):
     def _init_values(self):
         # Initializes the scales and the title label and sets the Y resolution
         # configuration visible if it's supported by the device.
-        (xres, yres) = self._resolution.resolution
+        xres, _ = self._resolution.resolution
         minres = self._resolution.min_res
         maxres = self._resolution.max_res
 
         self.index_label.set_text("Resolution {}".format(self._resolution.index))
 
-        self.scale_x.props.adjustment = Gtk.Adjustment(xres, minres, maxres)
-        self.scale_x.set_value(xres)
-        if self._separate_xy:
-            self.scale_y.props.adjustment = Gtk.Adjustment(yres, minres, maxres)
-            self.scale_y.set_value(yres)
-            self.frame_y.set_visible(True)
-        else:
-            self.label_x.set_text("Resolution")
+        self.scale.props.adjustment = Gtk.Adjustment(xres, minres, maxres)
+        self.scale.set_value(xres)
 
     @GtkTemplate.Callback
     def _on_delete_button_clicked(self, button):
@@ -73,19 +64,13 @@ class ResolutionRow(Gtk.ListBoxRow):
     def _on_value_changed(self, scale):
         # The scale has been moved, update RatbagdResolution's resolution and
         # the title label.
-        xres = int(self.scale_x.get_value())
-        yres = int(self.scale_y.get_value())
+        xres = int(self.scale.get_value())
 
         # Freeze the notify::resolution signal from firing to prevent Piper from
         # ending up in an infinite update loop.
         with self._resolution.handler_block(self._handler):
-            self._resolution.resolution = (xres, yres)
-
-        if self._separate_xy:
-            title = "{} DPI (X), {} DPI (Y)".format(xres, yres)
-        else:
-            title = "{} DPI".format(xres)
-        self.title_label.set_text(title)
+            self._resolution.resolution = xres, xres
+        self.title_label.set_text("{} DPI".format(xres))
 
     @GtkTemplate.Callback
     def _on_scroll_event(self, widget, event):
@@ -95,9 +80,8 @@ class ResolutionRow(Gtk.ListBoxRow):
 
     def _on_resolution_changed(self, obj, pspec):
         # RatbagdResolution's resolution has changed, update the scales.
-        (xres, yres) = self._resolution.resolution
-        self.scale_x.set_value(xres)
-        self.scale_y.set_value(yres)
+        xres, _ = self._resolution.resolution
+        self.scale.set_value(xres)
 
     def toggle_revealer(self):
         """Toggles the revealer to show or hide the configuration widgets."""

--- a/piper/resolutionrow.py
+++ b/piper/resolutionrow.py
@@ -53,8 +53,16 @@ class ResolutionRow(Gtk.ListBoxRow):
 
         self.index_label.set_text("Resolution {}".format(self._resolution.index))
 
-        self.scale.props.adjustment = Gtk.Adjustment(xres, minres, maxres)
+        self.scale.props.adjustment.configure(xres, minres, maxres, 50, 50, 0)
         self.scale.set_value(xres)
+
+    @GtkTemplate.Callback
+    def _on_change_value(self, scale, scroll, value):
+        # Round the value resulting from a scroll event to the nearest multiple
+        # of 50. This is to work around the Gtk.Scale not snapping to its
+        # Gtk.Adjustment's step_increment.
+        scale.set_value(int(value - (value % 50)))
+        return True
 
     @GtkTemplate.Callback
     def _on_delete_button_clicked(self, button):

--- a/piper/resolutionspage.py
+++ b/piper/resolutionspage.py
@@ -1,0 +1,90 @@
+# Copyright (C) 2017 Jente Hidskes <hjdskes@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from gettext import gettext as _
+
+from .gi_composites import GtkTemplate
+from .mousemap import MouseMap
+from .resolutionrow import ResolutionRow
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+
+@GtkTemplate(ui="/org/freedesktop/Piper/resolutionsPage.ui")
+class ResolutionsPage(Gtk.Box):
+    """The first stack page, exposing the resolution configuration with its
+    report rate buttons and resolutions list."""
+
+    __gtype_name__ = "ResolutionsPage"
+
+    rate_500 = GtkTemplate.Child()
+    rate_1000 = GtkTemplate.Child()
+    listbox = GtkTemplate.Child()
+    add_resolution_row = GtkTemplate.Child()
+
+    def __init__(self, ratbagd_device, *args, **kwargs):
+        """Instantiates a new ResolutionsPage.
+
+        @param ratbag_device The ratbag device to configure, as
+                             ratbagd.RatbagdDevice
+        """
+        Gtk.Box.__init__(self, *args, **kwargs)
+        self.init_template()
+
+        self._device = ratbagd_device
+        self._notification_commit_timeout_id = 0
+        self._last_activated_row = None
+
+        self._init_ui()
+
+    def _init_ui(self):
+        profile = self._device.active_profile
+
+        mousemap = MouseMap("#Buttons", self._device, spacing=20, border_width=20)
+        self.pack_start(mousemap, True, True, 0)
+        # Place the MouseMap on the left
+        self.reorder_child(mousemap, 0)
+        for button in profile.buttons:
+            if button.action_type == "special" and button.special == "resolution-default":
+                label = Gtk.Label(_("Switch resolution"))
+                mousemap.add(label, "#button{}".format(button.index))
+
+        self.rate_500.connect("toggled", self._on_report_rate_toggled, 500)
+        self.rate_500.set_active(profile.active_resolution.report_rate == 500)
+        self.rate_1000.connect("toggled", self._on_report_rate_toggled, 1000)
+        self.rate_1000.set_active(profile.active_resolution.report_rate == 1000)
+
+        for resolution in profile.resolutions:
+            row = ResolutionRow(resolution)
+            self.listbox.insert(row, resolution.index)
+
+    def _on_report_rate_toggled(self, button, rate):
+        profile = self._device.active_profile
+        profile.active_resolution.report_rate = rate
+
+    @GtkTemplate.Callback
+    def _on_row_activated(self, listbox, row):
+        if row is self.add_resolution_row:
+            print("TODO: RatbagdProfile needs a way to add resolutions")
+        elif row is self._last_activated_row:
+            row.toggle_revealer()
+        else:
+            if self._last_activated_row is not None:
+                self._last_activated_row.toggle_revealer()
+            self._last_activated_row = row
+            row.toggle_revealer()

--- a/piper/window.py
+++ b/piper/window.py
@@ -52,6 +52,7 @@ class Window(Gtk.ApplicationWindow):
         self._ratbag = ratbag
         self._device = self._fetch_ratbag_device()
         self._notification_commit_timeout_id = 0
+        self._last_activated_row = None
 
         self._setup_resolutions_page()
 
@@ -115,7 +116,12 @@ class Window(Gtk.ApplicationWindow):
     def _on_row_activated(self, listbox, row):
         if row is self.add_resolution_row:
             print("TODO: RatbagdProfile needs a way to add resolutions")
-        elif row is not None:
+        elif row is self._last_activated_row:
+            row.toggle_revealer()
+        else:
+            if self._last_activated_row is not None:
+                self._last_activated_row.toggle_revealer()
+            self._last_activated_row = row
             row.toggle_revealer()
 
     @GtkTemplate.Callback

--- a/piper/window.py
+++ b/piper/window.py
@@ -14,6 +14,8 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+from gettext import gettext as _
+
 from .gi_composites import GtkTemplate
 from .mousemap import MouseMap
 from .ratbagd import RatbagErrorCode
@@ -54,8 +56,13 @@ class Window(Gtk.ApplicationWindow):
         self._setup_resolutions_page()
 
     def _setup_resolutions_page(self):
-        # TODO: mousemap needs to show which button switches resolution
-        mousemap = MouseMap("#Device", self._device, spacing=20, border_width=20)
+        profile = self._device.active_profile
+
+        mousemap = MouseMap("#Buttons", self._device, spacing=20, border_width=20)
+        for button in profile.buttons:
+            if button.action_type == "special" and button.special == "resolution-default":
+                label = Gtk.Label(_("Switch resolution"))
+                mousemap.add(label, "#button{}".format(button.index))
 
         self.rate_500.connect("toggled", self._on_report_rate_toggled, 500)
         self.rate_500.set_active(profile.active_resolution.report_rate == 500)

--- a/piper/window.py
+++ b/piper/window.py
@@ -14,20 +14,21 @@
 # with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
-from gettext import gettext as _
+from .gi_composites import GtkTemplate
 
 import gi
 gi.require_version("Gtk", "3.0")
 from gi.repository import Gtk
 
-from .mousemap import MouseMap
 
-
+@GtkTemplate(ui="/org/freedesktop/Piper/window.ui")
 class Window(Gtk.ApplicationWindow):
     """A Gtk.ApplicationWindow subclass to implement the main application
     window."""
 
     __gtype_name__ = "ApplicationWindow"
+
+    stack = GtkTemplate.Child()
 
     def __init__(self, ratbag, *args, **kwargs):
         """Instantiates a new Window.
@@ -35,42 +36,10 @@ class Window(Gtk.ApplicationWindow):
         @param ratbag The ratbag instance to connect to, as ratbagd.Ratbag
         """
         Gtk.ApplicationWindow.__init__(self, *args, **kwargs)
+        self.init_template()
+
         self._ratbag = ratbag
-
-        stack = Gtk.Stack()
-        self.add(stack)
-        stack.props.homogeneous = True
-        stack.props.transition_duration = 500
-        stack.props.transition_type = Gtk.StackTransitionType.SLIDE_LEFT_RIGHT
-
-        device = self._fetch_ratbag_device()
-        stack.add_titled(self._setup_buttons_page(device), "buttons", _("Buttons"))
-        self.set_titlebar(self._setup_headerbar(stack))
-
-    def _setup_headerbar(self, stack):
-        headerbar = Gtk.HeaderBar()
-
-        sizeGroup = Gtk.SizeGroup.new(Gtk.SizeGroupMode.HORIZONTAL)
-        self._quit = Gtk.Button.new_with_mnemonic(_("_Quit"))
-        self._quit.connect("clicked", lambda button, data: data.destroy(), self)
-        sizeGroup.add_widget(self._quit)
-        headerbar.pack_start(self._quit)
-
-        switcher = Gtk.StackSwitcher()
-        switcher.set_stack(stack)
-        headerbar.set_custom_title(switcher)
-
-        return headerbar
-
-    def _setup_buttons_page(self, device):
-        mousemap = MouseMap("#Buttons", device, spacing=20, border_width=20)
-        sizegroup = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
-        profile = device.active_profile
-        for button in profile.buttons:
-            mapbutton = Gtk.Button("Button {}".format(button.index))
-            mousemap.add(mapbutton, "#button{}".format(button.index))
-            sizegroup.add_widget(mapbutton)
-        return mousemap
+        self._device = self._fetch_ratbag_device()
 
     def _fetch_ratbag_device(self):
         """Get the first ratbag device available. If there are multiple

--- a/piper/window.py
+++ b/piper/window.py
@@ -15,6 +15,9 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from .gi_composites import GtkTemplate
+from .mousemap import MouseMap
+from .ratbagd import RatbagErrorCode
+from .resolutionrow import ResolutionRow
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -29,6 +32,8 @@ class Window(Gtk.ApplicationWindow):
     __gtype_name__ = "ApplicationWindow"
 
     stack = GtkTemplate.Child()
+    listbox = GtkTemplate.Child()
+    add_resolution_row = GtkTemplate.Child()
 
     def __init__(self, ratbag, *args, **kwargs):
         """Instantiates a new Window.
@@ -41,11 +46,27 @@ class Window(Gtk.ApplicationWindow):
         self._ratbag = ratbag
         self._device = self._fetch_ratbag_device()
 
+        self._setup_resolutions_page()
+
+    def _setup_resolutions_page(self):
+        # TODO: mousemap needs to show which button switches resolution
+        mousemap = MouseMap("#Device", self._device, spacing=20, border_width=20)
+
+        page = self.stack.get_child_by_name("resolutions")
+        page.pack_start(mousemap, True, True, 0)
+        # Place the MouseMap on the left
+        page.reorder_child(mousemap, 0)
+
+        for resolution in profile.resolutions:
+            row = ResolutionRow(resolution)
+            self.listbox.insert(row, resolution.index)
+
     def _fetch_ratbag_device(self):
         """Get the first ratbag device available. If there are multiple
         devices, an error message is printed and we default to the first
         one. Otherwise, an error is shown and we return None.
         """
+        # TODO: replace with better implementation once we go for the welcome screen.
         if len(self._ratbag.devices) == 0:
             print("Could not find any devices. Do you have anything vaguely mouse-looking plugged in?")
             return None
@@ -54,3 +75,16 @@ class Window(Gtk.ApplicationWindow):
             for d in self._ratbag.devices[1:]:
                 print("Ignoring device {}".format(d.name))
         return self._ratbag.devices[0]
+
+    @GtkTemplate.Callback
+    def _on_row_activated(self, listbox, row):
+        if row is self.add_resolution_row:
+            print("TODO: RatbagdProfile needs a way to add resolutions")
+        elif row is not None:
+            row.toggle_revealer()
+
+    @GtkTemplate.Callback
+    def _on_save_button_clicked(self, button):
+        status = self._device.commit()
+        if not status == RatbagErrorCode.RATBAG_SUCCESS:
+            print("TODO: inform user of error")

--- a/piper/window.py
+++ b/piper/window.py
@@ -32,6 +32,8 @@ class Window(Gtk.ApplicationWindow):
     __gtype_name__ = "ApplicationWindow"
 
     stack = GtkTemplate.Child()
+    rate_500 = GtkTemplate.Child()
+    rate_1000 = GtkTemplate.Child()
     box_resolutions = GtkTemplate.Child()
     listbox = GtkTemplate.Child()
     add_resolution_row = GtkTemplate.Child()
@@ -54,6 +56,11 @@ class Window(Gtk.ApplicationWindow):
     def _setup_resolutions_page(self):
         # TODO: mousemap needs to show which button switches resolution
         mousemap = MouseMap("#Device", self._device, spacing=20, border_width=20)
+
+        self.rate_500.connect("toggled", self._on_report_rate_toggled, 500)
+        self.rate_500.set_active(profile.active_resolution.report_rate == 500)
+        self.rate_1000.connect("toggled", self._on_report_rate_toggled, 1000)
+        self.rate_1000.set_active(profile.active_resolution.report_rate == 1000)
 
         self.box_resolutions.pack_start(mousemap, True, True, 0)
         # Place the MouseMap on the left
@@ -92,6 +99,10 @@ class Window(Gtk.ApplicationWindow):
     def _on_notification_commit_timeout(self):
         self._hide_notification_commit()
         return False
+
+    def _on_report_rate_toggled(self, button, rate):
+        profile = self._device.active_profile
+        profile.active_resolution.report_rate = rate
 
     @GtkTemplate.Callback
     def _on_row_activated(self, listbox, row):


### PR DESCRIPTION
This PR adds the resolutions page according to the mockups (well, mostly). It's not entirely done but I would like some feedback and discussion:

1. Libratbag doesn't yet support adding and removing resolutions (see https://github.com/libratbag/libratbag/issues/211), how do I deal with this in Piper? At the moment, the widgets are there printing a message to stdout.
2. To draw only one leader in the MouseMap in the resolutions page, I modified the SVG requirements (again...). I'm not particularly happy with this as the list of SVG requirements is already pretty long, but basically I grouped the paths and the little squares they connect to and gave this group the id `buttonX-path`. Commit https://github.com/libratbag/piper/pull/28/commits/fb068e395c076755a2c2535c12e5fa842843c0d1 should explain itself, I think. If we don't do this, the MouseMap in the resolutions page will draw all the leaders, even those without a "Switch resolution" label next to it.
3. There is no option to set a resolution as the default; how shall I approach this? The mockups left this out.

I think that's all. Do try it out (any SVG from https://github.com/libratbag/libratbag/pull/182 should work), and let me know what you think of it thus far. It would also be great if someone can test it with a device that supports separate X/Y resolutions, as I cannot do this myself.