### PR TITLE
LedDialog: use new effect duration in ms

### DIFF
--- a/data/ui/LedDialog.ui
+++ b/data/ui/LedDialog.ui
@@ -7,11 +7,11 @@
     <property name="step_increment">1</property>
     <property name="page_increment">10</property>
   </object>
-  <object class="GtkAdjustment" id="adjustment_effect_rate">
-    <property name="lower">100</property>
-    <property name="upper">20000</property>
-    <property name="step_increment">50</property>
-    <property name="page_increment">50</property>
+  <object class="GtkAdjustment" id="adjustment_effect_duration">
+    <property name="lower">0</property>
+    <property name="upper">10000</property>
+    <property name="step_increment">100</property>
+    <property name="page_increment">500</property>
   </object>
   <template class="LedDialog" parent="GtkDialog">
     <property name="width_request">400</property>
@@ -132,11 +132,12 @@
                               <object class="GtkScale">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="tooltip_text" translatable="yes">Choose an effect rate for the LED</property>
-                                <property name="adjustment">adjustment_effect_rate</property>
+                                <property name="tooltip_text" translatable="yes">Choose an effect duration for the LED</property>
+                                <property name="adjustment">adjustment_effect_duration</property>
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
                                 <property name="value_pos">right</property>
+                                <signal name="change-value" handler="_on_change_value" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">True</property>
@@ -149,7 +150,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Hz</property>
+                                <property name="label" translatable="yes">ms</property>
                                 <property name="justify">right</property>
                                 <property name="track_visited_links">False</property>
                                 <style>
@@ -171,7 +172,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Effect rate</property>
+                        <property name="label" translatable="yes">Effect duration</property>
                         <property name="track_visited_links">False</property>
                       </object>
                     </child>
@@ -297,11 +298,12 @@
                               <object class="GtkScale">
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="tooltip_text" translatable="yes">Choose an effect rate for the LED</property>
-                                <property name="adjustment">adjustment_effect_rate</property>
+                                <property name="tooltip_text" translatable="yes">Choose an effect duration for the LED</property>
+                                <property name="adjustment">adjustment_effect_duration</property>
                                 <property name="round_digits">0</property>
                                 <property name="digits">0</property>
                                 <property name="value_pos">right</property>
+                                <signal name="change-value" handler="_on_change_value" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">True</property>
@@ -314,7 +316,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="halign">end</property>
-                                <property name="label" translatable="yes">Hz</property>
+                                <property name="label" translatable="yes">ms</property>
                                 <property name="justify">right</property>
                                 <property name="track_visited_links">False</property>
                                 <style>
@@ -336,7 +338,7 @@
                       <object class="GtkLabel">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">Effect rate</property>
+                        <property name="label" translatable="yes">Effect duration</property>
                         <property name="track_visited_links">False</property>
                       </object>
                     </child>
@@ -363,7 +365,7 @@
                   <object class="GtkImage" id="led_off_image">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                     <property name="resource">/org/freedesktop/Piper/led-off.svg</property>
+                    <property name="resource">/org/freedesktop/Piper/led-off.svg</property>
                   </object>
                   <packing>
                     <property name="expand">True</property>

--- a/piper/leddialog.py
+++ b/piper/leddialog.py
@@ -33,7 +33,7 @@ class LedDialog(Gtk.Dialog):
     colorchooser = GtkTemplate.Child()
     colorbutton = GtkTemplate.Child()
     adjustment_brightness = GtkTemplate.Child()
-    adjustment_effect_rate = GtkTemplate.Child()
+    adjustment_effect_duration = GtkTemplate.Child()
     led_off_image = GtkTemplate.Child()
 
     def __init__(self, ratbagd_led, *args, **kwargs):
@@ -59,12 +59,20 @@ class LedDialog(Gtk.Dialog):
         self.colorchooser.set_rgba(rgba)
         self.colorbutton.set_rgba(rgba)
         self.adjustment_brightness.set_value(self._led.brightness)
-        self.adjustment_effect_rate.set_value(self._led.effect_rate)
+        self.adjustment_effect_duration.set_value(self._led.effect_duration)
 
         sp = Gtk.CssProvider()
         sp.load_from_data("* { background: #565854}".encode())
         Gtk.StyleContext.add_provider(self.led_off_image.get_style_context(),
                                       sp, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION)
