### PR TITLE
Window: do not crash when no devices are plugged in

### DIFF
--- a/piper/window.py
+++ b/piper/window.py
@@ -52,6 +52,9 @@ class Window(Gtk.ApplicationWindow):
 
         self._ratbag = ratbag
         self._device = self._fetch_ratbag_device()
+        if self._device is None:
+            self._present_error_dialog("No devices found")
+            return
 
         try:
             capabilities = self._device.capabilities


### PR DESCRIPTION
This code will definitely be changed (read: improved) once I tackle the welcome screen. For now, just print another string to `stderr` and bail.

Fixes #65.