### PR TITLE
Ask for confirmation when quitting with unsaved changes

### DIFF
--- a/piper/errorperspective.py
+++ b/piper/errorperspective.py
@@ -57,6 +57,11 @@ class ErrorPerspective(Gtk.Box):
         there is more than one connected device."""
         return False
 
+    @GObject.Property
+    def can_shutdown(self):
+        """Whether this perspective can safely shutdown."""
+        return True
+
     def set_message(self, message):
         """Sets the error message.
 

--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -66,6 +66,14 @@ class MousePerspective(Gtk.Overlay):
         return True
 
     @GObject.Property
+    def can_shutdown(self):
+        """Whether this perspective can safely shutdown."""
+        for profile in self._device.profiles:
+            if profile.dirty:
+                return False
+        return True
+
+    @GObject.Property
     def device(self):
         return self._device
 

--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -84,7 +84,7 @@ class MousePerspective(Gtk.Overlay):
 
         active_profile = device.active_profile
         self.label_profile.set_label(_("Profile {}").format(active_profile.index + 1))
-        self.button_commit.set_sensitive(active_profile.dirty)
+        self._on_profile_notify_dirty(active_profile, None)
 
         # Find the first profile that is enabled. If there is none, disable the
         # add button.

--- a/piper/welcomeperspective.py
+++ b/piper/welcomeperspective.py
@@ -85,6 +85,11 @@ class WelcomePerspective(Gtk.Box):
         there is more than one connected device."""
         return False
 
+    @GObject.Property
+    def can_shutdown(self):
+        """Whether this perspective can safely shutdown."""
+        return True
+
     @GtkTemplate.Callback
     def _on_quit_button_clicked(self, button):
         window = button.get_toplevel()

--- a/piper/window.py
+++ b/piper/window.py
@@ -23,7 +23,7 @@ from .welcomeperspective import WelcomePerspective
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import GLib, Gtk
+from gi.repository import Gdk, GLib, Gtk
 
 
 @GtkTemplate(ui="/org/freedesktop/Piper/ui/Window.ui")
@@ -66,6 +66,20 @@ class Window(Gtk.ApplicationWindow):
             self._present_mouse_perspective(ratbag.devices[0])
         else:
             self._present_welcome_perspective(ratbag.devices)
+
+    def do_delete_event(self, event):
+        for perspective in self.stack_perspectives.get_children():
+            if not perspective.can_shutdown:
+                dialog = Gtk.MessageDialog(self, Gtk.DialogFlags.MODAL,
+                                           Gtk.MessageType.QUESTION,
+                                           Gtk.ButtonsType.YES_NO,
+                                           _("There are unapplied changes. Are you sure you want to quit?"))
+                response = dialog.run()
+                dialog.destroy()
+
+                if response == Gtk.ResponseType.NO or response == Gtk.ResponseType.DELETE_EVENT:
+                    return Gdk.EVENT_STOP
+        return Gdk.EVENT_PROPAGATE
 
     def _on_device_added(self, ratbag, device):
         if len(ratbag.devices) == 1:


### PR DESCRIPTION
This adds another property to the perspectives, which signals whether a perspective can safely shutdown. On a delete event, the Window checks all its perspectives' properties and if one perspective signals that it cannot safely shutdown, a dialog is presented that allows the user to either shutdown ignoring any changes or to abort and commit or make other changes.

Fixes #102.