### PR TITLE
Emit `RatbagdProfile::notify::is-active` in all instances where the property is updated

### DIFF
--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -501,6 +501,7 @@ class RatbagdResolution(_RatbagdDBus):
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Resolution", object_path)
         self._active = self._get_dbus_property("IsActive")
+        self._default = self._get_dbus_property("IsDefault")
 
     def _on_properties_changed(self, proxy, changed_props, invalidated_props):
         if "IsActive" in changed_props.keys():
@@ -508,6 +509,11 @@ class RatbagdResolution(_RatbagdDBus):
             if active != self._active:
                 self._active = active
                 self.notify("is-active")
+        elif "IsDefault" in changed_props.keys():
+            default = changed_props["IsDefault"]
+            if default != self._default:
+                self._default = default
+                self.notify("is-default")
 
     @GObject.Property
     def index(self):
@@ -570,7 +576,7 @@ class RatbagdResolution(_RatbagdDBus):
     def is_default(self):
         """True if this is the currently default resolution, False
         otherwise"""
-        return self._get_dbus_property("IsDefault")
+        return self._default
 
     def set_default(self):
         """Set this resolution to be the default."""

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -500,10 +500,14 @@ class RatbagdResolution(_RatbagdDBus):
 
     def __init__(self, object_path):
         _RatbagdDBus.__init__(self, "Resolution", object_path)
+        self._active = self._get_dbus_property("IsActive")
 
     def _on_properties_changed(self, proxy, changed_props, invalidated_props):
         if "IsActive" in changed_props.keys():
-            self.notify("is-active")
+            active = changed_props["IsActive"]
+            if active != self._active:
+                self._active = active
+                self.notify("is-active")
 
     @GObject.Property
     def index(self):
@@ -560,7 +564,7 @@ class RatbagdResolution(_RatbagdDBus):
     def is_active(self):
         """True if this is the currently active resolution, False
         otherwise"""
-        return self._get_dbus_property("IsActive")
+        return self._active
 
     @GObject.Property
     def is_default(self):


### PR DESCRIPTION
This ensures that `RatbagdProfile::notify::is-active` is fired in all instances where the property is updated, and not just on our own `set_active` method. This fixes #167.

I also added "caching" for `RatbagdProfile::is-active`, `RatbagdResolution::is-active` and `RatbagdResolution::is-default` so that the signals are only emitted on those objects where the properties actually changed, as a stop-gap for the FIXMEs in libratbag ([1](https://github.com/libratbag/libratbag/blob/bb23f68d53a5da85c195def66ec103f086b9254b/ratbagd/ratbagd-profile.c#L271), [2](https://github.com/libratbag/libratbag/blob/bb23f68d53a5da85c195def66ec103f086b9254b/ratbagd/ratbagd-resolution.c#L85) and [3]( https://github.com/libratbag/libratbag/blob/bb23f68d53a5da85c195def66ec103f086b9254b/ratbagd/ratbagd-resolution.c#L118)).