### PR TITLE
WelcomePerspective: delete window on quit

### DIFF
--- a/piper/welcomeperspective.py
+++ b/piper/welcomeperspective.py
@@ -19,7 +19,7 @@ from .gi_composites import GtkTemplate
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import GObject, Gtk
+from gi.repository import GObject, Gtk, Gdk
 
 
 @GtkTemplate(ui="/org/freedesktop/Piper/ui/WelcomePerspective.ui")
@@ -93,7 +93,9 @@ class WelcomePerspective(Gtk.Box):
     @GtkTemplate.Callback
     def _on_quit_button_clicked(self, button):
         window = button.get_toplevel()
-        window.destroy()
+
+        if not window.emit("delete-event", Gdk.Event(Gdk.EventType.DELETE)):
+            window.destroy()
 
     @GtkTemplate.Callback
     def _on_device_row_activated(self, listbox, row):


### PR DESCRIPTION
When clicking the Quit button we should emit the delete
event to go through the checks for unapplied changes in
the delete handler on the window.

Before we had inconsisten behavior between pressing Quit
and closing Piper from e.g. gnome-shell.

The issue was discovered in #220