### PR TITLE
Add installation via zypper to the documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ Installing Piper
 ================
 
 Most popular distributions package Piper and it is available through the
-packaging system (apt, dnf, yum, pacman, ...). This is the preferred way of
-installing Piper.
+packaging system (apt, dnf, yum, pacman, zypper, ...). This is the preferred
+way of installing Piper.
 
 Piper is also available as a
 [Flatpak](https://flathub.org/apps/details/org.freedesktop.Piper).


### PR DESCRIPTION
Piper [has recently been added to openSUSE](https://build.opensuse.org/request/show/644078) which uses zypper as its packaging system.