### PR TITLE
ResolutionsPage: fix bad toggles of report rate

### DIFF
--- a/piper/resolutionspage.py
+++ b/piper/resolutionspage.py
@@ -99,6 +99,8 @@ class ResolutionsPage(Gtk.Box):
         # TODO: currently no devices expose CAP_INDIVIDUAL_REPORT_RATE, but if
         # so then we should check for this here and set it only on the relevant
         # resolution.
+        if not button.get_active():
+            return
         profile = self._device.active_profile
         for resolution in profile.resolutions:
             resolution.report_rate = rate


### PR DESCRIPTION
The radiobuttons for changing the report rate fires the 'toggled'
signal both when being set and unset. This caused the report rate
to flip when chaning the active profile.

Follow the advice in the GTK documentation and check if the button
is active in the callback function.