### PR TITLE
Add a piper.devel output to run from source tree

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,3 @@
 [flake8]
 ignore = E402,E501
-exclude = .git,__pycache__,build,data,piper/piper.py
+exclude = .git,__pycache__,build,data,piper/piper.py,piper.in

--- a/circle.yml
+++ b/circle.yml
@@ -9,7 +9,7 @@ jobs:
           command: |
             dnf install -y git python3-flake8
       - checkout
-      - run: flake8-3 . piper.in
+      - run: flake8-3 .
 
       # now install and checks the resulting file (just in case)
       - run:
@@ -19,6 +19,6 @@ jobs:
           command: |
             meson build
             ninja -C build
-      - run: flake8-3 buildir/piper
+      - run: flake8-3 buil/piper buil/piper.devel
       - store_artifacts:
           path: ~/piper/build/meson-logs

--- a/meson.build
+++ b/meson.build
@@ -24,13 +24,25 @@ if not python_dir.endswith('site-packages')
 endif
 install_subdir('piper', install_dir: python_dir)
 
-conf = configuration_data()
-conf.set('pkgdatadir', pkgdatadir)
-conf.set('localedir', localedir)
+config_piper = configuration_data()
+config_piper.set('pkgdatadir', pkgdatadir)
+config_piper.set('localedir', localedir)
 
 configure_file(input: 'piper.in',
 	       output: 'piper',
-	       configuration: conf,
+	       configuration: config_piper,
 	       install_dir: 'bin')
+
+config_piper_devel = configuration_data()
+config_piper_devel.set('pkgdatadir', join_paths(meson.build_root(), 'data'))
+config_piper_devel.set('localedir', join_paths(meson.build_root(), 'po'))
+config_piper_devel.set('devel', '
+sys.path.insert(1, \'@0@\')
+print(\'Running from source tree, using local files\')
+'.format(meson.source_root()))
+
+configure_file(input: 'piper.in',
+	       output: 'piper.devel',
+	       configuration: config_piper_devel)
 
 meson.add_install_script('meson_install.sh')

--- a/piper.in
+++ b/piper.in
@@ -7,22 +7,14 @@ import os
 import signal
 import sys
 
-import piper
-from piper.application import Application
-
 gi.require_version('Gio', '2.0')
 gi.require_version('Gtk', '3.0')
 from gi.repository import Gio, Gtk
 
-localedir = '@localedir@'
-srcdir = os.path.abspath(os.path.join(os.path.dirname(piper.__file__), '..'))
-if os.path.exists(os.path.join(srcdir, 'meson.build')):
-    print('Running from source tree, using local files')
-    pkgdatadir = os.path.join(srcdir, 'data')
-    if not os.environ.get('GSETTINGS_SCHEMA_DIR'):
-        os.environ['GSETTINGS_SCHEMA_DIR'] = pkgdatadir
-else:
-    pkgdatadir = '@pkgdatadir@'
+@devel@
+
+# Must come after development code injection.
+from piper.application import Application
 
 
 def install_excepthook():
@@ -40,12 +32,12 @@ def install_excepthook():
 if __name__ == "__main__":
     install_excepthook()
 
-    locale.bindtextdomain('piper', localedir)
+    locale.bindtextdomain('piper', '@localedir@')
     locale.textdomain('piper')
-    gettext.bindtextdomain('piper', localedir)
+    gettext.bindtextdomain('piper', '@localedir@')
     gettext.textdomain('piper')
 
-    resource = Gio.resource_load(os.path.join(pkgdatadir, 'piper.gresource'))
+    resource = Gio.resource_load(os.path.join('@pkgdatadir@', 'piper.gresource'))
     Gio.Resource._register(resource)
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)


### PR DESCRIPTION
Fixes #50, by adding a `piper.devel` output next to the regular `piper` output. The regular `piper` output now doesn't have any debug or development code whatsoever, and the `piper.devel` output has two lines of code that 1) fix the Python path to import from the source directory and 2) print to the user that they're running from source.

I went for the approach that adds / moves around the least amount of files. It might be a bit abusive of Meson but I think overall the approach is quite minimal and the achieved effect is nice.