### PR TITLE
ResolutionsPage: set report rate for all resolutions

### DIFF
--- a/piper/resolutionspage.py
+++ b/piper/resolutionspage.py
@@ -75,7 +75,11 @@ class ResolutionsPage(Gtk.Box):
 
     def _on_report_rate_toggled(self, button, rate):
         profile = self._device.active_profile
-        profile.active_resolution.report_rate = rate
+        # TODO: currently no devices expose CAP_INDIVIDUAL_REPORT_RATE, but if
+        # so then we should check for this here and set it only on the relevant
+        # resolution.
+        for resolution in profile.resolutions:
+            resolution.report_rate = rate
 
     @GtkTemplate.Callback
     def _on_row_activated(self, listbox, row):


### PR DESCRIPTION
See https://github.com/libratbag/libratbag/issues/202.

It wouldn't be difficult to support devices that do support individual report rates; it would simply be a matter of the following to set the active resolution's report rate only:

```diff
diff --git a/piper/resolutionspage.py b/piper/resolutionspage.py
index 9c7faa6..c0b580f 100644
--- a/piper/resolutionspage.py
+++ b/piper/resolutionspage.py
@@ -75,11 +75,11 @@ class ResolutionsPage(Gtk.Box):
 
     def _on_report_rate_toggled(self, button, rate):
         profile = self._device.active_profile
-        # TODO: currently no devices expose CAP_INDIVIDUAL_REPORT_RATE, but if
-        # so then we should check for this here and set it only on the relevant
-        # resolution.
-        for resolution in profile.resolutions:
-            resolution.report_rate = rate
+        if RatbagdResolution.CAP_INDIVIDUAL_REPORT_RATE in profile.active_resolution:
+            profile.active_resolution.report_rate = rate
+        else:
+            for resolution in profile.resolutions:
+                resolution.report_rate = rate
 
     @GtkTemplate.Callback
     def _on_row_activated(self, listbox, row):
```

The above would require a callback connected to `active-resolution-changed` so that we update the report rate widgets to reflect the active resolution's report rate when the active resolution changes, but that's also a few minutes' work. Let me know if you want me to go ahead with this.
