### PR TITLE
data: link to flathub-compatible 16:9 screenshots in the appdata

### DIFF
--- a/data/org.freedesktop.Piper.appdata.xml.in
+++ b/data/org.freedesktop.Piper.appdata.xml.in
@@ -31,15 +31,15 @@
   <screenshots>
     <screenshot type="default">
       <caption>The button configuraton page</caption>
-      <image>https://github.com/libratbag/piper/raw/wiki/screenshots/piper-buttonpage.png</image>
+      <image>https://github.com/libratbag/piper/raw/wiki/screenshots/flathub/piper-buttonpage.png</image>
     </screenshot>
     <screenshot>
       <caption>The LED configuraton page</caption>
-      <image>https://github.com/libratbag/piper/raw/wiki/screenshots/piper-ledpage.png</image>
+      <image>https://github.com/libratbag/piper/raw/wiki/screenshots/flathub/piper-ledpage.png</image>
     </screenshot>
     <screenshot>
       <caption>The resolution configuraton page</caption>
-      <image>https://github.com/libratbag/piper/raw/wiki/screenshots/piper-resolutionpage.png</image>
+      <image>https://github.com/libratbag/piper/raw/wiki/screenshots/flathub/piper-resolutionpage.png</image>
     </screenshot>
   </screenshots>
 


### PR DESCRIPTION
Fixes: https://github.com/flathub/org.freedesktop.Piper/issues/1

Pretty sure that's the reason we don't show up in flathub.