### PR TITLE
ResolutionsPage: reduce width of the controls

### DIFF
--- a/data/ui/ResolutionsPage.ui
+++ b/data/ui/ResolutionsPage.ui
@@ -10,7 +10,7 @@
     </child>
     <child>
       <object class="GtkBox">
-        <property name="width_request">400</property>
+        <property name="width_request">300</property>
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="border_width">20</property>


### PR DESCRIPTION
As mentioned in #91. I think this is the smallest we can make it while it still looks OK.