### PR TITLE
React to devices being added or removed

### DIFF
--- a/piper/application.py
+++ b/piper/application.py
@@ -50,7 +50,6 @@ class Application(Gtk.Application):
         """This function is called when the user requests a new window to be
         opened."""
         window = Window(self._ratbag, application=self)
-        window.show_all()
         window.present()
 
     def _build_app_menu(self):

--- a/piper/errorperspective.py
+++ b/piper/errorperspective.py
@@ -51,6 +51,12 @@ class ErrorPerspective(Gtk.Box):
         """The titlebar to this perspective."""
         return self._titlebar
 
+    @GObject.Property
+    def can_go_back(self):
+        """Whether this perspective wants a back button to be displayed in case
+        there is more than one connected device."""
+        return False
+
     def set_message(self, message):
         """Sets the error message.
 

--- a/piper/mousemap.py
+++ b/piper/mousemap.py
@@ -177,9 +177,13 @@ class MouseMap(Gtk.Container):
         @param parameters The parameters to pass to the callback, as object or
                           None.
         """
-        if callback is not None:
-            for child in self._children:
-                callback(child.widget, *parameters)
+        try:
+            if callback is not None:
+                for child in self._children:
+                    callback(child.widget, *parameters)
+        except AttributeError:
+            # See https://bugzilla.gnome.org/show_bug.cgi?id=722562.
+            pass
 
     def do_get_request_mode(self):
         """Gets whether the container prefers a height-for-width or a

--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -60,6 +60,12 @@ class MousePerspective(Gtk.Overlay):
         return self._titlebar
 
     @GObject.Property
+    def can_go_back(self):
+        """Whether this perspective wants a back button to be displayed in case
+        there is more than one connected device."""
+        return True
+
+    @GObject.Property
     def device(self):
         return self._device
 

--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -59,7 +59,12 @@ class MousePerspective(Gtk.Overlay):
         """The titlebar to this perspective."""
         return self._titlebar
 
-    def set_device(self, device):
+    @GObject.Property
+    def device(self):
+        return self._device
+
+    @device.setter
+    def device(self, device):
         self._device = device
         capabilities = device.capabilities
 

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -218,6 +218,13 @@ class Ratbagd(_RatbagdDBus):
     Throws RatbagdDBusUnavailable when the DBus service is not available.
     """
 
