### PR TITLE
Add LED page to configure LEDs

### DIFF
--- a/data/piper.gresource.xml
+++ b/data/piper.gresource.xml
@@ -4,6 +4,7 @@
         <file>404.svg</file>
 
         <file preprocess="xml-stripblanks">AboutDialog.ui</file>
+        <file preprocess="xml-stripblanks">ui/LedDialog.ui</file>
         <file preprocess="xml-stripblanks">ui/OptionButton.ui</file>
         <file preprocess="xml-stripblanks">ui/ResolutionRow.ui</file>
         <file preprocess="xml-stripblanks">ui/ResolutionsPage.ui</file>

--- a/data/piper.gresource.xml
+++ b/data/piper.gresource.xml
@@ -4,6 +4,7 @@
         <file>404.svg</file>
 
         <file preprocess="xml-stripblanks">AboutDialog.ui</file>
+        <file preprocess="xml-stripblanks">ui/OptionButton.ui</file>
         <file preprocess="xml-stripblanks">ui/ResolutionRow.ui</file>
         <file preprocess="xml-stripblanks">ui/ResolutionsPage.ui</file>
         <file preprocess="xml-stripblanks">ui/Window.ui</file>

--- a/data/ui/LedDialog.ui
+++ b/data/ui/LedDialog.ui
@@ -1,0 +1,440 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <object class="GtkAdjustment" id="adjustment_brightness">
+    <property name="upper">255</property>
+    <property name="step_increment">1</property>
+    <property name="page_increment">10</property>
+  </object>
+  <object class="GtkAdjustment" id="adjustment_effect_rate">
+    <property name="lower">100</property>
+    <property name="upper">20000</property>
+    <property name="step_increment">50</property>
+    <property name="page_increment">50</property>
+  </object>
+  <template class="LedDialog" parent="GtkDialog">
+    <property name="width_request">400</property>
+    <property name="height_request">300</property>
+    <property name="can_focus">False</property>
+    <property name="resizable">False</property>
+    <property name="modal">True</property>
+    <property name="type_hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox">
+        <property name="can_focus">False</property>
+        <property name="margin_left">12</property>
+        <property name="margin_right">12</property>
+        <property name="margin_top">12</property>
+        <property name="margin_bottom">12</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox">
+            <property name="can_focus">False</property>
+            <property name="layout_style">end</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkStack" id="stack">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="transition_type">slide-left-right</property>
+            <child>
+              <object class="GtkColorChooserWidget" id="colorchooser">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="halign">center</property>
+                <property name="valign">center</property>
+                <property name="rgba">rgb(237,212,0)</property>
+                <property name="use_alpha">False</property>
+              </object>
+              <packing>
+                <property name="name">solid</property>
+                <property name="title" translatable="yes">Solid</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="homogeneous">True</property>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <object class="GtkAlignment">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="left_padding">12</property>
+                        <child>
+                          <object class="GtkScale">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="adjustment">adjustment_brightness</property>
+                            <property name="round_digits">0</property>
+                            <property name="digits">0</property>
+                            <property name="draw_value">False</property>
+                            <property name="value_pos">right</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Brightness</property>
+                        <property name="track_visited_links">False</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <object class="GtkAlignment">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="left_padding">12</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">10</property>
+                            <child>
+                              <object class="GtkScale">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="adjustment">adjustment_effect_rate</property>
+                                <property name="round_digits">0</property>
+                                <property name="digits">0</property>
+                                <property name="value_pos">right</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">end</property>
+                                <property name="label" translatable="yes">Hz</property>
+                                <property name="justify">right</property>
+                                <property name="track_visited_links">False</property>
+                                <style>
+                                  <class name="dim-label"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="pack_type">end</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Effect rate</property>
+                        <property name="track_visited_links">False</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">cycle</property>
+                <property name="title" translatable="yes">Cycle</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="homogeneous">True</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="homogeneous">True</property>
+                    <child>
+                      <object class="GtkColorButton" id="colorbutton">
+                        <property name="visible">True</property>
+                        <property name="can_focus">True</property>
+                        <property name="receives_default">True</property>
+                        <property name="halign">end</property>
+                        <property name="valign">center</property>
+                        <property name="title" translatable="yes">Pick a Color for the LED</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="pack_type">end</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="halign">start</property>
+                        <property name="label" translatable="yes">Color</property>
+                        <property name="track_visited_links">False</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <object class="GtkAlignment">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="left_padding">12</property>
+                        <child>
+                          <object class="GtkScale">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="adjustment">adjustment_brightness</property>
+                            <property name="digits">0</property>
+                            <property name="draw_value">False</property>
+                            <property name="value_pos">right</property>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Brightness</property>
+                        <property name="track_visited_links">False</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkFrame">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child>
+                      <object class="GtkAlignment">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="left_padding">12</property>
+                        <child>
+                          <object class="GtkBox">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="spacing">10</property>
+                            <child>
+                              <object class="GtkScale">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="adjustment">adjustment_effect_rate</property>
+                                <property name="round_digits">0</property>
+                                <property name="digits">0</property>
+                                <property name="value_pos">right</property>
+                              </object>
+                              <packing>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="halign">end</property>
+                                <property name="label" translatable="yes">Hz</property>
+                                <property name="justify">right</property>
+                                <property name="track_visited_links">False</property>
+                                <style>
+                                  <class name="dim-label"/>
+                                </style>
+                              </object>
+                              <packing>
+                                <property name="expand">False</property>
+                                <property name="fill">True</property>
+                                <property name="pack_type">end</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                    <child type="label">
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <property name="label" translatable="yes">Effect rate</property>
+                        <property name="track_visited_links">False</property>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">breathing</property>
+                <property name="title" translatable="yes">Breathing</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <child>
+                  <object class="GtkImage">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="stock">gtk-missing-image</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkLabel">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="label" translatable="yes">This LED is off</property>
+                    <property name="justify">center</property>
+                    <property name="track_visited_links">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="name">off</property>
+                <property name="title" translatable="yes">Off</property>
+                <property name="position">3</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <child type="titlebar">
+      <object class="GtkHeaderBar">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkButton" id="cancel">
+            <property name="label" translatable="yes">Cancel</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="receives_default">True</property>
+          </object>
+        </child>
+        <child type="title">
+          <object class="GtkStackSwitcher">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="stack">stack</property>
+          </object>
+        </child>
+        <child>
+          <object class="GtkButton" id="apply">
+            <property name="label" translatable="yes">Apply</property>
+            <property name="visible">True</property>
+            <property name="can_focus">True</property>
+            <property name="can_default">True</property>
+            <property name="receives_default">True</property>
+            <style>
+              <class name="suggested-action"/>
+            </style>
+          </object>
+          <packing>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="cancel">cancel</action-widget>
+      <action-widget response="apply" default="true">apply</action-widget>
+    </action-widgets>
+  </template>
+</interface>

