### PR TITLE
AboutDialog: hook up the response signal to the dialog's destroy()

### DIFF
--- a/piper/application.py
+++ b/piper/application.py
@@ -65,6 +65,7 @@ class Application(Gtk.Application):
         builder = Gtk.Builder().new_from_resource("/org/freedesktop/Piper/AboutDialog.ui")
         about = builder.get_object("about_dialog")
         about.set_transient_for(self.get_active_window())
+        about.connect('response', lambda about, param: about.destroy())
         about.show()
 
     def _quit(self, action, param):


### PR DESCRIPTION
Fixes #174 and #221.