### PR TITLE
Handle the Resync signal

### DIFF
--- a/data/ui/MousePerspective.ui
+++ b/data/ui/MousePerspective.ui
@@ -20,7 +20,7 @@
       </packing>
     </child>
     <child type="overlay">
-      <object class="GtkRevealer" id="notification_commit">
+      <object class="GtkRevealer" id="notification_error">
         <property name="visible">True</property>
         <property name="can_focus">False</property>
         <property name="halign">center</property>
@@ -36,14 +36,13 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkLabel" id="notification_commit_label">
+                  <object class="GtkLabel" id="notification_error_label">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="margin_right">30</property>
                     <property name="margin_end">30</property>
-                    <property name="label" translatable="yes">Failed to commit changes to the device</property>
+                    <property name="label" translatable="yes">Something went wrong. The device has been reset to a previous state.</property>
                     <property name="ellipsize">middle</property>
-                    <property name="max_width_chars">50</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -52,13 +51,13 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkButton" id="notification_commit_close">
+                  <object class="GtkButton" id="notification_error_close">
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="focus_on_click">False</property>
                     <property name="receives_default">True</property>
                     <property name="relief">none</property>
-                    <signal name="clicked" handler="_on_notification_commit_close_clicked" swapped="no"/>
+                    <signal name="clicked" handler="_on_notification_error_close_clicked" swapped="no"/>
                     <child>
                       <object class="GtkImage">
                         <property name="visible">True</property>

--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -36,7 +36,7 @@ class MousePerspective(Gtk.Overlay):
 
     _titlebar = GtkTemplate.Child()
     stack = GtkTemplate.Child()
-    notification_commit = GtkTemplate.Child()
+    notification_error = GtkTemplate.Child()
     listbox_profiles = GtkTemplate.Child()
     label_profile = GtkTemplate.Child()
     add_profile_button = GtkTemplate.Child()
@@ -48,7 +48,7 @@ class MousePerspective(Gtk.Overlay):
         Gtk.Overlay.__init__(self, *args, **kwargs)
         self.init_template()
         self._device = None
-        self._notification_commit_timeout_id = 0
+        self._notification_error_timeout_id = 0
 
     @GObject.Property
     def name(self):
@@ -113,19 +113,19 @@ class MousePerspective(Gtk.Overlay):
             if profile is active_profile:
                 self.listbox_profiles.select_row(row)
 
-    def _hide_notification_commit(self):
-        if self._notification_commit_timeout_id is not 0:
-            GLib.Source.remove(self._notification_commit_timeout_id)
-            self._notification_commit_timeout_id = 0
-        self.notification_commit.set_reveal_child(False)
+    def _hide_notification_error(self):
+        if self._notification_error_timeout_id is not 0:
+            GLib.Source.remove(self._notification_error_timeout_id)
+            self._notification_error_timeout_id = 0
+        self.notification_error.set_reveal_child(False)
 
-    def _show_notification_commit(self):
-        self.notification_commit.set_reveal_child(True)
-        self._notification_commit_timeout_id = GLib.timeout_add_seconds(5,
-                                                                        self._on_notification_commit_timeout)
+    def _show_notification_error(self):
+        self.notification_error.set_reveal_child(True)
+        self._notification_error_timeout_id = GLib.timeout_add_seconds(5,
+                                                                       self._on_notification_error_timeout)
 
-    def _on_notification_commit_timeout(self):
-        self._hide_notification_commit()
+    def _on_notification_error_timeout(self):
+        self._hide_notification_error()
         return False
 
     @GtkTemplate.Callback
@@ -133,8 +133,8 @@ class MousePerspective(Gtk.Overlay):
         self._device.commit()
 
     @GtkTemplate.Callback
-    def _on_notification_commit_close_clicked(self, button):
-        self._hide_notification_commit()
+    def _on_notification_error_close_clicked(self, button):
+        self._hide_notification_error()
 
     @GtkTemplate.Callback
     def _on_profile_row_activated(self, listbox, row):

--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -84,6 +84,7 @@ class MousePerspective(Gtk.Overlay):
     def set_device(self, device):
         self._device = device
         capabilities = device.capabilities
+        device.connect("resync", lambda _: self._show_notification_error())
 
         self.stack.foreach(Gtk.Widget.destroy)
         if RatbagdDevice.CAP_RESOLUTION in capabilities:

--- a/piper/resolutionspage.py
+++ b/piper/resolutionspage.py
@@ -57,7 +57,6 @@ class ResolutionsPage(Gtk.Box):
         self.init_template()
 
         self._device = ratbagd_device
-        self._notification_commit_timeout_id = 0
         self._last_activated_row = None
 
         self._device.connect("active-profile-changed", self._on_active_profile_changed)


### PR DESCRIPTION
This PR finally handles the resync signal and therefor fixes #182.

The resync signal is captured in the ratbagd bindings and emitted on the `RatbagdDevice`. The `MousePerspective` simply listens for this signal to be emitted and when it is, displays the notification overlay to inform the user that something went wrong and that the device has been restored to a previous state (which happens automagically in ratbagd).

Now we just need to get Piper to properly update itself when values change behind its back on the ratbagd side (edit: see https://github.com/libratbag/libratbag/pull/566), but that is for another PR.