### PR TITLE
meson: downgrade the 'ratbagd not found' to a message only

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -9,7 +9,14 @@ dependency('pygobject-3.0', required: true)
 ratbagd = find_program('ratbagd', required: false)
 
 if not ratbagd.found()
-  error('Dependency libratbag not found!')
+	message('''
+	*********************** WARNING **********************
+	* _???_     Dependency libratbag not found in $PATH! *
+	*(_)_(_)    ratbagd must be installed and running    *
+	* (o o)     for Piper to work.                       *
+	*==\o/==                                             *
+	******************************************************
+	''')
 endif
 
 # Gtk version required


### PR DESCRIPTION
This is too annoying when you build in multiple different prefixes etc. and
the PATH isn't always set up. Let alone requiring distributors to install
ratbagd to build Piper.

Downgrade it to a large warning and let's hope people at least read that one.