### PR TITLE
Correctly display the error perspective if the MouseMap cannot display itself

### DIFF
--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -77,8 +77,7 @@ class MousePerspective(Gtk.Overlay):
     def device(self):
         return self._device
 
-    @device.setter
-    def device(self, device):
+    def set_device(self, device):
         self._device = device
         capabilities = device.capabilities
 

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -473,8 +473,7 @@ class RatbagdResolution(_RatbagdDBus):
 
         @param res The new resolution, as (int, int)
         """
-        ret = self._set_dbus_property("Resolution", "(uu)", res)
-        return ret
+        return self._set_dbus_property("Resolution", "(uu)", res)
 
     @GObject.Property
     def report_rate(self):

--- a/piper/window.py
+++ b/piper/window.py
@@ -151,7 +151,7 @@ class Window(Gtk.ApplicationWindow):
             self.stack_titlebar.set_visible_child_name(mouse_perspective.name)
             self.stack_perspectives.set_visible_child_name(mouse_perspective.name)
         except ValueError as e:
-            self._present_error_perspective(_("Cannot display device SVG"), e)
+            self._present_error_perspective(_("Cannot display device SVG"), str(e))
         except GLib.Error as e:
             self._present_error_perspective(_("Unknown exception occurred"), e.message)
 

--- a/piper/window.py
+++ b/piper/window.py
@@ -146,7 +146,7 @@ class Window(Gtk.ApplicationWindow):
         # Present the mouse configuration perspective for the given device.
         try:
             mouse_perspective = self._get_child("mouse_perspective")
-            mouse_perspective.device = device
+            mouse_perspective.set_device(device)
 
             self.stack_titlebar.set_visible_child_name(mouse_perspective.name)
             self.stack_perspectives.set_visible_child_name(mouse_perspective.name)


### PR DESCRIPTION
As found here https://github.com/libratbag/piper/issues/115#issuecomment-322439908.