### PR TITLE
data/ui: add tooltips to control widgets

### DIFF
--- a/data/ui/LedDialog.ui
+++ b/data/ui/LedDialog.ui
@@ -55,6 +55,7 @@
               <object class="GtkColorChooserWidget" id="colorchooser">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
+                <property name="tooltip_text" translatable="yes">Choose a color for the LED</property>
                 <property name="halign">center</property>
                 <property name="valign">center</property>
                 <property name="rgba">rgb(237,212,0)</property>
@@ -86,6 +87,7 @@
                           <object class="GtkScale">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
+                            <property name="tooltip_text" translatable="yes">Choose a brightness for the LED</property>
                             <property name="adjustment">adjustment_brightness</property>
                             <property name="round_digits">0</property>
                             <property name="digits">0</property>
@@ -130,6 +132,7 @@
                               <object class="GtkScale">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
+                                <property name="tooltip_text" translatable="yes">Choose an effect rate for the LED</property>
                                 <property name="adjustment">adjustment_effect_rate</property>
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
@@ -202,6 +205,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="receives_default">True</property>
+                        <property name="tooltip_text" translatable="yes">Choose a color for the LED</property>
                         <property name="halign">end</property>
                         <property name="valign">center</property>
                         <property name="title" translatable="yes">Pick a Color for the LED</property>
@@ -249,6 +253,7 @@
                           <object class="GtkScale">
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
+                            <property name="tooltip_text" translatable="yes">Choose a brightness for the LED</property>
                             <property name="adjustment">adjustment_brightness</property>
                             <property name="digits">0</property>
                             <property name="draw_value">False</property>
@@ -292,6 +297,7 @@
                               <object class="GtkScale">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
+                                <property name="tooltip_text" translatable="yes">Choose an effect rate for the LED</property>
                                 <property name="adjustment">adjustment_effect_rate</property>
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
@@ -405,6 +411,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Ignore any changes made</property>
           </object>
         </child>
         <child type="title">
@@ -421,6 +428,7 @@
             <property name="can_focus">True</property>
             <property name="can_default">True</property>
             <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Apply any changes made</property>
             <style>
               <class name="suggested-action"/>
             </style>

--- a/data/ui/OptionButton.ui
+++ b/data/ui/OptionButton.ui
@@ -6,6 +6,7 @@
     <property name="visible">True</property>
     <property name="can_focus">True</property>
     <property name="receives_default">True</property>
+    <property name="tooltip_text" translatable="yes">Open the configuration dialog</property>
     <child>
       <object class="GtkBox">
         <property name="visible">True</property>

--- a/data/ui/ResolutionRow.ui
+++ b/data/ui/ResolutionRow.ui
@@ -48,6 +48,7 @@
               <object class="GtkButton" id="delete_button">
                 <property name="can_focus">False</property>
                 <property name="receives_default">False</property>
+                <property name="tooltip_text" translatable="yes">Remove this resolution from the profile</property>
                 <property name="relief">none</property>
                 <signal name="clicked" handler="_on_delete_button_clicked" swapped="no"/>
                 <child>
@@ -97,6 +98,7 @@
                       <object class="GtkScale" id="scale">
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
+                        <property name="tooltip_text" translatable="yes">Set this resolution's DPI</property>
                         <property name="round_digits">0</property>
                         <property name="digits">0</property>
                         <property name="draw_value">False</property>

--- a/data/ui/ResolutionsPage.ui
+++ b/data/ui/ResolutionsPage.ui
@@ -57,6 +57,7 @@
                       <object class="GtkButtonBox">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="tooltip_text" translatable="yes">Change the profile's report rate</property>
                         <property name="homogeneous">True</property>
                         <property name="layout_style">expand</property>
                         <child>
@@ -170,6 +171,7 @@
                               <object class="GtkListBoxRow" id="add_resolution_row">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
+                                <property name="tooltip_text" translatable="yes">Add a new resolution to the profile</property>
                                 <child>
                                   <object class="GtkBox">
                                     <property name="visible">True</property>

--- a/data/ui/Window.ui
+++ b/data/ui/Window.ui
@@ -8,6 +8,20 @@
       <object class="GtkOverlay">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
+        <child>
+          <object class="GtkStack" id="stack">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="transition_duration">400</property>
+            <property name="transition_type">slide-left-right</property>
+            <child>
+              <placeholder/>
+            </child>
+          </object>
+          <packing>
+            <property name="index">-1</property>
+          </packing>
+        </child>
         <child type="overlay">
           <object class="GtkRevealer" id="notification_commit">
             <property name="visible">True</property>
@@ -77,20 +91,6 @@
               </object>
             </child>
           </object>
-        </child>
-        <child>
-          <object class="GtkStack" id="stack">
-            <property name="visible">True</property>
-            <property name="can_focus">False</property>
-            <property name="transition_duration">400</property>
-            <property name="transition_type">slide-left-right</property>
-            <child>
-              <placeholder/>
-            </child>
-          </object>
-          <packing>
-            <property name="index">-1</property>
-          </packing>
         </child>
       </object>
     </child>

--- a/data/ui/Window.ui
+++ b/data/ui/Window.ui
@@ -111,6 +111,7 @@
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="receives_default">True</property>
+            <property name="tooltip_text" translatable="yes">Commit the changes to the device</property>
             <signal name="clicked" handler="_on_save_button_clicked" swapped="no"/>
             <child>
               <object class="GtkImage">


### PR DESCRIPTION
Every control widget should have a tooltip to explain its purpose.

Fixes #40