### PR TITLE
ButtonDialog: only allow swapping left- and right buttons

### DIFF
--- a/data/ui/ButtonDialog.ui
+++ b/data/ui/ButtonDialog.ui
@@ -69,7 +69,7 @@
                                 <property name="width_request">100</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="tooltip_text" translatable="yes">Add a new resolution to the profile</property>
+                                <property name="tooltip_text" translatable="yes">Capture a macro for this button</property>
                                 <child>
                                   <object class="GtkBox">
                                     <property name="visible">True</property>

--- a/data/ui/ButtonDialog.ui
+++ b/data/ui/ButtonDialog.ui
@@ -106,6 +106,7 @@
                                         <property name="can_focus">False</property>
                                         <property name="halign">start</property>
                                         <property name="label" translatable="yes">Send keystroke</property>
+                                        <property name="track_visited_links">False</property>
                                       </object>
                                       <packing>
                                         <property name="expand">False</property>

--- a/data/ui/ButtonDialog.ui
+++ b/data/ui/ButtonDialog.ui
@@ -47,7 +47,7 @@
                 <property name="orientation">vertical</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkScrolledWindow">
+                  <object class="GtkScrolledWindow" id="button_mappings">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="shadow_type">in</property>
@@ -129,7 +129,137 @@
                   </packing>
                 </child>
                 <child>
-                  <placeholder/>
+                  <object class="GtkScrolledWindow" id="swap_primaries">
+                    <property name="can_focus">True</property>
+                    <property name="shadow_type">in</property>
+                    <property name="max_content_height">300</property>
+                    <property name="propagate_natural_width">True</property>
+                    <property name="propagate_natural_height">True</property>
+                    <child>
+                      <object class="GtkViewport">
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkListBox">
+                            <property name="width_request">250</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="selection_mode">none</property>
+                            <child>
+                              <object class="GtkListBoxRow">
+                                <property name="width_request">100</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <child>
+                                  <object class="GtkGrid">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="margin_start">12</property>
+                                    <property name="margin_end">6</property>
+                                    <property name="margin_top">6</property>
+                                    <property name="margin_bottom">6</property>
+                                    <property name="column_spacing">16</property>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="hexpand">True</property>
+                                        <property name="label" translatable="yes">Swap primary mouse buttons</property>
+                                        <property name="track_visited_links">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="halign">start</property>
+                                        <property name="label" translatable="yes">Swaps the physical left- and right mouse buttons.</property>
+                                        <property name="single_line_mode">True</property>
+                                        <property name="max_width_chars">20</property>
+                                        <attributes>
+                                          <attribute name="scale" value="0.90000000000000002"/>
+                                        </attributes>
+                                        <style>
+                                          <class name="dim-label"/>
+                                        </style>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">0</property>
+                                        <property name="top_attach">1</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButtonBox">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="homogeneous">True</property>
+                                        <property name="layout_style">expand</property>
+                                        <child>
+                                          <object class="GtkRadioButton" id="radio_left_handed">
+                                            <property name="label" translatable="yes">Left Handed</property>
+                                            <property name="height_request">35</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="draw_indicator">False</property>
+                                            <property name="tooltip_text" translatable="yes">The left mouse button generates a left mouse click</property>
+                                            <signal name="toggled" handler="_on_primary_mode_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkRadioButton" id="radio_right_handed">
+                                            <property name="label" translatable="yes">Right Handed</property>
+                                            <property name="height_request">35</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="hexpand">True</property>
+                                            <property name="draw_indicator">False</property>
+                                            <property name="group">radio_left_handed</property>
+                                            <property name="tooltip_text" translatable="yes">The left mouse button generates a right mouse click</property>
+                                            <signal name="toggled" handler="_on_primary_mode_toggled" swapped="no"/>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">True</property>
+                                            <property name="fill">True</property>
+                                            <property name="position">1</property>
+                                          </packing>
+                                        </child>
+                                        <style>
+                                          <class name="linked"/>
+                                        </style>
+                                      </object>
+                                      <packing>
+                                        <property name="left_attach">1</property>
+                                        <property name="top_attach">0</property>
+                                        <property name="height">2</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                        </child>
+                      </object>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
                 </child>
               </object>
               <packing>

--- a/piper/buttonspage.py
+++ b/piper/buttonspage.py
@@ -105,7 +105,19 @@ class ButtonsPage(Gtk.Box):
         # changes before closing the dialog, otherwise just close the dialog.
         if response == Gtk.ResponseType.APPLY:
             if dialog.action_type == RatbagdButton.ACTION_TYPE_BUTTON:
-                ratbagd_button.mapping = dialog.mapping
+                if dialog.mapping in [ButtonDialog.LEFT_HANDED_MODE, ButtonDialog.RIGHT_HANDED_MODE]:
+                    left = self._find_button_type(0)
+                    right = self._find_button_type(1)
+                    if left is None or right is None:
+                        return
+                    # Mappings are 1-indexed, so 1 is left mouse click and 2 is
+                    # right mouse click.
+                    if dialog.mapping == ButtonDialog.LEFT_HANDED_MODE:
+                        left.mapping, right.mapping = 2, 1
+                    elif dialog.mapping == ButtonDialog.RIGHT_HANDED_MODE:
+                        left.mapping, right.mapping = 1, 2
+                else:
+                    ratbagd_button.mapping = dialog.mapping
             elif dialog.action_type == RatbagdButton.ACTION_TYPE_MACRO:
                 ratbagd_button.macro = dialog.mapping
             elif dialog.action_type == RatbagdButton.ACTION_TYPE_SPECIAL:
@@ -125,3 +137,11 @@ class ButtonsPage(Gtk.Box):
         for profile in self._device.profiles:
             if profile.is_active:
                 return profile
+
+    def _find_button_type(self, button_type):
+        # TODO: make this use RatbagdButton.Type once
+        # https://github.com/libratbag/libratbag/issues/233 is fixed.
+        for button in self._profile.buttons:
+            if button.index == button_type:
+                return button
+        return None


### PR DESCRIPTION
Another take for #82; where we only allow swapping the left- and right mouse button. Until https://github.com/libratbag/libratbag/issues/233 is fixed I'm using the buttons' indices to detect whether a button is left or right (with approval from @whot).