### PR TITLE
Application: change aboutDialog.ui resource path to AboutDialog.ui

### DIFF
--- a/piper/application.py
+++ b/piper/application.py
@@ -63,7 +63,7 @@ class Application(Gtk.Application):
 
     def _about(self, action, param):
         # Set up the about dialog.
-        builder = Gtk.Builder().new_from_resource("/org/freedesktop/Piper/aboutDialog.ui")
+        builder = Gtk.Builder().new_from_resource("/org/freedesktop/Piper/AboutDialog.ui")
         about = builder.get_object("about_dialog")
         about.set_transient_for(self.get_active_window())
         about.show()


### PR DESCRIPTION
The current about dialog is named `AboutDialog.ui` but is linked as `/org/freedesktop/Piper/aboutDialog.ui` in `src/application.py`. Which throws:
```
(piper.devel:6977): Gtk-ERROR **: failed to add UI: The resource at “/org/freedesktop/Piper/aboutDialog.ui” does not exist
```

This pr fixes that.