### PR TITLE
Allow shutdown with no device

### DIFF
--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -67,6 +67,9 @@ class MousePerspective(Gtk.Overlay):
 
     @GObject.Property
     def can_shutdown(self):
+        if self._device is None:
+            return True
+
         """Whether this perspective can safely shutdown."""
         for profile in self._device.profiles:
             if profile.dirty:

--- a/piper/welcomeperspective.py
+++ b/piper/welcomeperspective.py
@@ -94,7 +94,7 @@ class WelcomePerspective(Gtk.Box):
     def _on_quit_button_clicked(self, button):
         window = button.get_toplevel()
 
-        if not window.emit("delete-event", Gdk.Event(Gdk.EventType.DELETE)):
+        if not window.emit("delete-event", Gdk.Event.new(Gdk.EventType.DELETE)):
             window.destroy()
 
     @GtkTemplate.Callback


### PR DESCRIPTION
This is a followup fix for #220. In #226 we made Piper follow the same exit path from both the Quit button and closing the program from gnome-shell (or similar). This caused the bug to be consistently exposed in both ways.

The problem was that we hit an exception in MousePerspective.can_shutdown by accessing an attribute on the device, which is not yet set. can_shutdown is a GObject.Property and these do not (can not) support exceptions. This leads to can_shutdown returning False, which Piper thinks is due to unapplied changes which it warns the user about. After accepting to exit anyway the exception is printed.

This fix is simply to check if _device is None to avoid the exception. This fixes #220 

I also included a small patch for a deprecation warning I missed in the commit in #226.