### PR TITLE
Fix deprecation warnings

### DIFF
--- a/piper/buttonspage.py
+++ b/piper/buttonspage.py
@@ -45,7 +45,7 @@ class ButtonsPage(Gtk.Box):
 
         self._mousemap = MouseMap("#Buttons", self._device, spacing=20, border_width=20)
         self.pack_start(self._mousemap, True, True, 0)
-        self._sizegroup = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
+        self._sizegroup = Gtk.SizeGroup(mode=Gtk.SizeGroupMode.HORIZONTAL)
 
         self._set_profile(self._device.active_profile)
         self.show_all()

--- a/piper/ledspage.py
+++ b/piper/ledspage.py
@@ -45,7 +45,7 @@ class LedsPage(Gtk.Box):
 
         self._mousemap = MouseMap("#Leds", self._device, spacing=20, border_width=20)
         self.pack_start(self._mousemap, True, True, 0)
-        self._sizegroup = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
+        self._sizegroup = Gtk.SizeGroup(mode=Gtk.SizeGroupMode.HORIZONTAL)
 
         self._set_profile(self._device.active_profile)
         self.show_all()

--- a/piper/mousemap.py
+++ b/piper/mousemap.py
@@ -85,7 +85,7 @@ class MouseMap(Gtk.Container):
                     "spacing",
                     "The amount of space between children and the SVG leaders",
                     0, GLib.MAXINT, 0,
-                    GObject.PARAM_READABLE),
+                    GObject.ParamFlags.READABLE),
     }
 
     def __init__(self, layer, ratbagd_device, spacing=10, *args, **kwargs):

--- a/piper/resolutionspage.py
+++ b/piper/resolutionspage.py
@@ -76,7 +76,7 @@ class ResolutionsPage(Gtk.Box):
         for button in profile.buttons:
             if button.action_type == RatbagdButton.ACTION_TYPE_SPECIAL and \
                     button.special in self._resolution_labels:
-                label = Gtk.Label(_(RatbagdButton.SPECIAL_DESCRIPTION[button.special]))
+                label = Gtk.Label(label=_(RatbagdButton.SPECIAL_DESCRIPTION[button.special]))
                 mousemap.add(label, "#button{}".format(button.index))
         mousemap.show_all()
 

--- a/piper/welcomeperspective.py
+++ b/piper/welcomeperspective.py
@@ -30,7 +30,7 @@ class WelcomePerspective(Gtk.Box):
     __gtype_name__ = "WelcomePerspective"
 
     __gsignals__ = {
-        "device-selected": (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
+        "device-selected": (GObject.SignalFlags.RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
     }
 
     listbox = GtkTemplate.Child()


### PR DESCRIPTION
On fedora 29 we get the following deprecation warnings, which
this commit fixes

/usr/lib/python3.7/site-packages/piper/mousemap.py:88: PyGIDeprecationWarning: GObject.PARAM_READABLE is deprecated; use GObject.ParamFlags.READABLE instead
  GObject.PARAM_READABLE),
/usr/lib/python3.7/site-packages/piper/welcomeperspective.py:33: PyGIDeprecationWarning: GObject.SIGNAL_RUN_FIRST is deprecated; use GObject.SignalFlags.RUN_FIRST instead
  "device-selected": (GObject.SIGNAL_RUN_FIRST, None, (GObject.TYPE_PYOBJECT,)),
/usr/lib/python3.7/site-packages/piper/resolutionspage.py:79: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "label" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  label = Gtk.Label(_(RatbagdButton.SPECIAL_DESCRIPTION[button.special]))
/usr/lib/python3.7/site-packages/piper/buttonspage.py:48: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "mode" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self._sizegroup = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)
/usr/lib/python3.7/site-packages/piper/ledspage.py:48: PyGTKDeprecationWarning: Using positional arguments with the GObject constructor has been deprecated. Please specify keyword(s) for "mode" or use a class specific constructor. See: https://wiki.gnome.org/PyGObject/InitializerDeprecations
  self._sizegroup = Gtk.SizeGroup(Gtk.SizeGroupMode.HORIZONTAL)