+
+    @GtkTemplate.Callback
+    def _on_change_value(self, scale, scroll, value):
+        # Round the value resulting from a scroll event to the nearest multiple
+        # of 500. This is to work around the Gtk.Scale not snapping to its
+        # Gtk.Adjustment's step_increment.
+        scale.set_value(int(value - (value % 500)))
+        return True
 
     def _get_led_color_as_rgba(self):
         # Helper function to convert ratbagd's 0-255 color range to a Gdk.RGBA
@@ -90,5 +98,5 @@ class LedDialog(Gtk.Dialog):
         return self.adjustment_brightness.get_value()
 
     @GObject.Property
-    def effect_rate(self):
-        return self.adjustment_effect_rate.get_value()
+    def effect_duration(self):
+        return self.adjustment_effect_duration.get_value()

--- a/piper/ledspage.py
+++ b/piper/ledspage.py
@@ -87,5 +87,5 @@ class LedsPage(Gtk.Box):
             led.mode = dialog.mode
             led.color = dialog.color
             led.brightness = dialog.brightness
-            led.effect_rate = dialog.effect_rate
+            led.effect_duration = dialog.effect_duration
         dialog.destroy()

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -275,11 +275,24 @@ class Ratbagd(_RatbagdDBus):
         """A list of RatbagdDevice objects supported by ratbagd."""
         return self._devices
 
+    def __getitem__(self, id):
+        """Returns the requested device, or None."""
+        for d in self.devices:
+            if d.id == id:
+                return d
+        return None
+
     @GObject.Property
     def themes(self):
         """A list of theme names. The theme 'default' is guaranteed to be
         available."""
         return self._get_dbus_property("Themes")
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        pass
 
 
 class RatbagdDevice(_RatbagdDBus):
@@ -584,6 +597,11 @@ class RatbagdResolution(_RatbagdDBus):
     def resolutions(self):
         """The list of supported DPI values"""
         return self._get_dbus_property("Resolutions")
+
+    @GObject.Property
+    def report_rates(self):
+        """The list of supported report rates"""
+        return self._get_dbus_property("ReportRates")
 
     @GObject.Property
     def is_active(self):
@@ -926,8 +944,14 @@ class RatbagdLed(_RatbagdDBus):
         self._set_dbus_property("Mode", "u", mode)
 
     @GObject.Property
+    def modes(self):
+        """The supported modes as a list"""
+        return self._get_dbus_property("Modes")
+
+    @GObject.Property
     def type(self):
-        """An enum describing this led's type, one of RatbagdLed.TYPE_*."""
+        """An enum describing this led's type,
+        RatbagdLed.TYPE_LOGO or RatbagdLed.TYPE_SIDE."""
         return self._get_dbus_property("Type")
 
     @GObject.Property
@@ -950,17 +974,17 @@ class RatbagdLed(_RatbagdDBus):
         return self._get_dbus_property("ColorDepth")
 
     @GObject.Property
-    def effect_rate(self):
-        """The LED's effect rate in Hz, values range from 100 to 20000."""
-        return self._get_dbus_property("EffectRate")
+    def effect_duration(self):
+        """The LED's effect duration in ms, values range from 0 to 10000."""
+        return self._get_dbus_property("EffectDuration")
 
-    @effect_rate.setter
-    def effect_rate(self, effect_rate):
-        """Set the effect rate in Hz. Allowed values range from 100 to 20000.
+    @effect_duration.setter
+    def effect_duration(self, effect_duration):
+        """Set the effect duration in ms. Allowed values range from 0 to 10000.
 
-        @param effect_rate The new effect rate, as int
+        @param effect_duration The new effect duration, as int
         """
-        self._set_dbus_property("EffectRate", "u", effect_rate)
+        self._set_dbus_property("EffectDuration", "u", effect_duration)
 
     @GObject.Property
     def brightness(self):


### PR DESCRIPTION
libratbag/libratbag#422 introduced effect duration in ms for LEDs as opposed to effect rate in Hz, as was discussed in #175. This commit updates Piper's UI to reflect these changes.

Fixes #175.

NOTE: this depends on libratbag/libratbag#422 and should not be changed before 1) that PR is merged and 2) its changes to ratbagd.py have been synced back into Piper.