--- a/data/ui/OptionButton.ui
+++ b/data/ui/OptionButton.ui
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.20.0 -->
+<interface>
+  <requires lib="gtk+" version="3.20"/>
+  <template class="OptionButton" parent="GtkButton">
+    <property name="visible">True</property>
+    <property name="can_focus">True</property>
+    <property name="receives_default">True</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <child>
+          <object class="GtkImage">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="icon_name">emblem-system-symbolic</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkSeparator">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="margin_left">6</property>
+            <property name="margin_right">6</property>
+            <property name="orientation">vertical</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkLabel" id="label">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="halign">center</property>
+            <property name="label" translatable="yes">LED 0: solid</property>
+            <property name="track_visited_links">False</property>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+  </template>
+</interface>

--- a/piper/leddialog.py
+++ b/piper/leddialog.py
@@ -1,0 +1,88 @@
+# Copyright (C) 2017 Jente Hidskes <hjdskes@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from .gi_composites import GtkTemplate
+from .ratbagd import RatbagdLed
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gdk, GObject, Gtk
+
+
+@GtkTemplate(ui="/org/freedesktop/Piper/ui/LedDialog.ui")
+class LedDialog(Gtk.Dialog):
+    """A Gtk.Dialog subclass to implement the dialog that shows the
+    configuration options for the LED effects."""
+
+    __gtype_name__ = "LedDialog"
+
+    stack = GtkTemplate.Child()
+    colorchooser = GtkTemplate.Child()
+    colorbutton = GtkTemplate.Child()
+    adjustment_brightness = GtkTemplate.Child()
+    adjustment_effect_rate = GtkTemplate.Child()
+
+    def __init__(self, ratbagd_led, *args, **kwargs):
+        """Instantiates a new LedDialog.
+
+        @param ratbagd_led The LED to configure, as ratbagd.RatbagdLed.
+        """
+        Gtk.Dialog.__init__(self, *args, **kwargs)
+        self.init_template()
+        self._led = ratbagd_led
+        self._modes = {
+            "solid": RatbagdLed.MODE_ON,
+            "cycle": RatbagdLed.MODE_CYCLE,
+            "breathing": RatbagdLed.MODE_BREATHING,
+            "off": RatbagdLed.MODE_OFF
+        }
+
+        mode = self._led.mode
+        for k, v in self._modes.items():
+            if mode == v:
+                self.stack.set_visible_child_name(k)
+        rgba = self._get_led_color_as_rgba()
+        self.colorchooser.set_rgba(rgba)
+        self.colorbutton.set_rgba(rgba)
+        self.adjustment_brightness.set_value(self._led.brightness)
+        self.adjustment_effect_rate.set_value(self._led.effect_rate)
+
+    def _get_led_color_as_rgba(self):
+        # Helper function to convert ratbagd's 0-255 color range to a Gdk.RGBA
+        # with a 0.0-1.0 color range.
+        r, g, b = self._led.color
+        return Gdk.RGBA(r / 255.0, g / 255.0, b / 255.0, 1.0)
+
+    @GObject.Property
+    def mode(self):
+        visible_child = self.stack.get_visible_child_name()
+        return self._modes[visible_child]
+
+    @GObject.Property
+    def color(self):
+        if self.mode == RatbagdLed.MODE_ON:
+            rgba = self.colorchooser.get_rgba()
+        else:
+            rgba = self.colorbutton.get_rgba()
+        return (rgba.red * 255.0, rgba.green * 255.0, rgba.blue * 255.0)
+
+    @GObject.Property
+    def brightness(self):
+        return self.adjustment_brightness.get_value()
+
+    @GObject.Property
+    def effect_rate(self):
+        return self.adjustment_effect_rate.get_value()

