### PR TITLE
ResolutionRow: add label to highlight the active resolution

### DIFF
--- a/data/ui/ResolutionRow.ui
+++ b/data/ui/ResolutionRow.ui
@@ -58,6 +58,21 @@
                 <property name="position">1</property>
               </packing>
             </child>
+            <child>
+              <object class="GtkLabel" id="active_label">
+                <property name="can_focus">False</property>
+                <property name="halign">end</property>
+                <property name="label" translatable="yes">Active</property>
+                <property name="justify">right</property>
+                <property name="track_visited_links">False</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="pack_type">end</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">True</property>

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -455,6 +455,10 @@ class RatbagdResolution(_RatbagdDBus):
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Resolution", object_path)
 
+    def _on_properties_changed(self, proxy, changed_props, invalidated_props):
+        if "IsActive" in changed_props.keys():
+            self.notify("is-active")
+
     @GObject.Property
     def index(self):
         """The index of this resolution."""


### PR DESCRIPTION
The same approach should work for showing and setting the default resolution (see #36) so I'll look into fixing that too. Note that this depends on an incoming patch to ratbagd.