### PR TITLE
Do not crash if there is no active profile or resolution

### DIFF
--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -104,7 +104,7 @@ class MousePerspective(Gtk.Overlay):
             profile.connect("notify::dirty", self._on_profile_notify_dirty)
             row = ProfileRow(profile)
             self.listbox_profiles.insert(row, profile.index)
-            if profile == active_profile:
+            if profile is active_profile:
                 self.listbox_profiles.select_row(row)
         self.show_all()
 

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -318,10 +318,14 @@ class RatbagdDevice(_RatbagdDBus):
     @GObject.Property
     def active_profile(self):
         """The currently active profile. This is a non-DBus property computed
-        over the cached list of profiles."""
+        over the cached list of profiles. In the unlikely case that your device
+        driver is misconfigured and there is no active profile, this returns
+        the first profile."""
         for profile in self._profiles:
             if profile.is_active:
                 return profile
+        print("No active profile. Please report this bug to the libratbag developers", file=sys.stderr)
+        return self._profiles[0]
 
     def get_svg(self, theme):
         """Gets the full path to the SVG for the given theme, or the empty
@@ -406,10 +410,14 @@ class RatbagdProfile(_RatbagdDBus):
     @GObject.Property
     def active_resolution(self):
         """The currently active resolution of this profile. This is a non-DBus
-        property computed over the cached list of resolutions."""
+        property computed over the cached list of resolutions. In the unlikely
+        case that your device driver is misconfigured and there is no active
+        resolution, this returns the first resolution."""
         for resolution in self._resolutions:
             if resolution.is_active:
                 return resolution
+        print("No active resolution. Please report this bug to the libratbag developers", file=sys.stderr)
+        return self._resolutions[0]
 
     @GObject.Property
     def buttons(self):


### PR DESCRIPTION
See #120.

I'm not entirely sure about this, because basically we're working around broken device drivers here. If the driver is broken, it doesn't make much sense to try and continue. Maybe instead I should add a check for an active profile and resolution when the MousePerspective is being opened, and bail from there only. Or, we let things as-is and make sure our drivers work.