### PR TITLE
ResolutionsRow: snap to nearest allowed resolution value

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ README](https://github.com/libratbag/libratbag/blob/master/README.md#running-rat
 Screenshots
 ===========
 
-![resolution configuration screenshot](https://github.com/whot/piper/blob/wiki/screenshots/piper-resolutionpage.png)
+![resolution configuration screenshot](https://github.com/libratbag/piper/blob/wiki/screenshots/piper-resolutionpage.png)
 
-![button configuration screenshot](https://github.com/whot/piper/blob/wiki/screenshots/piper-buttonpage.png)
+![button configuration screenshot](https://github.com/libratbag/piper/blob/wiki/screenshots/piper-buttonpage.png)
 
-![LED configuration screenshot](https://github.com/whot/piper/blob/wiki/screenshots/piper-ledpage.png)
+![LED configuration screenshot](https://github.com/libratbag/piper/blob/wiki/screenshots/piper-ledpage.png)
 
 Installing Piper
 ================


### PR DESCRIPTION
libratbag now exports a list of permitted resolutions rather than a min/max
value (and a guesswork step increment on piper's side). Use that and snap the
resolution slider to the nearest value in that list.

See https://github.com/libratbag/libratbag/pull/393

Related to #186