### PR TITLE
ResolutionsPage: reset the last row if we click the "add" button

### DIFF
--- a/piper/resolutionspage.py
+++ b/piper/resolutionspage.py
@@ -116,6 +116,7 @@ class ResolutionsPage(Gtk.Box):
 
             if row is self.add_resolution_row:
                 print("TODO: RatbagdProfile needs a way to add resolutions")
+                self._last_activated_row = None
             else:
                 self._last_activated_row = row
                 row.toggle_revealer()


### PR DESCRIPTION
Reproducer:
- click on resolution A, B
- click on the + button
- click on resolution C

Now both B and C are revealed because B is still the last row and we call
toggle reveal on it.
