### PR TITLE
MouseMap: if the old highlight is None, don't try to redraw

### DIFF
--- a/piper/mousemap.py
+++ b/piper/mousemap.py
@@ -314,6 +314,10 @@ class MouseMap(Gtk.Container):
     def _on_leave(self, widget, event):
         # Restores the device SVG to its original state.
         old_highlight = self._highlight_element
+
+        if old_highlight is None:
+            return
+
         self._highlight_element = None
         self._redraw_svg_element(old_highlight)
 


### PR DESCRIPTION
When pressing a button and moving out of the button area with the button held
down, we get two leave events - once when actually leaving the button and once
more when the button press is released later. On the second call, the old
highlight is already None, causing a crash when we're trying to get SVG
information about it.

Fixes #185