### PR TITLE
Do not generate icon-cache when DESTDIR is set

### DIFF
--- a/meson_install.sh
+++ b/meson_install.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env sh
 
-# Update icon cache
-gtk-update-icon-cache -f -t ${DESTDIR}/${MESON_INSTALL_PREFIX}/share/icons/hicolor
+if [ -z $DESTDIR ]; then
+	PREFIX=${MESON_INSTALL_PREFIX:-/usr}
 
-# Install new schemas
-#glib-compile-schemas ${DESTDIR}/${MESON_INSTALL_PREFIX}/share/glib-2.0/schemas/
+    # Update icon cache
+    gtk-update-icon-cache -f -t $PREFIX/share/icons/hicolor
+
+    # Install new schemas
+    #glib-compile-schemas $PREFIX/share/glib-2.0/schemas/
+fi


### PR DESCRIPTION
This ensures that the icon cache will be generated when installed locally,
but will also make sure that we don't generate one when DESTDIR is set.
This helps with packaging, where packages should never provide the duplicate
"icon-theme.cache" file inside the package.

This is based around the meson build system implemented by @TingPing in
the gnome-twitch project.

Signed-off-by: Ikey Doherty <ikey@solus-project.com>