### PR TITLE
MouseMap: redraw on allocate

### DIFF
--- a/piper/mousemap.py
+++ b/piper/mousemap.py
@@ -112,7 +112,6 @@ class MouseMap(Gtk.Container):
 
         Gtk.Container.__init__(self, *args, **kwargs)
         self.set_has_window(False)
-        self.set_redraw_on_allocate(False)
 
         self.spacing = spacing
         self._layer = layer


### PR DESCRIPTION
In a previous commit I added this optimization that prevents redrawing
the widget when it is reallocated: with the widget being centered,
enlarging the window does not require to redraw the widget.

However, I missed the case where the allocation actually gets smaller
(and thus the SVG is repositioned) when the width of one of the child
widgets changes, which would with this optimization result in parts of
the SVG being shifted a few pixels to the left with the remainder being
in its original position. Hence, this fixes a visual glitch in drawing
the SVG.