--- a/piper/ledspage.py
+++ b/piper/ledspage.py
@@ -1,0 +1,92 @@
+# Copyright (C) 2017 Jente Hidskes <hjdskes@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from gettext import gettext as _
+
+from .leddialog import LedDialog
+from .mousemap import MouseMap
+from .optionbutton import OptionButton
+from .ratbagd import RatbagdLed
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+
+class LedsPage(Gtk.Box):
+    """The third stack page, exposing the LED configuration."""
+
+    __gtype_name__ = "LedsPage"
+
+    def __init__(self, ratbagd_device, *args, **kwargs):
+        """Instantiates a new LedsPage.
+
+        @param ratbag_device The ratbag device to configure, as
+                             ratbagd.RatbagdDevice
+        """
+        Gtk.Box.__init__(self, *args, **kwargs)
+        self._device = ratbagd_device
+        self._init_ui()
+
+    def _init_ui(self):
+        profile = self._device.active_profile
+
+        mousemap = MouseMap("#Leds", self._device, spacing=20, border_width=20)
+        self.pack_start(mousemap, True, True, 0)
+
+        sizegroup = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
+        for led in profile.leds:
+            index = led.index
+            mode = self._mode_to_string(led.mode)
+            button = OptionButton("LED {}: {}".format(index, mode))
+            button.connect("clicked", self._on_button_clicked, led)
+            led.connect("notify::mode", self._on_led_mode_changed, button)
+            mousemap.add(button, "#led{}".format(index))
+            sizegroup.add_widget(button)
+
+    def _on_led_mode_changed(self, led, pspec, button):
+        mode = self._mode_to_string(led.mode)
+        button.set_label("LED {}: {}".format(led.index, mode))
+
+    def _on_button_clicked(self, button, led):
+        # Presents the LedDialog to configure the LED corresponding to the
+        # clicked button.
+        dialog = LedDialog(led, transient_for=self.get_toplevel())
+        dialog.connect("response", self._on_dialog_response, button, led)
+        dialog.present()
+
+    def _on_dialog_response(self, dialog, response, button, led):
+        # The user either pressed cancel or apply. If it's apply, apply the
+        # changes before closing the dialog, otherwise just close the dialog.
+        if response == Gtk.ResponseType.APPLY:
+            led.mode = dialog.mode
+            led.color = dialog.color
+            led.brightness = dialog.brightness
+            led.effect_rate = dialog.effect_rate
+        dialog.destroy()
+
+    def _mode_to_string(self, mode):
+        # Converts a RatbagdLed mode to a string.
+        if mode == RatbagdLed.MODE_ON:
+            return _("solid")
+        elif mode == RatbagdLed.MODE_CYCLE:
+            return _("cycle")
+        elif mode == RatbagdLed.MODE_BREATHING:
+            return _("breathing")
+        elif mode == RatbagdLed.MODE_OFF:
+            return _("off")
+        else:
+            return _("n/a")

