### PR TITLE
Hide the "add a resolution" button

### DIFF
--- a/data/ui/ResolutionsPage.ui
+++ b/data/ui/ResolutionsPage.ui
@@ -169,7 +169,7 @@
                             <signal name="row-activated" handler="_on_row_activated" swapped="no"/>
                             <child>
                               <object class="GtkListBoxRow" id="add_resolution_row">
-                                <property name="visible">True</property>
+                                <property name="visible">False</property>
                                 <property name="can_focus">True</property>
                                 <property name="tooltip_text" translatable="yes">Add a new resolution to the profile</property>
                                 <child>


### PR DESCRIPTION
This hasn't been implemented in over a year, let's hide it from sight. Maybe
that spurns someone on to actually implement it.

It's an improvement to the GUI either way because the message printed to stdout
wouldn't be seen by most users starting the Piper through e.g. gnome shell. So
it just looks like the button is broken.