### PR TITLE
Make the commit button more obvious

### DIFF
--- a/data/ui/MousePerspective.ui
+++ b/data/ui/MousePerspective.ui
@@ -120,7 +120,7 @@
       </object>
     </child>
     <child>
-      <object class="GtkButton">
+      <object class="GtkButton" id="button_commit">
         <property name="visible">True</property>
         <property name="can_focus">True</property>
         <property name="receives_default">True</property>

--- a/data/ui/ResolutionRow.ui
+++ b/data/ui/ResolutionRow.ui
@@ -89,7 +89,6 @@
                         <property name="value_pos">bottom</property>
                         <signal name="change-value" handler="_on_change_value" swapped="no"/>
                         <signal name="scroll-event" handler="_on_scroll_event" swapped="no"/>
-                        <signal name="value-changed" handler="_on_value_changed" swapped="no"/>
                       </object>
                     </child>
                   </object>

--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -40,6 +40,7 @@ class MousePerspective(Gtk.Overlay):
     listbox_profiles = GtkTemplate.Child()
     label_profile = GtkTemplate.Child()
     add_profile_button = GtkTemplate.Child()
+    button_commit = GtkTemplate.Child()
 
     def __init__(self, *args, **kwargs):
         """Instantiates a new MousePerspective."""
@@ -80,6 +81,7 @@ class MousePerspective(Gtk.Overlay):
 
         for profile in device.profiles:
             profile.connect("notify::enabled", self._on_profile_notify_enabled)
+            profile.connect("notify::dirty", self._on_profile_notify_dirty)
             row = ProfileRow(profile)
             self.listbox_profiles.insert(row, profile.index)
             if profile == active_profile:
@@ -132,3 +134,13 @@ class MousePerspective(Gtk.Overlay):
         # so that we can reset the sensitivity of the add button.
         if not profile.enabled and profile == self._device.profiles[-1]:
             self.add_profile_button.set_sensitive(True)
+
+    def _on_profile_notify_dirty(self, profile, pspec):
+        style_context = self.button_commit.get_style_context()
+        if profile.dirty and not style_context.has_class("suggested-action"):
+            style_context.add_class("suggested-action")
+        else:
+            # There is no way to make a single profile non-dirty, so this works
+            # for now. Ideally, this should however check if there are any other
+            # profiles on the device that are dirty.
+            style_context.remove_class("suggested-action")

--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -73,6 +73,7 @@ class MousePerspective(Gtk.Overlay):
 
         active_profile = device.active_profile
         self.label_profile.set_label(_("Profile {}").format(active_profile.index + 1))
+        self.button_commit.set_sensitive(active_profile.dirty)
 
         # Find the first profile that is enabled. If there is none, disable the
         # add button.
@@ -139,8 +140,10 @@ class MousePerspective(Gtk.Overlay):
         style_context = self.button_commit.get_style_context()
         if profile.dirty and not style_context.has_class("suggested-action"):
             style_context.add_class("suggested-action")
+            self.button_commit.set_sensitive(True)
         else:
             # There is no way to make a single profile non-dirty, so this works
             # for now. Ideally, this should however check if there are any other
             # profiles on the device that are dirty.
             style_context.remove_class("suggested-action")
+            self.button_commit.set_sensitive(False)


### PR DESCRIPTION
This PR implements some of @hadess' suggestions from #69. I think that timeout-based commit is something we should look into and is perhaps something for a future version of Piper, but for now as a stop-gap sort of thing I went with these suggestions:

1. Disable the button when nothing has been changed
2. Make the button blue like the default button in dialogues ('suggested-action' style IIRC) when something has been changed

As for the icon, personally I'm not confused by it but if you feel that others might I'm open to switching it for something else. Perhaps we can make a custom save icon, that replaces the disk with a mouse? In any case, I much prefer an icon over text so I'd rather do that as a last resort.

The other suggestions about asking users about unsaved changes before exiting are not related to the button per sé so I'll open separate issues for those, because I do like them and want to implement them.

As for activity indicators, I think that all our operations are fast enough not to require those, but that might be my device only? In any case, this would also be something for the future. Feel free to open an issue for this yourself.

@hadess if you're reading this, I'd appreciate your comments on these changes!