### PR TITLE
MouseMap: save & restore GtkStyleContext to prevent hogging the CPU

### DIFF
--- a/piper/mousemap.py
+++ b/piper/mousemap.py
@@ -112,6 +112,7 @@ class MouseMap(Gtk.Container):
 
         Gtk.Container.__init__(self, *args, **kwargs)
         self.set_has_window(False)
+        self.set_redraw_on_allocate(False)
 
         self.spacing = spacing
         self._layer = layer

--- a/piper/mousemap.py
+++ b/piper/mousemap.py
@@ -390,7 +390,10 @@ class MouseMap(Gtk.Container):
         # Draws the SVG into the Cairo context. If there is an element to be
         # highlighted, it will do as such in a separate surface which will be
         # used as a mask over the device surface.
-        color = self.get_style_context().get_color(Gtk.StateFlags.LINK)
+        style_context = self.get_style_context()
+        style_context.save()
+        color = style_context.get_color(Gtk.StateFlags.LINK)
+        style_context.restore()
         cr.set_source_rgba(color.red, color.green, color.blue, 0.5)
 
         self._handle.render_cairo_sub(cr, id="#Device")


### PR DESCRIPTION
Since Gtk 3.18 passing a state other than the current state isn't
recommended and can apparently lead to hogging the CPU due to triggering
a loop: requesting style context triggers pixel cache refresh, which triggers
do_draw, which requests the style context that triggers the pixel cache again,
et cetera.

For background, see https://bugzilla.gnome.org/show_bug.cgi?id=760462
and the linked blog post https://blogs.gnome.org/mclasen/2015/11/20/a-gtk-update/.
Note that the advice of using the gtk_render_* API doesn't work for the
MouseMap, so we have to use the suggested workaround.

Fixes #133.