### PR TITLE
MousePerspective: change button icon to text

### DIFF
--- a/data/ui/MousePerspective.ui
+++ b/data/ui/MousePerspective.ui
@@ -127,10 +127,10 @@
         <property name="tooltip_text" translatable="yes">Commit the changes to the device</property>
         <signal name="clicked" handler="_on_save_button_clicked" swapped="no"/>
         <child>
-          <object class="GtkImage">
+          <object class="GtkLabel">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="icon_name">document-save-symbolic</property>
+            <property name="label" translatable="yes">Apply</property>
           </object>
         </child>
       </object>


### PR DESCRIPTION
Fixes #69.

@hadess [is right](https://github.com/libratbag/piper/issues/69#issuecomment-321776046).