--- a/piper/optionbutton.py
+++ b/piper/optionbutton.py
@@ -1,0 +1,46 @@
+# Copyright (C) 2017 Jente Hidskes <hjdskes@gmail.com>
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from .gi_composites import GtkTemplate
+
+import gi
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk
+
+
+@GtkTemplate(ui="/org/freedesktop/Piper/ui/OptionButton.ui")
+class OptionButton(Gtk.Button):
+    """A Gtk.Button subclass that displays a label, a separator and a cog."""
+
+    __gtype_name__ = "OptionButton"
+
+    label = GtkTemplate.Child()
+
+    def __init__(self, label, *args, **kwargs):
+        """Instantiates a new OptionButton.
+
+        @param label The text to display.
+        """
+        Gtk.Button.__init__(self, *args, **kwargs)
+        self.init_template()
+        self.set_label(label)
+
+    def set_label(self, label):
+        """Set the text to display.
+
+        @param label The new text to display, as str.
+        """
+        self.label.set_text(label)

--- a/piper/window.py
+++ b/piper/window.py
@@ -17,7 +17,7 @@
 from gettext import gettext as _
 
 from .gi_composites import GtkTemplate
-from .ratbagd import RatbagErrorCode
+from .ratbagd import RatbagErrorCode, RatbagdDevice
 from .resolutionspage import ResolutionsPage
 from .ledspage import LedsPage
 
@@ -49,8 +49,11 @@ class Window(Gtk.ApplicationWindow):
         self._ratbag = ratbag
         self._device = self._fetch_ratbag_device()
 
-        self.stack.add_titled(ResolutionsPage(self._device), "resolutions", _("Resolutions"))
-        self.stack.add_titled(LedsPage(self._device), "leds", _("LEDs"))
+        capabilities = self._device.capabilities
+        if RatbagdDevice.CAP_RESOLUTION in capabilities:
+            self.stack.add_titled(ResolutionsPage(self._device), "resolutions", _("Resolutions"))
+        if RatbagdDevice.CAP_LED in capabilities:
+            self.stack.add_titled(LedsPage(self._device), "leds", _("LEDs"))
 
     def _fetch_ratbag_device(self):
         """Get the first ratbag device available. If there are multiple

--- a/piper/window.py
+++ b/piper/window.py
@@ -19,6 +19,7 @@ from gettext import gettext as _
 from .gi_composites import GtkTemplate
 from .ratbagd import RatbagErrorCode
 from .resolutionspage import ResolutionsPage
+from .ledspage import LedsPage
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -49,7 +50,7 @@ class Window(Gtk.ApplicationWindow):
         self._device = self._fetch_ratbag_device()
 
         self.stack.add_titled(ResolutionsPage(self._device), "resolutions", _("Resolutions"))
-        self.stack.set_visible_child_name("resolutions")
+        self.stack.add_titled(LedsPage(self._device), "leds", _("LEDs"))
 
     def _fetch_ratbag_device(self):
         """Get the first ratbag device available. If there are multiple


### PR DESCRIPTION
As per [the mockups](https://github.com/libratbag/piper/raw/wiki/redesign/leds.png), but dialogs instead of popovers to consistently use dialogs throughout Piper (as they are required for button mapping) and with the color selection button moved into the configuration dialog as not every mode has a configurable color.

Changes are applied only after the commit button is pressed. State in between two invocations of any configuration dialog is not remembered; not even after a commit. The former is intentional, the latter is a bug. I suspect this is due to the bindings only retrieving their properties from DBus upon instantiation, but I'll look into this after opening this PR.

Also, as noted in the code, we cannot toggle *after* the user has accepted the changes in the dialog or not toggle when the user cancelled the dialog. This means that the mode will be changed even when the user cancels that mode's configuration dialog. I don't like it, it would certainly be better to not toggle when the user cancels the dialog, but I suppose it's fine since the changes have to be committed before they are applied to the device. If it's a deal breaker, I can look into subclassing `Gtk.ToggleButton` to fix this. Let me know your opinion.

Finally, I attempted to add capability checking before adding pages to the main window's stack, but I'm not sure if I'm doing this correctly; my device doesn't seem to have `RatbagdDevice.CAP_RESOLUTION` (which I think it should, given its documentation) but it does have `CAP_SWITCHABLE_RESOLUTION`. Which of these should I use to check if the resolutions page should be shown?

I think that's it; please test the changes and let me know what you think.

