### PR TITLE
Update for libratbag removing device capabilities

### DIFF
--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -115,7 +115,7 @@ class MousePerspective(Gtk.Overlay):
                 self.listbox_profiles.select_row(row)
 
     def _hide_notification_error(self):
-        if self._notification_error_timeout_id is not 0:
+        if self._notification_error_timeout_id != 0:
             GLib.Source.remove(self._notification_error_timeout_id)
             self._notification_error_timeout_id = 0
         self.notification_error.set_reveal_child(False)

--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -19,7 +19,6 @@ from gettext import gettext as _
 from .buttonspage import ButtonsPage
 from .gi_composites import GtkTemplate
 from .profilerow import ProfileRow
-from .ratbagd import RatbagdDevice
 from .resolutionspage import ResolutionsPage
 from .ledspage import LedsPage
 
@@ -83,20 +82,18 @@ class MousePerspective(Gtk.Overlay):
 
     def set_device(self, device):
         self._device = device
-        capabilities = device.capabilities
         device.connect("resync", lambda _: self._show_notification_error())
 
         self.stack.foreach(Gtk.Widget.destroy)
-        if RatbagdDevice.CAP_RESOLUTION in capabilities:
+        active_profile = device.active_profile
+        if active_profile.resolutions:
             self.stack.add_titled(ResolutionsPage(device), "resolutions", _("Resolutions"))
-        if RatbagdDevice.CAP_BUTTON in capabilities:
+        if active_profile.buttons:
             self.stack.add_titled(ButtonsPage(device), "buttons", _("Buttons"))
-        if RatbagdDevice.CAP_LED in capabilities:
+        if active_profile.leds:
             self.stack.add_titled(LedsPage(device), "leds", _("LEDs"))
 
         self.button_profile.set_visible(len(device.profiles) > 1)
-
-        active_profile = device.active_profile
         self.label_profile.set_label(active_profile.name)
         self._on_profile_notify_dirty(active_profile, None)
 

--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -100,7 +100,7 @@ class MousePerspective(Gtk.Overlay):
         # Find the first profile that is enabled. If there is none, disable the
         # add button.
         left = next((p for p in device.profiles if not p.enabled), None)
-        self.add_profile_button.set_sensitive(left is not None)
+        self.add_profile_button.set_visible(left is not None)
 
         self.listbox_profiles.foreach(Gtk.Widget.destroy)
         for profile in device.profiles:


### PR DESCRIPTION
This PR includes the changes we need to make in order to work with [libratbag removing device capabilities](https://github.com/libratbag/libratbag/pull/631). Note that I didn't include the changes to ratbagd.py in this PR, nor [the changes I had to make to it in order to show profile names](https://github.com/libratbag/libratbag/pull/631#issuecomment-465549800).

It'd be good if someone could test this on a device that doesn't allow one or more of the following:

1. resolution changes
2. button remapping
3. led changes

My device supports all three and it works on here.