### PR TITLE
RatbagdButton: add ACTION_SPECIAL_UNKNOWN to SPECIAL_DESCRIPTION

### DIFF
--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -594,6 +594,7 @@ class RatbagdButton(_RatbagdDBus):
 
     """A table mapping a special function to its human-readable description."""
     SPECIAL_DESCRIPTION = {
+        ACTION_SPECIAL_UNKNOWN: _("Unknown"),
         ACTION_SPECIAL_DOUBLECLICK: _("Doubleclick"),
         ACTION_SPECIAL_WHEEL_LEFT: _("Wheel Left"),
         ACTION_SPECIAL_WHEEL_RIGHT: _("Wheel Right"),


### PR DESCRIPTION
This prevents crashing when a device reports an unknown special action
type to libratbag, see e.g. #120.