+    __gsignals__ = {
+        "device-added":
+            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+        "device-removed":
+            (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+    }
+
     def __init__(self):
         _RatbagdDBus.__init__(self, "Manager", None)
         result = self._get_dbus_property("Devices")
@@ -228,9 +235,12 @@ class Ratbagd(_RatbagdDBus):
             for prop in changed_props["Devices"]:
                 index = self._find_object_with_path(self._devices, prop)
                 if index >= 0:
-                    del self._devices[index]
+                    device = self._devices.pop(index)
+                    self.emit("device-removed", device)
                 else:
-                    self._devices.append(RatbagdDevice(prop))
+                    device = RatbagdDevice(prop)
+                    self._devices.append(device)
+                    self.emit("device-added", device)
 
     @GObject.Property
     def devices(self):

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -232,15 +232,16 @@ class Ratbagd(_RatbagdDBus):
 
     def _on_properties_changed(self, proxy, changed_props, invalidated_props):
         if "Devices" in changed_props.keys():
-            for prop in changed_props["Devices"]:
-                index = self._find_object_with_path(self._devices, prop)
-                if index >= 0:
-                    device = self._devices.pop(index)
-                    self.emit("device-removed", device)
-                else:
-                    device = RatbagdDevice(prop)
+            object_paths = [d._object_path for d in self._devices]
+            for object_path in changed_props["Devices"]:
+                if object_path not in object_paths:
+                    device = RatbagdDevice(object_path)
                     self._devices.append(device)
                     self.emit("device-added", device)
+            for device in self.devices:
+                if device._object_path not in changed_props["Devices"]:
+                    self._devices.remove(device)
+                    self.emit("device-removed", device)
 
     @GObject.Property
     def devices(self):

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -242,6 +242,7 @@ class Ratbagd(_RatbagdDBus):
                 if device._object_path not in changed_props["Devices"]:
                     self._devices.remove(device)
                     self.emit("device-removed", device)
+            self.notify("devices")
 
     @GObject.Property
     def devices(self):

--- a/piper/welcomeperspective.py
+++ b/piper/welcomeperspective.py
@@ -79,6 +79,12 @@ class WelcomePerspective(Gtk.Box):
         """The titlebar to this perspective."""
         return self._titlebar
 
+    @GObject.Property
+    def can_go_back(self):
+        """Whether this perspective wants a back button to be displayed in case
+        there is more than one connected device."""
+        return False
+
     @GtkTemplate.Callback
     def _on_quit_button_clicked(self, button):
         window = button.get_toplevel()

--- a/piper/welcomeperspective.py
+++ b/piper/welcomeperspective.py
@@ -50,7 +50,24 @@ class WelcomePerspective(Gtk.Box):
         """
         self.listbox.foreach(Gtk.Widget.destroy)
         for device in devices:
-            self.listbox.add(DeviceRow(device))
+            self.add_device(device)
+
+    def add_device(self, device):
+        """Add a device to the list.
+
+        @param device The device to add, as ratbagd.RatbagdDevice
+        """
+        self.listbox.add(DeviceRow(device))
+
+    def remove_device(self, device):
+        """Remove a device from the list.
+
+        @param device The device to remove, as ratbagd.RatbagdDevice
+        """
+        for child in self.listbox.get_children():
+            if child._device is device:
+                child.destroy()
+                break
 
     @GObject.Property
     def name(self):

--- a/piper/window.py
+++ b/piper/window.py
@@ -79,7 +79,7 @@ class Window(Gtk.ApplicationWindow):
         # Present the mouse configuration perspective for the given device.
         try:
             mouse_perspective = self.stack_perspectives.get_child_by_name("mouse_perspective")
-            mouse_perspective.set_device(device)
+            mouse_perspective.device = device
 
             self.stack_titlebar.set_visible_child_name(mouse_perspective.name)
             self.stack_perspectives.set_visible_child_name(mouse_perspective.name)

--- a/piper/window.py
+++ b/piper/window.py
@@ -56,7 +56,7 @@ class Window(Gtk.ApplicationWindow):
                                             _("Please make sure it is running"))
         elif len(ratbag.devices) == 0:
             self._present_error_perspective(_("Cannot find any devices"),
-                                            _("Please make sure it is supported and plugged in"))
+                                            _("Please make sure your device is supported and plugged in"))
         elif len(ratbag.devices) == 1:
             self._present_mouse_perspective(ratbag.devices[0])
         else:


### PR DESCRIPTION
This should go after #84.

Maybe we can show an [empty placeholder](https://developer.gnome.org/gtk3/stable/GtkListBox.html#gtk-list-box-set-placeholder) in the welcome perspective's listbox when there are no devices, instead of displaying the error perspective. This would look something like the empty search result in GNOME Control Center's keyboard panel:

![screenshot from 2017-08-08 17-38-45](https://user-images.githubusercontent.com/1260727/29080597-74210dc4-7c60-11e7-9fc8-314c47483bb6.png)

Right now, Piper does the following:

Device added:
* No device connected currently → immediately configure the connected device
* Devices currently connected, in welcome perspective → add the new device to the list
* Device(s) currently connected, in mouse perspective → make the back button visible (will be added in this PR, currently not there), possibly an in-app notification if we want it

Device removed:
* Removed device is the one currently being edited → error perspective
* Device(s) currently connected, in welcome perspective → remove it from the list. If it was the last device, display the error perspective
* Devices currently connected, configuring another in the mouse perspective → hide the back button if required (will be added in this PR, currently not there), possibly an in-app notification if we want it

Of course you can mix and match these, for example if you are configuring a device, disconnect it and then connect it again you'll jump straight back into editing it. Please let me know if there's a scenario that I missed!

Also, I think that the Window class is getting quite messy. I'd like to clean it up a bit and get some more structure in there, but I'll see what I can do given the time frame and other, more important issues.
