### PR TITLE
Rename anonymous variables from _ to __

### DIFF
--- a/piper/resolutionrow.py
+++ b/piper/resolutionrow.py
@@ -44,7 +44,7 @@ class ResolutionRow(Gtk.ListBoxRow):
     def _init_values(self):
         # Initializes the scales and the title label and sets the Y resolution
         # configuration visible if it's supported by the device.
-        xres, _ = self._resolution.resolution
+        xres, __ = self._resolution.resolution
         minres = self._resolution.minimum
         maxres = self._resolution.maximum
 
@@ -85,7 +85,7 @@ class ResolutionRow(Gtk.ListBoxRow):
 
     def _on_resolution_changed(self, obj, pspec):
         # RatbagdResolution's resolution has changed, update the scales.
-        xres, _ = self._resolution.resolution
+        xres, __ = self._resolution.resolution
         self.scale.set_value(xres)
 
     def toggle_revealer(self):

--- a/piper/resolutionrow.py
+++ b/piper/resolutionrow.py
@@ -15,7 +15,6 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
 from .gi_composites import GtkTemplate
-from .ratbagd import RatbagdResolution
 
 import gi
 gi.require_version("Gtk", "3.0")
@@ -38,8 +37,6 @@ class ResolutionRow(Gtk.ListBoxRow):
         Gtk.ListBoxRow.__init__(self, *args, **kwargs)
         self.init_template()
         self._resolution = ratbagd_resolution
-        self._separate_xy = RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION in \
-            ratbagd_resolution.capabilities
         self._handler = self._resolution.connect("notify::resolution",
                                                  self._on_resolution_changed)
         self._init_values()


### PR DESCRIPTION
Modules that need internationalization import gettext as `_`, so anonymous variables should be named `__` instead (double underscore) so as not to clash.