### PR TITLE
Add SVG handling to piper

### DIFF
--- a/data/generate-piper-gresource.xml.py
+++ b/data/generate-piper-gresource.xml.py
@@ -1,0 +1,20 @@
+#!/bin/python3
+
+import sys
+
+infile = sys.argv[1]
+outfile = sys.argv[2]
+svgs = sys.argv[3:]
+print("Using input file: {}".format(infile))
+print("Writing to output file: {}".format(outfile))
+print("SVG files: {}".format(",".join(svgs)))
+
+with open(infile) as f_in:
+    with open(outfile, 'w') as f_out:
+        for line in f_in:
+            if '@SVG_FILES@' in line:
+                for svg in svgs:
+                    f_out.write(line.replace('@SVG_FILES@', svg))
+                continue
+
+            f_out.write(line)

--- a/data/meson.build
+++ b/data/meson.build
@@ -13,13 +13,6 @@ about_dialog = configure_file(input: 'ui/AboutDialog.ui.in',
 			      output: 'AboutDialog.ui',
 			      configuration: conf)
 
-gnome.compile_resources('piper', 'piper.gresource.xml',
-			source_dir: '.',
-			dependencies: [about_dialog],
-			gresource_bundle: true,
-			install: true,
-			install_dir: pkgdatadir)
-
 install_data('org.freedesktop.Piper.svg', install_dir: icondir)
 
 i18n.merge_file(input: 'org.freedesktop.Piper.desktop.in',
@@ -39,3 +32,60 @@ i18n.merge_file(input: appdata,
                 po_dir: podir,
                 install: true,
                 install_dir: metainfodir)
+
+
+# SVG files
+
+svgs = [
+	'svgs/fallback.svg',
+	'svgs/logitech-g102-g203.svg',
+	'svgs/logitech-g300.svg',
+	'svgs/logitech-g303.svg',
+	'svgs/logitech-g402.svg',
+	'svgs/logitech-g403.svg',
+	'svgs/logitech-g500s.svg',
+	'svgs/logitech-g500.svg',
+	'svgs/logitech-g502.svg',
+	'svgs/logitech-g600.svg',
+	'svgs/logitech-g603.svg',
+	'svgs/logitech-g700.svg',
+	'svgs/logitech-g703.svg',
+	'svgs/logitech-g900.svg',
+	'svgs/logitech-g9.svg',
+	'svgs/logitech-g-pro.svg',
+	'svgs/logitech-g-pro-wireless.svg',
+	'svgs/logitech-mx-anywhere2s.svg',
+	'svgs/logitech-mx-anywhere2.svg',
+	'svgs/logitech-mx-master-2s.svg',
+	'svgs/logitech-mx-master.svg',
+	'svgs/roccat-kone-xtd.svg',
+	'svgs/steelseries-kinzu-v2.svg',
+	'svgs/steelseries-rival310.svg',
+	'svgs/steelseries-rival600.svg',
+	'svgs/steelseries-rival.svg',
+	'svgs/steelseries-sensei310.svg',
+	'svgs/steelseries-senseiraw.svg',
+]
+
+svg_mapping = files('svgs/svg-lookup.ini')
+
+test_svg_files = find_program('svgs/check-svg.py')
+test('check-svg', test_svg_files,
+     args: svgs,
+     env: ['BASEDIR=@0@'.format(meson.current_source_dir())])
+
+gresource = configure_file(input: 'piper.gresource.xml.in',
+                           output: 'piper.gresource.xml',
+                           command: ['generate-piper-gresource.xml.py',
+                                     join_paths(meson.current_source_dir(), 'piper.gresource.xml.in'),
+                                     join_paths(meson.current_build_dir(), 'piper.gresource.xml'),
+                                     svgs
+                                     ]
+                           )
+
+gnome.compile_resources('piper', gresource,
+			source_dir: '.',
+			dependencies: [about_dialog],
+			gresource_bundle: true,
+			install: true,
+			install_dir: pkgdatadir)

--- a/data/piper.gresource.xml.in
+++ b/data/piper.gresource.xml.in
@@ -4,6 +4,7 @@
         <file>404.svg</file>
         <file>enter-keyboard-shortcut.svg</file>
         <file>led-off.svg</file>
+        <file>svgs/svg-lookup.ini</file>
 
         <file preprocess="xml-stripblanks">AboutDialog.ui</file>
         <file preprocess="xml-stripblanks">ui/ButtonDialog.ui</file>
@@ -18,5 +19,7 @@
         <file preprocess="xml-stripblanks">ui/ResolutionsPage.ui</file>
         <file preprocess="xml-stripblanks">ui/WelcomePerspective.ui</file>
         <file preprocess="xml-stripblanks">ui/Window.ui</file>
+
+        <file>@SVG_FILES@</file>
     </gresource>
 </gresources>

--- a/data/svgs/README.md
+++ b/data/svgs/README.md
@@ -1,0 +1,104 @@
+libratbag gnome theme
+====================
+
+Requirements
+------------
+
+See the Logitech G403 for an example of a device with a small amount of buttons,
+and the Logitech G700 for an example of a device with a large amount of buttons.
+
+- Canvas size should be between 400x400 and 500x500 pixels.
+- Three layers in the final SVG:
+  1. a lower layer named "Device" with the device itself. Each button on the
+  device should have an id `buttonX`, with `X` being the number of the button
+  (so for button 0 the id would be `button0`). Similarly, each LED on the device
+  should have an id `ledX`.
+  2. a middle layer named "Buttons" with the button leaders (see below for
+  leaders).
+  3. an upper layer named "LEDs" with the LED leaders.
+- A leader line is a path that extends from the button or LED to the left or the
+  right of the device (see below). Each leader line requires the following:
+  - It should start with a 7x7 square placed on or close to the button or LED
+    that it maps with.
+  - From this square, a path should extend left or right (see below).
+  - Each path should end with a 1x1 pixel with identifier `buttonX-leader` (or
+    `ledX-leader`), where `X` is the number of the button (or LED) with
+    which the leader maps. For button 0, this would be `button0-leader`.
+  - All these elements should be grouped and given the identifier `buttonX-path`
+    (or `ledX-path` for LEDs)
+- Leader lines should have a vertical spacing of at least 40 pixels. When there
+  are several leader lines above and below each other, make the spacing between
+  them equal.
+- If the device's scroll wheel supports horizontal tilting, add two small arrows
+  left and right of the scroll wheel with the respective button identifiers (see
+  the Logitech G700 for an example). Do not cut the scroll wheel in half
+  vertically to map these buttons.
+- If there aren't too many buttons, preferably make the leaders point to the
+  right with the device itself placed on the left. If the buttons would extend
+  below or above the device, make some point to the left instead with the device
+  itself centered in the middle. In this case, half of the leaders should extend
+  to the left and the other half to the right.
+- When a leader points to the right, its 1x1 pixel should have a style property
+  `text-align:start`. When a leader points to the left, its 1x1 pixel should
+  have a style property `text-align:end`.
+- The canvas should be resized so that there is a 20px gap between the device
+  and the edge of the canvas and no gap between the 1x1 pixels and the canvas.
+
+Please note that due to the way the SVG is drawn, you cannot rely on the
+z-ordering of elements to line up or cover elements (as noted in [this
+issue](https://github.com/libratbag/piper/issues/48), which includes links to
+examples). As such, please make sure that you align the elements appropriately;
+[this
+comment](https://github.com/libratbag/piper/issues/48#issuecomment-315979109)
+includes some helpful tips.
+
+Technique
+---------
+
+The simplest approach is to find a photo of the device and import it into
+inkscape. Put it on the lowest layer, create a new layer "Device" above it
+and start tracing the outlines and edges of the device. Fill in the shapes
+and your device should resemble the underlying photo. Delete the photo
+layer, add leaders in their respective layers and you're done.
+
+Make sure the image looks ''toned-down'' and not realistic. Do not use dark or
+bright colors.
+
+
+License
+-------
+The SVG files listed below were imported from libratbag and are MIT licensed
+as of the time of import. See the libratbag COPYING file for details.
+
+ fallback.svg
+ logitech-g-pro-wireless.svg
+ logitech-g-pro.svg
+ logitech-g102-g203.svg
+ logitech-g300.svg
+ logitech-g303.svg
+ logitech-g402.svg
+ logitech-g403.svg
+ logitech-g500.svg
+ logitech-g500s.svg
+ logitech-g502.svg
+ logitech-g600.svg
+ logitech-g603.svg
+ logitech-g700.svg
+ logitech-g703.svg
+ logitech-g9.svg
+ logitech-g900.svg
+ logitech-mx-anywhere2.svg
+ logitech-mx-anywhere2s.svg
+ logitech-mx-master-2s.svg
+ logitech-mx-master.svg
+ roccat-kone-xtd.svg
+ steelseries-kinzu-v2.svg
+ steelseries-rival.svg
+ steelseries-rival310.svg
+ steelseries-rival600.svg
+ steelseries-sensei310.svg
+ steelseries-senseiraw.svg
+
+Where changes are made to these files, the changes will be made under
+piper's license (GPLv3). Use the git commit log to determine the exact
+license state of each file.

--- a/data/svgs/check-svg.py
+++ b/data/svgs/check-svg.py
@@ -1,6 +1,7 @@
 #!/usr/bin/python3
 # vim: set expandtab shiftwidth=4 tabstop=4:
 
+import os
 import sys
 from lxml import etree
 import logging
@@ -102,6 +103,7 @@ def check_buttons(root):
 
 
 def check_svg(path):
+    path = os.path.join(os.environ.get('BASEDIR', '.'), path)
     svg = etree.parse(path)
     root = svg.getroot()
 

--- a/data/svgs/check-svg.py
+++ b/data/svgs/check-svg.py
@@ -11,6 +11,7 @@ style_query = '//svg:rect[@id=\"{}\"][contains(@style, \"{}\")]'
 
 logger = None
 
+
 class SVGLogger(logging.Logger):
     def __init__(self, name, level=logging.NOTSET):
         self.success = True
@@ -111,6 +112,7 @@ def check_svg(path):
     check_layers(root)
     check_buttons(root)
     check_leds(root)
+
 
 if __name__ == "__main__":
     success = True

--- a/data/svgs/check-svg.py
+++ b/data/svgs/check-svg.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python3
+# vim: set expandtab shiftwidth=4 tabstop=4:
+
+import sys
+from lxml import etree
+import logging
+
+ns = {'svg': 'http://www.w3.org/2000/svg'}
+style_query = '//svg:rect[@id=\"{}\"][contains(@style, \"{}\")]'
+
+logger = None
+
+class SVGLogger(logging.Logger):
+    def __init__(self, name, level=logging.NOTSET):
+        self.success = True
+        return super().__init__(name, level)
+
+    def error(self, msg, *args, **kwargs):
+        self.success = False
+        return super().error(msg, *args, **kwargs)
+
+    @classmethod
+    def get_logger(cls, path):
+        logging.setLoggerClass(SVGLogger)
+        logging.basicConfig(level=logging.DEBUG)
+        return logging.getLogger(path)
+
+
+def check_size(root):
+    width = float(root.attrib['width'])
+    height = float(root.attrib['height'])
+    if not 400 < width < 500:
+        logger.error("Width is outside of range: {}".format(width))
+    if not 400 < height < 500:
+        logger.error("Height is outside of range: {}".format(height))
+
+
+def check_layers(root):
+    """
+    Check there are layers (well, groups) for the components we require.
+    """
+    layer_ids = [g.attrib['id'] for g in root.iterfind('svg:g', ns)]
+
+    for layer in ["Device", "Buttons", "LEDs"]:
+        if layer not in layer_ids:
+            logger.error("Missing layer: {}".format(layer))
+
+
+def check_elements(root, prefix, required=0):
+    """
+    Checks for elements of the form 'prefixN' in the root tag. Any elements
+    found must be consecutive or an warning is printed, i.e. if there's a
+    'button8' there has to be a 'button7'.
+
+    If required is nonzero, an error is logged for any missing element with
+    an index less than required.
+    """
+
+    # elements can be paths and rects
+    # This includes leaders and lines
+    element_ids = [p.attrib['id'] for p in root.xpath('//svg:path', namespaces=ns) if p.attrib['id'].startswith(prefix)]
+    element_ids += [p.attrib['id'] for p in root.xpath('//svg:rect', namespaces=ns) if p.attrib['id'].startswith(prefix)]
+    element_ids += [g.attrib['id'] for g in root.xpath('//svg:g', namespaces=ns) if g.attrib['id'].startswith(prefix)]
+
+    idx = 0
+    highest = -1
+    for idx in range(0, 20):
+        e = '{}{}'.format(prefix, idx)
+        previous = '{}{}'.format(prefix, idx - 1)
+        leader = '{}{}-leader'.format(prefix, idx)
+        path = '{}{}-path'.format(prefix, idx)
+        if e in element_ids:
+            highest = idx
+            if idx > 0 and previous not in element_ids:
+                logger.warning("Non-consecutive {}: {}".format(prefix, e))
+
+            if leader not in element_ids:
+                logger.error("Missing {} for {}".format(leader, e))
+            else:
+                element = root.xpath(style_query.format(leader, 'text-align'), namespaces=ns)
+                if element is None or len(element) != 1 or element[0] is None:
+                    logger.error("Missing style property for {}".format(leader))
+
+            if path not in element_ids:
+                logger.error("Missing {} for {}".format(path, e))
+        elif leader in element_ids:
+            logger.error("Have {} but not {}".format(leader, e))
+        elif path in element_ids:
+            logger.error("Have {} but not {}".format(path, e))
+        elif idx < required:
+            logger.error("Missing {}: {}".format(prefix, e))
+
+    logger.info("Found {} {}s".format(highest + 1, prefix))
+
+
+def check_leds(root):
+    check_elements(root, "led")
+
+
+def check_buttons(root):
+    check_elements(root, "button", 3)
+
+
+def check_svg(path):
+    svg = etree.parse(path)
+    root = svg.getroot()
+
+    check_size(root)
+    check_layers(root)
+    check_buttons(root)
+    check_leds(root)
+
+if __name__ == "__main__":
+    success = True
+    for path in sys.argv[1:]:
+        logger = SVGLogger.get_logger(path)
+        check_svg(path)
+        if not logger.success:
+            success = False
+
+    if not success:
+        sys.exit(1)

--- a/data/svgs/fallback.svg
+++ b/data/svgs/fallback.svg
@@ -1,0 +1,506 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="450"
+   height="450"
+   viewBox="0 0 450.00001 450.00001"
+   id="svg4844"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="fallback.svg">
+  <defs
+     id="defs4846" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4"
+     inkscape:cx="162.83067"
+     inkscape:cy="254.74718"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1920"
+     inkscape:window-height="1101"
+     inkscape:window-x="1920"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     showguides="true"
+     inkscape:guide-bbox="true">
+    <sodipodi:guide
+       position="20.203051,215.1625"
+       orientation="1,0"
+       id="guide6533" />
+    <sodipodi:guide
+       position="263.64982,40.406102"
+       orientation="0,1"
+       id="guide6535" />
+    <sodipodi:guide
+       position="119.198,430.32499"
+       orientation="0,1"
+       id="guide6537" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata4849">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline">
+    <g
+       id="mouse"
+       transform="matrix(1.4157338,0,0,1.4150394,-15.907361,-83.397825)"
+       inkscape:label="#g5682">
+      <path
+         sodipodi:nodetypes="csssssscssssccccccccsccccscccccccc"
+         inkscape:connector-curvature="0"
+         id="path5554"
+         d="m 107.18942,257.50398 c -4.99714,2.43535 -12.465604,2.63664 -17.258052,-1.44306 -13.182502,-11.22196 -9.97511,-20.42755 -11.852724,-27.60442 -2.086919,-7.9769 -8.394971,-14.22057 -14.204755,-19.22015 -2.452298,-2.11032 -15.074169,-8.92571 -22.581405,-6.39459 -7.284157,2.45591 -8.927109,7.96865 -7.039536,13.91417 0.942265,2.96796 6.341731,12.02153 3.965931,13.71887 -6.197029,4.42735 -6.062903,-6.5818 -10.547143,-6.17694 -3.155437,2.60598 5.722132,16.20922 13.501397,8.54975 5.287042,-5.20562 -7.079343,-19.36707 -3.390295,-23.44484 9.484404,-10.48379 25.055087,3.37163 28.181213,6.1766 3.122791,2.80198 9.248496,8.52414 9.875553,20.12323 0.843858,15.60941 10.74282,34.96801 34.650426,29.65168 5.06065,14.01778 13.49867,22.70826 23.95424,24.35573 -0.73268,4.29744 8.14899,6.47132 -4.44275,21.19745 3.06561,2.85685 8.01758,11.19489 5.36011,25.42154 -5.7187,3.96316 -16.72683,16.45412 0.58015,5.39321 7.47117,-0.31027 14.12258,9.86529 24.83436,3.31115 -4.03605,-1.39212 -8.28293,-7.96174 -18.1528,-9.13334 -0.39969,-10.26297 -0.36143,-17.7796 5.94065,-24.85378 14.19011,-17.96422 10.92982,-12.10811 13.41925,-19.23937 2.48943,-7.13126 2.52109,-11.34 2.33441,-19.25558 -2.9569,-16.18074 -2.70058,-16.2775 -0.11605,-1.49727 16.61294,-0.76638 32.95879,-6.2945 39.23502,-17.29952 9.79039,-1.32985 22.51147,-7.39605 29.90276,0.56675 -5.22785,1.2715 -19.1955,26.95192 0.95314,7.4515 11.02869,-10.67388 23.99028,5.40711 27.28604,-12.1447 -31.80018,1.43261 -37.30275,-17.43649 -56.67811,-17.25445 -7.30408,-0.27416 -20.44309,-0.17002 -25.52504,9.24102 9.11653,-12.47147 0.88952,-27.94431 -1.51863,-41.85017 -15.02015,-21.13729 -30.18152,-29.86148 -43.79923,-20.54814 -13.65771,11.51411 -22.41864,26.83759 -23.4676,44.34506 -1.03036,11.6519 -3.29737,12.1189 -3.40046,33.94261 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="zcsccczzczz"
+         inkscape:connector-curvature="0"
+         id="button6"
+         d="m 125.00072,147.3762 c -3.94854,2.46476 -1.91248,4.22271 -6.56842,3.47664 -6.04044,-0.49004 -12.10893,4.61986 -13.01838,8.83118 -1.05538,4.887 0.82228,9.01123 6.09563,9.60013 4.20528,0.52222 4.02895,-1.99743 6.87568,-2.5868 4.10235,6.95899 19.61805,11.70942 26.38361,11.76956 4.71763,-0.6919 4.81094,-3.03006 11.87015,-12.70472 7.05921,-9.67466 6.92045,-10.39092 6.98781,-15.5586 0.0674,-5.16768 5.35659,-7.43289 0.64282,-10.74954 -1.91632,-0.43449 -6.15926,0.21143 -17.24225,0.33896 -11.08299,0.12753 -18.07811,5.11843 -22.02665,7.58319 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5399" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5405"
+         d="m 163.20277,150.23723 c -1.06521,-0.0557 -3.7617,0.42888 -4.65914,1.09722 -2,1.49899 -2.78079,2.58243 -4.28466,4.28408"
+         style="fill:none;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.70652068px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="zszzcz"
+         inkscape:connector-curvature="0"
+         id="path5414"
+         d="m 140.75099,145.17797 c -1.18229,0.40938 -2.17328,0.089 -3.548,0.54388 -1.29024,0.42688 -0.38888,1.67372 0.70446,2.31451 1.09334,0.64079 4.0134,-0.29332 5.06491,-1.10649 1.05151,-0.81317 1.6576,-2.35673 1.26243,-2.48934 -0.39517,-0.13262 -2.30151,0.32805 -3.4838,0.73744 z"
+         style="fill:none;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.70652068px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cscccccccccc"
+         inkscape:connector-curvature="0"
+         id="button4"
+         d="m 78.728764,157.07155 c 2.729308,11.45367 -4.592785,23.20521 4.683418,32.67799 4.193755,4.28262 13.716552,5.67648 28.077598,4.49959 -16.964136,7.07876 -15.435974,11.82485 -18.038124,14.76602 -0.367398,1.93959 3.51961,2.8971 16.874634,15.52043 5.69621,-9.78547 8.32004,-20.52393 15.45362,-28.52298 15.91171,-4.8206 -2.52533,-22.7944 -2.52533,-22.7944 0,0 -6.14675,-4.9701 -9.92352,3.09571 -7.99103,-6.69016 -16.706109,-2.41957 -17.256932,4.64391 1.356748,-6.41288 0.152959,-21.95234 -2.71781,-27.4956 -9.538417,1.9887 -10.559123,3.86954 -14.594684,3.59772 -0.398494,-4.23259 11.719989,-4.91038 14.599568,-3.59704"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5425" />
+      <path
+         sodipodi:nodetypes="sscscccs"
+         inkscape:connector-curvature="0"
+         id="path5459"
+         d="m 170.57402,194.85052 c 1.27147,3.99383 5.43056,12.02629 7.61859,15.67135 1.67031,2.78261 3.12076,3.57306 4.37974,10.16536 3.35106,-2.36328 2.26625,-4.37687 7.86716,-6.63393 6.78116,-2.73268 10.74994,-17.14078 7.59325,-20.21486 -2.56921,-1.4377 -13.90652,-7.54721 -16.5961,-8.75778 -8.64652,-2.75344 -18.11595,-5.26303 -26.29721,-3.34848 9.47658,1.68644 14.2189,9.2998 15.43457,13.11834 z"
+         style="fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="cccczccszccccc"
+         inkscape:connector-curvature="0"
+         id="button5"
+         d="m 156.57364,174.60716 c 0.61451,3.45259 -4.17141,8.40305 2.31606,7.85954 11.99907,4.07348 25.62973,4.1469 36.30113,11.66165 7.04625,4.94297 4.95335,13.00607 7.04625,4.94297 1.1521,-9.09961 -1.67322,-15.30143 -7.75899,-16.73475 -6.08578,-1.43332 -8.13701,-3.55535 -13.61967,-4.14262 -2.80249,-1.72124 -8.8609,-0.0129 -18.78998,0.48317 7.50071,-0.84183 14.47216,-0.73196 18.56074,-2.80565 0,0 6.30334,-9.54951 7.53958,-14.37709 1.23624,-4.82758 1.50074,-6.5184 3.27709,-10.38873 -4.42899,-1.01319 -7.07586,-3.6542 -10.44975,-4.61991 -2.18062,4.20089 -3.52881,8.12787 -6.83587,11.50939 -4.41968,6.55835 -8.29193,5.97237 -14.60181,12.79024 -0.89825,2.92739 -2.98478,3.82179 -2.98478,3.82179 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5453" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="button2"
+         d="m 129.85315,182.50093 c 3.6135,2.58802 10.74551,5.75132 14.60758,1.93282 0.45507,-2.97455 -0.19296,-6.87423 -0.19285,-7.3212 -7.27257,-0.13193 -16.12143,-4.19401 -22.95494,-6.35683 1.4347,5.55248 6.71272,10.53825 8.54021,11.74521 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5540" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="button3"
+         d="m 147.13503,177.00627 c 1.16519,3.28142 3.63994,3.84875 5.91906,6.18906 4.77775,-2.47336 5.12452,-13.43108 3.9723,-16.57185 -3.79251,3.28442 -5.96683,8.30504 -9.89136,10.38279 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5547" />
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="button7"
+         d="m 96.280703,132.06305 c 0,0 58.294677,-1.61611 100.929457,-0.83206 -1.27875,-12.91598 2.4481,-38.633128 2.05831,-56.889372 -46.40187,1.475128 -77.8249,2.200365 -105.250613,1.551238 4.495692,30.284264 2.262846,56.170194 2.262846,56.170194 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:2.11956239;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5566" />
+      <path
+         sodipodi:nodetypes="cscsccsccscsccccc"
+         inkscape:connector-curvature="0"
+         id="button0"
+         d="m 82.544643,155.53571 c 0.305172,-3.31535 0.980416,-11.89491 2.489066,-14.57767 2.810136,-4.99714 6.565433,-8.72285 8.454552,-11.91369 2.686043,-3.2364 2.701225,-4.20604 4.184853,-5.44313 1.47935,-1.23353 7.182396,-9.27661 8.097236,-8.77569 1.51464,3.42922 -5.03984,11.03401 -6.93589,13.34978 2.62462,-2.24644 4.10033,-4.85435 7.49772,-7.85092 3.00882,-2.65384 6.26227,-2.5427 3.72007,0.68937 -2.64048,3.02394 -3.55215,4.11719 -8.76065,8.25327 10.88502,-8.17285 19.09259,-9.06063 9.30462,-2.01748 -1.40825,1.01334 -8.4791,4.08043 -5.58663,2.88614 2.72294,-0.18651 10.84559,-2.68876 10.05588,-0.49162 -1.65227,4.59693 -8.23017,2.61804 -12.09164,4.12386 -2.17312,2.61683 -5.158266,3.64905 -7.879445,5.87814 -1.853363,2.41097 -3.914211,8.13746 -5.08138,13.723 -0.977626,0.29825 -5.450462,1.56098 -7.468362,2.16661 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:1.41304147;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5561" />
+      <text
+         sodipodi:linespacing="100%"
+         id="text5583"
+         y="117.5"
+         x="110.17857"
+         style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:12px;line-height:100%;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#bfc2bb;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         xml:space="preserve"><tspan
+           style="font-style:italic;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:40px;font-family:sans-serif;-inkscape-font-specification:'sans-serif Italic';fill:#bfc2bb;fill-opacity:1"
+           y="117.5"
+           x="110.17857"
+           id="tspan5585"
+           sodipodi:role="line">404</tspan></text>
+      <path
+         sodipodi:nodetypes="cccccsscssccccc"
+         inkscape:connector-curvature="0"
+         id="button1"
+         d="m 183.97321,147.27678 c 3.33335,-1.48288 3.09826,-6.77076 3.85156,-9.86053 -0.35674,-3.91061 0.37686,-5.05433 -1.93804,-6.90092 -2.10346,-1.08198 -0.13041,-3.85244 1.93457,-2.9861 2.92925,1.60616 0.94495,6.22838 4.12041,7.61394 0,0 1.87775,-1.15731 1.99206,-3.40725 0.1301,-2.56065 -1.15427,-11.79601 1.03251,-13.08991 0.96059,-0.56838 1.75458,9.82486 2.96125,11.86818 -0.30586,-2.13132 -0.65718,-12.83967 0.19291,-12.16594 3.65618,2.89768 1.37042,11.98208 3.4547,14.61683 1.72735,2.18354 -3.64795,6.53893 -6.93051,11.03314 -2.12109,2.77912 -2.89583,2.76412 -4.9476,6.04875 -2.40971,-1.47777 -3.69229,-1.95944 -5.72384,-2.77019 l 0,0 z"
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:1.41304147;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:label="#path5587" />
+      <path
+         style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:3.02452755;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 129.71002,288.41558 c -7.1173,2.84692 -18.1026,3.61499 -24.6415,-2.32569 C 86.783262,269.47748 90.830889,256.94793 88.150941,246.7094 85.172248,235.32955 76.168664,226.42233 67.876267,219.28992 64.376063,216.27934 46.360664,206.5565 35.645466,210.16739 25.248672,213.671 22.903661,221.53548 25.597824,230.01736 c 1.34491,4.23409 9.051654,17.14992 5.660636,19.57135 -8.845118,6.31606 -8.653678,-9.3896 -15.054105,-8.81203 -4.503806,3.71769 8.16729,23.12409 19.27076,12.19708 7.546279,-7.42634 -10.10446,-27.62907 -4.839023,-33.44642 13.537242,-14.95619 35.761527,4.80997 40.223496,8.81154 4.45721,3.9973 13.200527,12.16054 14.095535,28.70781 1.204452,22.2684 15.333397,49.88539 49.444437,42.2623 -0.73591,-2.53682 -4.15602,-6.43263 -4.68954,-10.89341 z"
+         id="led0"
+         transform="matrix(0.7006157,0,0,0.70096699,16.318711,55.521354)"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="csssssscsssscc"
+         inkscape:label="#path6431" />
+      <path
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:3.02452755;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 169.91186,400.60038 c -8.16239,5.65385 -23.87447,23.47346 0.82806,7.69396 10.66372,-0.44263 20.15739,14.07383 35.44648,4.72369 -5.76072,-1.986 -11.82236,-11.35822 -25.88738,-13.10742 -3.01274,0.0336 -8.44501,-0.32858 -10.38716,0.68977 z"
+         id="path6437"
+         transform="matrix(0.7006157,0,0,0.70096699,16.318711,55.521354)"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+    </g>
+    <path
+       inkscape:label="#path6478"
+       style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:3.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 175.72866,392.52094 c -8.09615,5.60803 -23.68073,23.28322 0.82135,7.6316 10.57718,-0.43903 19.9938,13.95978 35.15883,4.68542 -5.71397,-1.96992 -11.72643,-11.26617 -25.67731,-13.0012 -2.98831,0.0334 -8.37648,-0.32592 -10.30287,0.68418 z"
+       id="led1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       sodipodi:nodetypes="csccc"
+       inkscape:connector-curvature="0"
+       id="led2"
+       d="m 314.43906,276.47676 c -7.40123,1.79921 -27.17571,38.13802 1.3494,10.54417 15.61369,-15.10398 33.96384,7.65126 38.62976,-17.18524 -11.69141,0.52644 -20.87204,-0.88448 -28.52139,-3.25631 -0.91845,1.9989 -7.62356,10.08149 -11.45777,9.89738 z"
+       style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:3.00000024;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline">
+    <g
+       style="display:inline"
+       id="button1-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,68.669278)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+    <g
+       transform="translate(12.063466,28.669278)"
+       inkscape:label="#g131"
+       id="button0-path"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5628"
+         d="m 282.94764,50.505764 154.05236,0"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="277"
+         height="6.999999"
+         width="6.999999"
+         id="rect5630"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="437"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+    <g
+       transform="translate(12.063466,148.66928)"
+       inkscape:label="#g131"
+       id="button3-path"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5636"
+         d="m 282.94764,50.505764 154.05236,0"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="277"
+         height="6.999999"
+         width="6.999999"
+         id="rect5638"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="437"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+    <g
+       style="display:inline"
+       id="button2-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,108.66928)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path5644"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5646"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button2-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+    <g
+       transform="translate(12.063466,228.66928)"
+       inkscape:label="#g131"
+       id="button5-path"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5652"
+         d="m 282.94764,50.505764 154.05236,0"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="277"
+         height="6.999999"
+         width="6.999999"
+         id="rect5654"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="437"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+    <g
+       style="display:inline"
+       id="button4-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,188.66928)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path5660"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5662"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button4-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+    <g
+       style="display:inline"
+       id="button7-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,308.66928)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path5668"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5670"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button7-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+    <g
+       transform="translate(12.063466,268.66928)"
+       inkscape:label="#g131"
+       id="button6-path"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5676"
+         d="m 282.94764,50.505764 154.05236,0"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="277"
+         height="6.999999"
+         width="6.999999"
+         id="rect5678"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="437"
+         height="1"
+         width="1"
+         id="button6-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs">
+    <g
+       style="display:inline"
+       id="led0-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,28.669278)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path5785"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5787"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="led0-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+    <g
+       transform="translate(12.063466,68.669278)"
+       inkscape:label="#g131"
+       id="led1-path"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5797"
+         d="m 282.94764,50.505764 154.05236,0"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="277"
+         height="6.999999"
+         width="6.999999"
+         id="rect5799"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="437"
+         height="1"
+         width="1"
+         id="led1-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+    <g
+       style="display:inline"
+       id="led2-path"
+       inkscape:label="#g131"
+       transform="translate(12.063466,108.66928)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 282.94764,50.505764 154.05236,0"
+         id="path6411"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect6413"
+         width="6.999999"
+         height="6.999999"
+         x="277"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="led2-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/logitech-g-pro-wireless.svg
+++ b/data/svgs/logitech-g-pro-wireless.svg
@@ -1,0 +1,358 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="417.20001"
+   height="407.25"
+   viewBox="0 0 417.20001 407.24999"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.2 2405546, 2018-03-11"
+   sodipodi:docname="logitech-g-pro-wireless.svg"
+   inkscape:export-filename="/home/jimmac/logitech-g-pro.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs2">
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4193"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4185"
+       is_visible="true" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.2804595"
+     inkscape:cx="68.346407"
+     inkscape:cy="156.12394"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="false"
+     showguides="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     fit-margin-top="20"
+     fit-margin-left="20"
+     fit-margin-bottom="20"
+     fit-margin-right="0"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     objecttolerance="10"
+     gridtolerance="10"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-others="true"
+     inkscape:snap-global="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid956"
+       originx="-68.791593"
+       originy="1.2767161" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     transform="translate(-68.791597,-394.02675)"
+     style="display:inline">
+    <path
+       sodipodi:nodetypes="cccccccccccccccccsccccsccccccccc"
+       inkscape:connector-curvature="0"
+       id="path1292"
+       d="m 360.53959,454.98488 c 3.74994,7.11792 5.22331,12.82285 5.80424,19.98939 1.3281,12.56244 0.9478,23.81846 0.96947,36.4814 l -3.17737,93.86839 c 2.16614,21.37627 5.56926,62.75825 5.56926,62.75825 0.65653,8.98996 -0.46847,26.48228 -0.46847,26.48228 -2.86905,23.33152 -10.5133,37.74934 -19.00067,50.59334 -18.20786,20.92677 -40.13338,36.77577 -73.78077,36.6144 -27.02249,-2.01448 -53.27969,-9.87305 -76.17266,-43.4221 -9.26342,-15.31303 -16.69901,-34.15568 -15.08733,-70.46891 0.62849,-14.11561 1.69038,-28.25238 4.18994,-49.46082 l -0.49311,-29.00325 1.18979,-1.57231 -0.0795,-4.45976 c -1.39215,-1.83047 -1.66233,-3.22446 -1.77535,-5.08282 -0.64341,-16.4181 -3.4946,-31.1865 -1.60176,-47.4595 l 1.47194,-0.0964 c -0.37849,-21.34319 -3.11342,-49.72121 2.66511,-66.67692 1.24485,-3.65274 1.80259,-6.37401 3.52312,-8.88212 l 1.05297,-0.01 c 0.54288,1.3278 1.67594,1.1345 2.10889,-0.024 v -5.52825 c 3.59201,-4.68158 7.50203,-9.54243 12.85097,-13.19967 15.55153,-10.63308 32.80347,-19.96687 65.99229,-22.56979 l -0.0387,6.48824 h 2.2079 l -0.01,-6.47842 c 23.50552,1.65098 57.68029,9.24243 79.04493,36.21112 l -0.0104,4.95885 0.5328,0.02 c -0.0202,1.38148 1.14549,1.60947 1.23348,-0.0306 z"
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       sodipodi:nodetypes="cccccc"
+       inkscape:connector-curvature="0"
+       id="button4"
+       d="m 188.09729,530.74646 c 1.24811,16.49039 3.84562,32.89212 4.67165,49.41274 -0.23358,2.47096 -1.75447,3.01485 -2.76648,3.22598 -1.40633,-1.85652 -1.95252,-3.40284 -2.12696,-4.9258 -0.5931,-13.32083 -2.99544,-30.31661 -1.59655,-47.61652 z"
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#path1308" />
+    <path
+       sodipodi:nodetypes="ccczzc"
+       inkscape:connector-curvature="0"
+       id="button3"
+       d="m 193.52072,585.08288 -4.67671,4.33437 c -0.0827,14.62518 0.50637,29.18789 1.55352,43.76306 0.38765,1.69742 1.72362,5.2371 2.9655,5.04628 1.24187,-0.19081 2.03429,-4.00811 2.05005,-4.80974 0.0158,-0.80162 -1.89236,-48.33397 -1.89236,-48.33397 z"
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#path1310" />
+    <rect
+       style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       id="button0"
+       width="21.618355"
+       height="54.844131"
+       x="-288.2897"
+       y="458.7883"
+       rx="10.20224"
+       ry="9.3806696"
+       inkscape:label="#rect932"
+       transform="scale(-1,1)" />
+    <path
+       sodipodi:nodetypes="ccccccccccc"
+       inkscape:connector-curvature="0"
+       id="button1"
+       d="m 348.93916,572.45034 c -0.55088,2.3786 -2.02369,4.23561 -5.30087,5.25105 l -65.10412,-0.0533 -0.056,-61.16607 c 6.69027,-0.62851 12.7931,-2.33598 13.40584,-12.8421 l 0.11678,-35.30516 c -0.67751,-4.76842 -1.92823,-11.08275 -13.43942,-12.70653 l -0.11153,-41.76267 c 28.32131,1.35252 61.44583,12.93152 79.04493,36.21112 -0.49018,45.87326 -3.70717,82.71393 -8.55561,122.37369 z"
+       style="fill:#e6e6e4;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#path1314" />
+    <path
+       style="fill:#e6e6e4;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 206.00299,572.3517 c 0.55088,2.3786 2.02369,4.23561 5.30087,5.25105 l 65.10412,-0.0533 -0.0153,-61.06743 c -6.69027,-0.62851 -12.72181,-2.43462 -13.33455,-12.94074 l -0.11678,-35.30516 c 0.67751,-4.76842 2.20116,-11.4932 13.43942,-12.70653 l 0.11153,-41.76267 c -28.7246,1.50375 -63.81513,13.58686 -79.04493,35.85825 0.49018,45.87326 3.70717,83.0668 8.55561,122.72656 z"
+       id="button2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc"
+       inkscape:label="#path1316" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       inkscape:connector-curvature="0"
+       id="path1318"
+       d="m 360.53959,454.98488 c 0.43129,16.08426 -0.23059,32.16852 -1.31311,48.25278 -2.19193,26.2623 -4.67884,48.98479 -7.12913,72.1468 -1.46408,3.93001 -3.86084,5.76149 -6.84397,6.27364 -43.14472,-1.05018 -87.90934,-1.3804 -135.88124,-0.28516 -2.36085,-0.76628 -4.72268,-1.52623 -6.5588,-5.70331 -2.11905,-20.75413 -4.2381,-39.15076 -6.35715,-65.36609 -1.04644,-16.292 -1.64275,-37.04208 -2.17067,-55.11612"
+       style="fill:none;stroke:#babdb6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <g
+       transform="translate(0.23449552,400.00009)"
+       style="display:inline"
+       id="led0">
+      <g
+         transform="translate(427.72943,-408.9487)"
+         id="g1304"
+         style="display:inline">
+        <ellipse
+           style="fill:#babdb6;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+           id="ellipse1298"
+           cx="-150.51967"
+           cy="622.58923"
+           rx="1.8137393"
+           ry="1.9375004" />
+        <ellipse
+           ry="1.9375004"
+           rx="1.8137393"
+           cy="610.96423"
+           cx="-150.51967"
+           id="ellipse1300"
+           style="fill:#babdb6;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none" />
+        <ellipse
+           style="fill:#babdb6;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none"
+           id="ellipse1302"
+           cx="-150.51967"
+           cy="599.15173"
+           rx="1.8137393"
+           ry="1.9375004" />
+      </g>
+      <path
+         style="color:#000000;display:inline;overflow:visible;vector-effect:none;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:10;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="led0-3"
+         sodipodi:type="arc"
+         sodipodi:cx="-284.0806"
+         sodipodi:cy="277.20975"
+         sodipodi:rx="19.936752"
+         sodipodi:ry="19.936752"
+         sodipodi:start="0.78539816"
+         sodipodi:end="5.4977871"
+         sodipodi:arc-type="arc"
+         d="m -269.98318,291.30716 a 19.936752,19.936752 0 0 1 -28.19483,0 19.936752,19.936752 0 0 1 0,-28.19483 19.936752,19.936752 0 0 1 28.19483,0"
+         sodipodi:open="true"
+         transform="rotate(-90)"
+         inkscape:label="#path883" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-68.791597,5.973336)">
+    <g
+       id="button0-path"
+       inkscape:label="#button0-path">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path960"
+         d="m 485.19274,86.21028 -207.71221,10e-7"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="82.710281"
+         x="273.98053"
+         height="6.999999"
+         width="6.999999"
+         id="rect970"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect871"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button0-leader"
+         width="1"
+         height="1"
+         x="485"
+         y="85.710289" />
+    </g>
+    <g
+       id="button4-path"
+       inkscape:label="#g979">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path964"
+         d="m 186.12905,161.04893 -116.990518,0.0625"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         transform="scale(-1,1)"
+         inkscape:label="#rect875"
+         style="color:#000000;text-align:end;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994;stroke-linecap:round"
+         id="button4-leader"
+         width="0.32565016"
+         height="1"
+         x="-69.138535"
+         y="160.58018" />
+      <rect
+         transform="scale(-1,1)"
+         y="157.58018"
+         x="-189.79312"
+         height="6.999999"
+         width="6.999999"
+         id="rect974"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+    <g
+       id="button3-path"
+       inkscape:label="#g984">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 187.9817,205.35644 H 69.129695"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         transform="scale(-1,1)"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="-191.91962"
+         y="201.85645" />
+      <rect
+         transform="scale(-1,1)"
+         y="204.85645"
+         x="-69.1297"
+         height="1"
+         width="0.32190493"
+         id="button3-leader"
+         style="color:#000000;text-align:end;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       id="button1-path"
+       inkscape:label="#button1-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 316.65466,47.839954 25.8491,-28.270742 H 485"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="485"
+         y="19.069216" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="313.15466"
+         y="44.339954" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="#g974">
+      <rect
+         transform="scale(-1,1)"
+         inkscape:label="#rect869"
+         y="19.069212"
+         x="-69.800262"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:end;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1398"
+         d="M 237.81014,47.839954 211.96104,19.569212 H 69.464797"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect910"
+         width="6.999999"
+         height="6.999999"
+         x="234.31013"
+         y="44.339954" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     style="display:inline"
+     transform="translate(-68.791597,5.973336)">
+    <g
+       id="led0-path">
+      <path
+         inkscape:connector-curvature="0"
+         id="path877"
+         d="m 484.99999,289.92309 -182.37295,10e-6"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="286.4231"
+         x="299.12704"
+         height="6.999999"
+         width="6.999999"
+         id="rect879"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect881"
+         y="289.4231"
+         x="485"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/logitech-g-pro.svg
+++ b/data/svgs/logitech-g-pro.svg
@@ -1,0 +1,416 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="417.20001"
+   height="407.25"
+   viewBox="0 0 417.20001 407.24999"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.2 2405546, 2018-03-11"
+   sodipodi:docname="logitech-g-pro.svg"
+   inkscape:export-filename="/home/jimmac/logitech-g-pro.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs2">
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4193"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4185"
+       is_visible="true" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.99408785"
+     inkscape:cx="119.04209"
+     inkscape:cy="99.169501"
+     inkscape:document-units="px"
+     inkscape:current-layer="Buttons"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="false"
+     showguides="true"
+     inkscape:window-width="960"
+     inkscape:window-height="1016"
+     inkscape:window-x="960"
+     inkscape:window-y="27"
+     inkscape:window-maximized="0"
+     fit-margin-top="20"
+     fit-margin-left="20"
+     fit-margin-bottom="20"
+     fit-margin-right="0"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     objecttolerance="10"
+     gridtolerance="10"
+     inkscape:snap-global="true"
+     inkscape:snap-object-midpoints="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid956"
+       originx="-68.791593"
+       originy="1.2767161" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     transform="translate(-68.791597,-394.02675)"
+     style="display:inline">
+    <path
+       transform="translate(0,400.00009)"
+       inkscape:connector-curvature="0"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 266.16642,15.04496 c -22.92467,4.66104 -61.30054,24.9861 -69.63884,36.00461 -12.61957,47.68515 -14.80528,106.34213 -15.92423,155.87459 -2.00552,88.77814 32.07323,172.95939 100.58708,173.36506 46.62862,0.10701 67.422,-29.01299 84.50986,-68.69579 14.62944,-39.36304 14.98472,-73.16931 15.71414,-103.07446 0.40991,-66.33641 -5.20115,-105.262 -13.70975,-157.25734 C 354.76319,35.15715 299.72236,14.28047 297.61469,15.04496 v 5.05311 h -3.45953 v -5.05311 l -25.2862,3.5e-4 v 5.05276 l -2.70254,-10e-6 z"
+       id="path870"
+       sodipodi:nodetypes="ccscccccccccccc" />
+    <path
+       style="display:inline;fill:#989896;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 229.17383,21.009766 c -0.16635,-0.01757 -0.2857,-0.01608 -0.35156,0.0078 v 5.054688 h -3.45899 v -5.054688 l -25.28516,0.002 v 5.052735 H 197.375 v -5.054688 c -22.92467,4.66104 -61.30037,24.987349 -69.63867,36.00586 -11.37711,42.990297 -14.261,94.837567 -15.54102,140.937497 l 0.002,0.002 82.08984,-38.08008 c -0.097,0.0416 -1.55299,19.69858 16.98437,19.22852 18.53736,-0.47006 17.52732,-19.05273 17.55079,-19.06055 l 83.70898,37.93164 0.0488,-0.0996 C 312.02168,141.36823 306.68242,104.71806 298.91211,57.234375 286.37504,41.63316 234.33067,21.554483 229.17383,21.009766 Z"
+       id="path1006"
+       inkscape:connector-curvature="0"
+       transform="translate(68.791597,394.02675)" />
+    <path
+       transform="translate(0,400.00009)"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:1.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 266.16185,15.045758 c -18.53203,3.769004 -47.15067,17.769904 -61.84571,28.81836 -11.15926,49.01809 -14.18353,94.599442 -16.57028,140.693352 l 75.52927,-35.0039 2.89062,-129.455077 h -0.004 z"
+       id="button0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc"
+       inkscape:label="#button0" />
+    <path
+       style="display:inline;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 132.05273,52.619141 c -1.82879,1.575925 -3.29915,3.06006 -4.3164,4.404297 -11.02439,41.657485 -14.08583,91.685452 -15.42969,136.691402 l 0.0527,-0.0137 3.71874,-1.73242 c 1.00541,-44.43893 6.38155,-97.490788 15.99415,-139.328125 0.001,-0.0054 -0.0176,-0.01533 -0.0195,-0.02148 z"
+       id="path1008"
+       inkscape:connector-curvature="0"
+       transform="translate(68.791597,394.02675)" />
+    <rect
+       transform="translate(0,400.00009)"
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect985"
+       width="25.286205"
+       height="35.886375"
+       x="268.86896"
+       y="15.044975"
+       rx="0"
+       ry="0" />
+    <path
+       transform="translate(0,400.00009)"
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 267.69435,112.88968 25.82029,0.0837 0.40098,45.62246 c -3.09214,13.17174 -23.47755,15.50099 -27.35134,0 z"
+       id="rect1003"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       transform="translate(0,400.00009)"
+       inkscape:label="#button5"
+       ry="5.2884812"
+       rx="6.152226"
+       y="132.22084"
+       x="273.28256"
+       height="31.288317"
+       width="13.468106"
+       id="button5"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:0.99999988;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    <path
+       style="display:inline;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 294.34961,52.697266 c 7.67404,38.319455 12.12064,93.009104 13.58789,139.437504 l 4.29102,2.33203 0.31445,0.13867 c -0.72941,-54.66832 -6.01154,-90.81008 -13.63086,-137.371095 -1.18866,-1.479179 -2.73716,-2.997879 -4.5625,-4.537109 z"
+       id="path1010"
+       inkscape:connector-curvature="0"
+       transform="translate(68.791597,394.02675)" />
+    <path
+       transform="translate(0,400.00009)"
+       inkscape:connector-curvature="0"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:1.5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 297.61497,15.045758 v 5.052735 h -0.004 c -0.072,38.851502 0.17641,91.903097 0.004,129.455077 l 76.24024,35.0039 C 371.4683,138.46428 370.62141,92.883297 359.46263,43.866071 348.69198,36.04897 332.00497,28.07624 318.64622,22.491071 307.62271,18.054789 298.7509,15.065752 297.61497,15.045758 Z"
+       id="button1" />
+    <rect
+       transform="translate(0,400.00009)"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       id="button2"
+       width="21.314863"
+       height="55.109035"
+       x="270.83594"
+       y="53.880791"
+       rx="10.657432"
+       ry="11.054664"
+       inkscape:label="#button2" />
+    <path
+       transform="translate(0,400.00009)"
+       inkscape:connector-curvature="0"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 183.47044,134.90318 -3.23828,3.46679 -2.36328,40.83203 3.375,2.76368 c 0.0158,-0.0318 0.0292,-0.0639 0.0449,-0.0957 0.4971,-15.01188 1.2161,-30.49256 2.37305,-45.99218 -0.0654,-0.32133 -0.12562,-0.6554 -0.19141,-0.97461 z"
+       id="button4" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:10;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="led0"
+       sodipodi:type="arc"
+       sodipodi:cx="-328.60678"
+       sodipodi:cy="280.97754"
+       sodipodi:rx="13.376111"
+       sodipodi:ry="13.525835"
+       sodipodi:start="0.78539816"
+       sodipodi:end="5.4977871"
+       sodipodi:arc-type="arc"
+       d="m -319.14844,290.54175 a 13.376111,13.525835 0 0 1 -18.91668,0 13.376111,13.525835 0 0 1 0,-19.12842 13.376111,13.525835 0 0 1 18.91668,0"
+       sodipodi:open="true"
+       transform="rotate(-90,200.00004,200.00004)"
+       inkscape:label="#led0" />
+    <path
+       transform="translate(0,400.00009)"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 180.98802,191.98911 -3.65625,3.90235 0.70171,41.21448 3.55024,4.1781 c -0.0255,-0.32903 -0.0218,-0.78636 -0.0254,-1.21094 -0.88777,-10.87151 -1.20752,-21.97334 -0.95508,-33.14844 0.11017,-4.87659 0.24499,-9.90124 0.38477,-14.93555 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccsc" />
+    <path
+       transform="translate(0,400.00009)"
+       sodipodi:nodetypes="ccccsccsccccc"
+       id="led1"
+       d="m 381.38813,191.93864 c 0.0522,5.34015 0.0617,10.85826 0.0263,16.58033 -0.72942,29.90515 -1.0847,63.71142 -15.71414,103.07446 -17.08786,39.6828 -37.88124,68.8028 -84.50986,68.69579 -68.51385,-0.40567 -102.5926,-84.58692 -100.58708,-173.36506 0.11095,-4.91156 0.2425,-9.86517 0.38356,-14.93656 l 2.19839,0.0215 c -0.13796,4.95985 -0.26661,11.86142 -0.37513,16.66495 -1.96142,86.82554 31.36807,166.8792 98.37558,167.27594 45.60344,0.10466 65.93966,-26.09877 82.65183,-64.90878 14.30779,-38.49728 14.65526,-71.56001 15.36865,-100.80742 0.0346,-5.59622 0.0253,-13.00199 -0.0257,-18.22469 z"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#babdb6;fill-opacity:1;stroke:#babdb6;stroke-width:1.5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:connector-curvature="0"
+       inkscape:label="#led1" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-68.791597,5.973336)">
+    <g
+       id="button4-path">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path964"
+         d="M 69.397827,158.3947 H 177.72623"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect875"
+         style="color:#000000;text-align:end;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button4-leader"
+         width="1"
+         height="1"
+         x="68.806679"
+         y="157.8947" />
+      <rect
+         y="154.8947"
+         x="174.22623"
+         height="6.999999"
+         width="6.999999"
+         id="rect974"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+    <g
+       id="button3-path">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 69.516354,216.62752 H 176.10094"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="216.12752"
+         x="68.814278"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:end;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="172.60094"
+         y="213.12752" />
+    </g>
+    <g
+       id="button5-path">
+      <rect
+         y="147.48535"
+         x="485"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+      <path
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 484.55132,147.9915 H 280.86242"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="276.5166"
+         y="144.36501" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="#g997">
+      <rect
+         inkscape:label="#rect869"
+         y="80.93531"
+         x="485"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+      <path
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 281.49336,81.435307 203.01408,2e-6"
+         id="path908"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect910"
+         width="6.999999"
+         height="6.999999"
+         x="277.99338"
+         y="77.935318" />
+    </g>
+    <g
+       id="button1-path"
+       inkscape:label="#g1002"
+       transform="translate(0,-11.999703)">
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="485"
+         y="52.581367" />
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 329.18291,53.081369 H 485.00002"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="325.29486"
+         y="49.581367" />
+    </g>
+    <g
+       id="button0-path"
+       inkscape:label="#button0-path">
+      <rect
+         inkscape:label="#rect871"
+         style="color:#000000;text-align:end;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button0-leader"
+         width="1"
+         height="1"
+         x="68.718681"
+         y="52.581367" />
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path960"
+         d="m 236.34967,53.081367 -166.192195,2e-6"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="49.581367"
+         x="232.84967"
+         height="6.999999"
+         width="6.999999"
+         id="rect970"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     style="display:inline"
+     transform="translate(-68.791597,5.973336)">
+    <g
+       id="led0-path">
+      <path
+         inkscape:connector-curvature="0"
+         id="path877"
+         d="M 485,329.52026 H 281.05416"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="326.02026"
+         x="277.47754"
+         height="6.999999"
+         width="6.999999"
+         id="rect879"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect881"
+         y="329.02026"
+         x="485"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+    <g
+       id="led1-path">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 484.99745,272.95285 H 379.23883"
+         id="path4525"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;text-align:start;display:inline;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="led1-leader"
+         width="1"
+         height="1"
+         x="485"
+         y="272.45285"
+         inkscape:label="#rect881" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect4544"
+         width="6.999999"
+         height="6.999999"
+         x="375.73883"
+         y="269.45285" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/logitech-g102-g203.svg
+++ b/data/svgs/logitech-g102-g203.svg
@@ -1,0 +1,1 @@
+logitech-g-pro.svg

--- a/data/svgs/logitech-g300.svg
+++ b/data/svgs/logitech-g300.svg
@@ -1,0 +1,514 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="490"
+   height="490"
+   viewBox="0 0 129.64583 129.64583"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="logitech-g300.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="202.78034"
+     inkscape:cy="279.63686"
+     inkscape:document-units="px"
+     inkscape:current-layer="LEDs"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     showguides="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1163"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showborder="true"
+     inkscape:guide-bbox="true"
+     units="px"
+     inkscape:snap-global="false"
+     inkscape:measure-start="200.26,379.645"
+     inkscape:measure-end="199.294,334.274">
+    <inkscape:grid
+       type="xygrid"
+       id="grid78" />
+    <sodipodi:guide
+       position="58.722772,112.40709"
+       orientation="0,1"
+       id="guide79"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="39.611923,100.54373"
+       orientation="0,1"
+       id="guide81"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="51.756014,88.614617"
+       orientation="0,1"
+       id="guide83"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="57.778386,76.729167"
+       orientation="0,1"
+       id="guide85"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="45.047078,64.795712"
+       orientation="0,1"
+       inkscape:locked="false"
+       id="guide87" />
+    <sodipodi:guide
+       position="57.646696,52.899321"
+       orientation="0,1"
+       id="guide89"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline;opacity:1"
+     transform="translate(0,-167.35416)">
+    <path
+       id="path41-6"
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:0.98645592;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 64.822903,179.22931 h -3.479995 l -3.915,-6.09 c 0,0 -11.305381,-0.13059 -17.399991,5.22 0,0 -8.990317,5.04814 -8.69995,26.96998 0,0 -0.262683,13.22939 2.609964,26.96999 -8.15696,17.08865 -6.959951,19.57498 -6.959951,19.57498 3.486257,28.75756 24.359929,38.27998 24.359929,38.27998 4.318847,1.41447 22.65114,1.41447 26.969986,0 0,0 20.873694,-9.52242 24.359955,-38.27998 0,0 1.19699,-2.48633 -6.959957,-19.57498 2.87265,-13.7406 2.609996,-26.96999 2.609996,-26.96999 0.290352,-21.92184 -8.700007,-26.96998 -8.700007,-26.96998 -6.094602,-5.35059 -17.399985,-5.22 -17.399985,-5.22 l -3.914995,6.09 h -3.479999"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccc" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.61653525;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 55.252905,176.68083 4.35,6.95997 h 10.439993 l 4.349999,-6.95997 c 0,0 4.713304,-0.60703 13.049968,4.34999 0,0 5.4795,2.46746 6.960015,18.26998 0,0 0.682398,10.45737 -0.869997,20.88 -6.631477,30.71466 -9.233113,35.45823 -12.179994,44.36996 -0.0055,0.3105 -0.606568,3.30574 -2.609998,12.17998 0,0 -1.945797,7.04942 -13.919989,6.96001 -13.44865,0.0748 -13.919991,-6.96001 -13.919991,-6.96001 -1.238296,-8.85308 -14.879861,-47.03985 -14.789987,-56.54994 0,0 -1.799981,-15.15662 -0.869993,-20.88 0,0 1.16252,-13.31705 6.089986,-18.26998 8.388589,-5.24851 13.919988,-4.34999 13.919988,-4.34999 z"
+       id="path4607"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccc" />
+    <path
+       style="fill:none;stroke:#babdb6;stroke-width:0.61653525;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 64.822903,183.6408 c -0.06118,25.29724 0,55.68 0,55.68 v 0"
+       id="path4530"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="display:inline;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.61653525;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 93.967914,196.69083 c 0,0 -3.141541,-12.93515 -4.350032,-13.05003 -2.701088,1.93408 -2.614239,2.22922 -4.349992,4.35002 2.394025,7.89236 3.479995,9.57001 3.479995,9.57001 z"
+       id="button6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#path4541-3" />
+    <rect
+       style="fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.61653525;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="button2"
+       width="8.6999846"
+       height="14.789989"
+       x="60.472919"
+       y="189.29581"
+       ry="3.9149992"
+       inkscape:label="#rect4615" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.61653525;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 44.286958,270.37954 c -1.184921,4.53183 -5.479801,5.02739 -9.331541,1.1532 -3.062052,-4.76909 -6.934437,-16.17092 -6.816123,-19.86098 0.118269,-3.69003 1.372851,-5.59065 5.281209,-14.91112 1.954179,-4.66034 1.9368,-3.20903 2.958075,0.49871 1.190396,4.32175 9.093304,28.58842 7.90838,33.12019 z"
+       id="path4617"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="zczssz" />
+    <path
+       sodipodi:type="arc"
+       style="display:inline;fill:none;fill-opacity:0.39215686;stroke:#babdb6;stroke-width:2.08971024;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="led0-5"
+       sodipodi:cx="64.773148"
+       sodipodi:cy="257.64056"
+       sodipodi:rx="3.7614744"
+       sodipodi:ry="3.7614779"
+       d="m 67.432912,254.9808 a 3.7614744,3.7614779 0 0 1 0,5.31953 3.7614744,3.7614779 0 0 1 -5.319528,0 3.7614744,3.7614779 0 0 1 -1e-6,-5.31953"
+       sodipodi:start="5.4977871"
+       sodipodi:end="3.9269907"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc" />
+    <path
+       style="display:inline;opacity:1;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.61653525;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 85.335258,270.71558 c 1.18491,4.53186 5.479785,5.02738 9.331555,1.15324 3.062033,-4.76913 6.934417,-16.17102 6.816127,-19.86101 -0.11829,-3.69003 -1.37286,-5.59071 -5.281228,-14.91121 -1.95418,-4.66025 -1.936795,-3.20892 -2.95807,0.49877 -1.190396,4.32176 -9.093291,28.58839 -7.908384,33.12021 z"
+       id="path4617-5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="zczssz" />
+    <path
+       style="display:inline;opacity:1;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.61653525;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 93.967914,214.09081 c 0.815935,-16.75448 0,-17.39998 0,-17.39998 l -5.220029,0.87 c 0,0 0.239252,0.36327 -0.870008,12.17998 6.651607,6.71191 6.090037,4.35 6.090037,4.35 z"
+       id="button5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#path4541-3-3" />
+    <path
+       style="display:inline;opacity:1;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.61653525;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 35.737567,196.69083 c 0,0 3.141541,-12.93515 4.350032,-13.05003 2.701088,1.93408 2.614239,2.22922 4.349992,4.35002 -2.394025,7.89236 -3.479995,9.57001 -3.479995,9.57001 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#path4541-3-5" />
+    <path
+       style="display:inline;opacity:1;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.61653525;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 35.737567,214.09081 c -0.815935,-16.75448 0,-17.39998 0,-17.39998 l 5.220029,0.87 c 0,0 -0.239252,0.36327 0.870008,12.17998 -6.651607,6.71191 -6.090037,4.35 -6.090037,4.35 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#path4541-3-3-6" />
+    <path
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:0.61653525;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 60.426305,217.35644 v -6.74249 c -0.01103,-1.73802 1.304999,-1.74 1.304999,-1.74 h 6.089995 c 0,0 1.352705,0.0157 1.304999,1.74 v 6.74249 z"
+       id="button8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc"
+       inkscape:label="#path4589-9" />
+    <path
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:0.61653525;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 60.426305,217.35644 v 6.74249 c -0.01103,1.73802 1.304999,1.74 1.304999,1.74 H 67.8213 c 0,0 1.352705,-0.0157 1.304998,-1.74 v -6.74249 z"
+       id="button7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc"
+       inkscape:label="#path4589-9-1" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 46.143947,189.21374 -3.642001,8.50625 1.101002,10.95189 16.221334,-7.70159 -0.921076,-16.08486 z"
+       id="button0"
+       inkscape:connector-curvature="0"
+       inkscape:label="#path3664"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 70.954987,185.09032 -1.109402,16.05391 16.940367,7.82608 0.477526,-11.0865 -3.352352,-9.32016 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       inkscape:label="#path4486"
+       sodipodi:nodetypes="cccccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(-0.28471359,0,0,-0.26458333,70.320391,74.101432)"
+       style="display:inline;opacity:1"
+       id="button4-path"
+       inkscape:label="#g151">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path964"
+         d="m 109.31232,181.51438 38.69266,43.39973 h 98.98144"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect875"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button4-leader"
+         width="1"
+         height="1"
+         x="245.98642"
+         y="223.91411" />
+      <rect
+         y="177"
+         x="105"
+         height="6.999999"
+         width="6.999999"
+         id="rect974"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+    <g
+       transform="matrix(-0.30394757,0,0,0.26458333,100.78231,-2.4556928)"
+       style="display:inline"
+       id="button0-path"
+       inkscape:label="#g141">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path960"
+         d="m 331.57794,109.27355 -66.76739,-0.0347 -34.51493,21.26646 h -68.95164"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="127.00576"
+         x="157"
+         height="6.999999"
+         width="6.999999"
+         id="rect970"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect871"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button0-leader"
+         width="1"
+         height="1"
+         x="330.57794"
+         y="108.28136" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.19679,-27.761975)"
+       style="display:inline"
+       id="button3-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 114.17805,250.50576 125.44617,0.0352"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="108"
+         y="247.00577" />
+      <rect
+         y="250.00575"
+         x="238.62422"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,40.502648,-6.6313911)"
+       style="display:inline"
+       id="button5-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 336.91912,170.14213 -143.57514,0.36405"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="189"
+         y="167" />
+      <rect
+         y="169.75269"
+         x="336.91913"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(-0.2847136,0,0,0.26458333,87.493539,-7.2646706)"
+       style="display:inline;opacity:1"
+       id="button2-path"
+       inkscape:label="#g151">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path964-6"
+         d="m 79.210952,148.6933 62.691188,68.76371 165.40155,1e-5"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect875"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button2-leader"
+         width="1"
+         height="1"
+         x="306.30368"
+         y="216.45702" />
+      <rect
+         y="145.19263"
+         x="76.187187"
+         height="6.999999"
+         width="6.999999"
+         id="rect974-5"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,13.746167,11.443545)"
+       style="display:inline"
+       id="button7-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 438.04598,191.7488 H 219.48839 l -26.14441,-21.24262"
+         id="path51-1-9-6-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-2-3-2-7"
+         width="6.999999"
+         height="6.999999"
+         x="189"
+         y="167" />
+      <rect
+         y="191.3428"
+         x="438.04599"
+         height="1"
+         width="1"
+         id="button7-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,13.746167,3.106915)"
+       style="display:inline"
+       id="button8-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 438.04598,178.25732 H 203.75439 l -10.41041,-7.75114"
+         id="path51-1-9-6-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-2-3-2-2"
+         width="6.999999"
+         height="6.999999"
+         x="189"
+         y="167" />
+      <rect
+         y="177.79317"
+         x="438.04599"
+         height="1"
+         width="1"
+         id="button8-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(0.2847136,0,0,-0.26458333,59.129968,74.101431)"
+       style="display:inline;opacity:1"
+       id="button6-path"
+       inkscape:label="#g151">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path964-67"
+         d="m 109.31232,181.51438 38.69266,43.39973 h 99.66799"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect875"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button6-leader"
+         width="1"
+         height="1"
+         x="247.67297"
+         y="223.9144" />
+      <rect
+         y="177"
+         x="105"
+         height="6.999999"
+         width="6.999999"
+         id="rect974-3"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+    <g
+       transform="matrix(0.30394757,0,0,0.26458333,28.636101,-2.4556931)"
+       style="display:inline"
+       id="button1-path"
+       inkscape:label="#g141">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path960-6"
+         d="m 332.32616,109.27355 -67.51561,-0.0347 -34.51493,21.26646 h -68.95164"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="127.00576"
+         x="157"
+         height="6.999999"
+         width="6.999999"
+         id="rect970-2"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect871"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="332.32617"
+         y="109.27355" />
+    </g>
+    <g
+       id="led0"
+       inkscape:label="#g4411"
+       style="fill:#eeee35;fill-opacity:1">
+      <g
+         id="g4457">
+        <path
+           id="led0-0"
+           style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#eeeeec;fill-opacity:1;stroke:none;stroke-width:0.28991818;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="M 36.851726,81.915105 C 41.99239,103.21594 40.604019,101.71476 43.62439,106.21567 44.61563,98.208963 38.156084,80.727537 35.152327,69.797094 Z"
+           inkscape:label="#path5630"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+        <path
+           id="led0-1"
+           style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#eeeeec;fill-opacity:1;stroke:none;stroke-width:0.28991818;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="M 93.039402,81.561768 C 87.898738,102.8626 89.287109,101.36142 86.266738,105.86233 85.275498,97.855627 91.735044,80.3742 94.738801,69.443757 Z"
+           inkscape:label="#path5630"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccc" />
+      </g>
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       style="display:inline"
+       id="led0-path"
+       inkscape:label="#g161"
+       transform="matrix(0.26458333,0,0,0.26458333,38.838972,19.46058)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path877"
+         d="M 343.20703,290.50577 H 208.64438 l -18.97696,-18.97696"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         y="269.96875"
+         x="188.28125"
+         height="6.999999"
+         width="6.999999"
+         id="rect879"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect881"
+         y="290.00577"
+         x="343.20703"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/logitech-g303.svg
+++ b/data/svgs/logitech-g303.svg
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="417.20001"
+   height="407.25"
+   viewBox="0 0 417.20001 407.24999"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="logitech-g303.svg"
+   inkscape:export-filename="/home/jimmac/logitech-g403.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs2">
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4193"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4185"
+       is_visible="true" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="21.208975"
+     inkscape:cy="195.5613"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="false"
+     showguides="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1101"
+     inkscape:window-x="1920"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     fit-margin-top="20"
+     fit-margin-left="20"
+     fit-margin-bottom="20"
+     fit-margin-right="0"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     objecttolerance="10"
+     gridtolerance="10">
+    <inkscape:grid
+       type="xygrid"
+       id="grid956"
+       originx="-68.791593"
+       originy="1.2767161" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     transform="translate(-68.791597,-394.02675)"
+     style="display:inline">
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;overflow:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 183.34499,416.02062 c -24.661,4.08226 -49.92333,21.30746 -57.18502,32.68484 -8.18178,12.81894 -33.473053,116.65587 -34.496301,163.9888 15.773271,86.16472 55.738681,146.5572 61.556861,154.99421 4.70624,6.82458 9.70825,11.92177 42.30188,12.39158 32.59363,0.46981 37.71496,-5.68647 43.38814,-11.32031 4.79276,-4.75952 54.85052,-92.05678 61.98662,-153.22394 -1.55176,-67.0395 -18.56389,-150.61293 -30.38133,-163.10122 -11.79119,-12.46055 -51.83653,-36.40671 -54.76015,-36.45817 l 0,7.19061 -32.4107,0 z"
+       id="path870"
+       sodipodi:nodetypes="cscssscscccc" />
+    <path
+       sodipodi:nodetypes="cc"
+       inkscape:connector-curvature="0"
+       id="path5040"
+       d="m 92.50792,592.62443 c 17.91963,82.02052 35.18878,118.28381 72.23883,184.44829"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#bfc2bb;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 216.16981,422.85766 -2.60225,201.6236 c -0.0907,7.03035 -6.07063,10.44123 -13.61129,10.44123 -7.54065,0 -13.50652,-3.41107 -13.61128,-10.44123 l -3,-201.31424 z"
+       id="rect913"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscc" />
+    <rect
+       style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       id="button2"
+       width="23.15593"
+       height="57.717773"
+       x="188.55382"
+       y="469.01868"
+       rx="11.577965"
+       ry="11.577967"
+       inkscape:label="#rect932" />
+    <path
+       sodipodi:nodetypes="cssscc"
+       inkscape:connector-curvature="0"
+       id="button5"
+       d="m 209.20722,547.47605 -0.65676,37.92859 c -0.0779,4.49803 -3.83301,8.12045 -8.59419,8.12045 -4.76117,0 -8.51628,-3.62242 -8.59417,-8.12045 l -0.65677,-37.92859 z"
+       style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:label="#path942" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:10;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="led0"
+       sodipodi:type="arc"
+       sodipodi:cx="-729.17651"
+       sodipodi:cy="199.82953"
+       sodipodi:rx="13.376111"
+       sodipodi:ry="13.525835"
+       sodipodi:start="0.78539816"
+       sodipodi:end="5.4977871"
+       sodipodi:arc-type="arc"
+       d="m -719.71817,209.39374 a 13.376111,13.525835 0 0 1 -18.91668,0 13.376111,13.525835 0 0 1 0,-19.12842 13.376111,13.525835 0 0 1 18.91667,0"
+       sodipodi:open="true"
+       transform="matrix(0,-1,1,0,0,0)"
+       inkscape:label="#path883" />
+    <path
+       id="button1"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:3;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="M 298.92308,580.98137 C 293.8094,522.57046 280.3602,462.83778 270.51584,452.43458 258.72465,439.97403 218.67931,416.02787 215.75569,415.97641 l -0.003,7.2085 -0.50645,110.06055 83.95322,47.95787"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscccc"
+       inkscape:label="#path4278" />
+    <path
+       id="button0"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 115.69423,138.97706 -1.12358,-110.662125 -0.0378,-6.147082 C 89.8643,26.095287 64.626024,43.307658 57.368373,54.67871 52.0464,63.017 39.485291,109.86559 31.072821,154.624 c -1.978688,10.52757 -3.72786,20.93951 -5.142655,31.38156 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsccc"
+       transform="translate(68.791597,394.02675)"
+       inkscape:label="#path4256" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#bfc2bb;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="M 299.98341,585.82953 C 288.7813,671.38558 244.14684,741.20584 228.31,776.96473"
+       id="path5042"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       sodipodi:nodetypes="cscssscscccc"
+       id="path5016"
+       d="m 183.34499,416.02062 c -24.661,4.08226 -49.92333,21.30746 -57.18502,32.68484 -8.18178,12.81894 -33.47305,116.65587 -34.4963,163.9888 15.77327,86.16472 55.73868,146.5572 61.55686,154.99421 4.70624,6.82458 9.70825,11.92177 42.30188,12.39158 32.59363,0.46981 37.71496,-5.68647 43.38814,-11.32031 4.79276,-4.75952 54.85052,-92.05678 61.98662,-153.22394 -1.55176,-67.0395 -18.56389,-150.61293 -30.38133,-163.10122 -11.79119,-12.46055 -51.83653,-36.40671 -54.76015,-36.45817 l 0,7.19061 -32.4107,0 z"
+       style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 102.08895,531.68418 c 0.53723,0.0143 -0.15214,3.8319 -0.54934,6.21419 l -7.140506,42.82642 -5.16583,0.42115 8.76037,-44.50491 c 0.466456,-2.3697 1.681005,-5.02125 4.095306,-4.95685 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ssccss"
+       inkscape:label="#rect921" />
+    <path
+       inkscape:label="#path924"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 92.206722,591.3329 c 2.40195,-0.25239 2.836696,1.11858 3.023443,3.52652 l 3.57032,46.03607 c 0.186747,2.40794 -0.771034,3.65494 -3.172974,3.90732 -2.40195,0.25238 -6.087456,-7.10638 -6.124623,-9.52127 l -0.504216,-32.76168 c -0.03717,-2.41488 0.8061,-10.93458 3.20805,-11.18696 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssss" />
+    <path
+       id="led1"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 29.707031,242.95703 c 17.947503,72.58734 50.782189,122.34942 55.957031,129.85352 2.115971,3.06841 4.009169,5.50137 8.642579,7.49023 C 59.190137,317.56953 43.428144,284.03672 27.683594,216.87891 l 2.023437,26.07812 z M 229.75195,201.85742 c -14.69885,84.15847 -52.92757,142.415 -68.74414,178.1543 3.74134,-1.87015 5.74151,-4.04661 8.05469,-6.34375 0.24888,-0.24715 1.70524,-2.23579 3.5293,-5.16992 1.82406,-2.93413 4.19179,-6.95551 6.92187,-11.84375 5.46015,-9.77649 12.37582,-23.01815 19.36133,-38.01368 13.95635,-29.95956 28.17703,-66.96234 31.72656,-97.20898 -0.14948,-6.39067 -0.43956,-12.93267 -0.84961,-19.57422 z"
+       inkscape:label="#path5630"
+       inkscape:connector-curvature="0"
+       transform="translate(68.791597,394.02675)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-68.791597,5.973336)">
+    <g
+       id="button1-path"
+       inkscape:label="#g131"
+       transform="translate(8,-8)">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 242.94764,50.505764 234.05236,0"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="237"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="50.005764" />
+    </g>
+    <g
+       id="button0-path"
+       inkscape:label="#g141"
+       transform="translate(8,-8)">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path960"
+         d="m 477,130.50576 -327.65602,0"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="127.00576"
+         x="143"
+         height="6.999999"
+         width="6.999999"
+         id="rect970"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect871"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button0-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="130.00577" />
+    </g>
+    <g
+       id="button4-path"
+       inkscape:label="#g151"
+       transform="translate(8,-8)">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path964"
+         d="M 89.31232,181.51438 117.74787,210.44326 477,210.50576"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect875"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button4-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="210.00577" />
+      <rect
+         y="177"
+         x="85"
+         height="6.999999"
+         width="6.999999"
+         id="rect974"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="#g136"
+       transform="translate(8,-8)">
+      <rect
+         inkscape:label="#rect869"
+         y="90.00576"
+         x="477"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+      <path
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 195.97852,108.49147 17.9857,-17.98571 263.03578,0"
+         id="path908"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect910"
+         width="6.999999"
+         height="6.999999"
+         x="194"
+         y="104" />
+    </g>
+    <g
+       id="button3-path"
+       inkscape:label="#g156"
+       transform="translate(8,-8)">
+      <path
+         sodipodi:nodetypes="ccc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 88.786361,231.47803 18.999029,19.02773 369.21461,0"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="82.883881"
+         y="225.00577" />
+      <rect
+         y="250.00575"
+         x="477"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       id="button5-path"
+       inkscape:label="#g146"
+       transform="translate(8,-8)">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 476.55132,170.50615 -283.20734,0"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="189"
+         y="167" />
+      <rect
+         y="170"
+         x="477"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     style="display:inline"
+     transform="translate(-68.791597,5.973336)">
+    <g
+       id="led0-path"
+       inkscape:label="#g161"
+       transform="translate(8,56)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path877"
+         d="m 477,290.50577 -268.35562,0 -18.97696,-18.97696"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="269.96875"
+         x="188.28125"
+         height="6.999999"
+         width="6.999999"
+         id="rect879"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect881"
+         y="290.00577"
+         x="477"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+    <g
+       id="led1-path"
+       inkscape:label="#g126"
+       transform="translate(8,274)">
+      <path
+         sodipodi:nodetypes="ccc"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 476.99745,10.505764 -192.31824,0 -23.37131,23.307989"
+         id="path4525"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;text-align:start;display:inline;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="led1-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="10.005764"
+         inkscape:label="#rect881" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect4544"
+         width="6.999999"
+         height="6.999999"
+         x="257.69327"
+         y="30.345425" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/logitech-g402.svg
+++ b/data/svgs/logitech-g402.svg
@@ -1,0 +1,479 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="467.83105"
+   height="400.87393"
+   viewBox="0 0 467.83105 398.87393"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="logitech-g402.svg"
+   inkscape:export-filename="/home/daniele/Scrivania/logitech-g402.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="247.98208"
+     inkscape:cy="192.40531"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="false"
+     showguides="true"
+     inkscape:window-width="1280"
+     inkscape:window-height="992"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     fit-margin-top="20"
+     fit-margin-bottom="20"
+     fit-margin-left="0"
+     fit-margin-right="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid956"
+       originx="-16.168953"
+       originy="-1.1260801" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     transform="translate(-16.168953,-400)"
+     style="display:inline">
+    <g
+       transform="translate(-374,-4.864278e-6)"
+       id="g1170">
+      <path
+         inkscape:connector-curvature="0"
+         id="path981"
+         d="m 617.52893,453.41998 -49.99065,26.66899 c -2.22449,1.86937 -2.81832,3.35837 -3.6652,5.83317 l -15.9563,53.34684 c -0.49748,2.25523 -0.34218,3.74811 0.48513,6.46679 l 3.99946,10.9325 -3.53186,0.74244 -1.35901,12.37091 -1.50378,2.8507 2.09912,18.55549 c 0,0 -13.03638,4.81768 -18.22998,15.00854 -5.19361,10.19086 -9.29541,53.53534 -6.03613,59.82001 3.25927,6.28467 25.6018,33.9057 28.70703,40.07849 3.10522,6.17279 24.79553,45.22613 30.93054,51.77106 6.13501,6.54492 35.79895,19.27618 35.79895,19.27618 6.39358,-5.0822 15.98738,-6.80155 23.61682,-0.45557 0,0 31.72192,-10.76812 43.56091,-26.60644 11.83899,-15.83832 24.57691,-52.0235 24.57691,-52.0235 0,0 -2.04663,-1.98694 -2.04663,-9.06775 0,-7.08081 3.24377,-9.90655 3.24377,-9.90655 l -7.41565,-77.33204 c 0,0 0.90478,-68.51501 -1.01514,-76.49939 -1.57946,-6.56849 -5.90589,-29.81348 -7.88675,-38.02183 -0.42699,-1.76936 -0.95122,-1.65743 -2.07882,-3.29921 l -52.65222,-36.341 4.00378,32.1344 h -28.47082 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="ccccccccccsccsccscsccssccccc" />
+      <path
+         sodipodi:nodetypes="cccccscssccc"
+         inkscape:connector-curvature="0"
+         id="path1014"
+         d="m 648.06347,618.15601 34.51828,10.05586 c 2.62858,0.8078 3.9256,5.47034 3.9256,5.47034 l -0.44831,35.46611 23.5331,26.29168 c 0,0 -9.4414,38.41029 -27.23181,57.70209 -11.60967,12.58946 -39.46726,23.54443 -39.46726,23.54443 0,0 -4.87562,-48.51623 -9.30469,-56.255 -4.42908,-7.73877 -35.48734,-18.11903 -50.81543,-30.61249 -5.82123,-4.7447 -15.27906,-16.55719 -15.27906,-16.55719 l -4.00329,-23.86047 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         sodipodi:nodetypes="cccsc"
+         inkscape:connector-curvature="0"
+         id="path1144"
+         d="m 620.3461,775.42623 3.91771,-44.34657 c 1.3829,-6.28113 -0.99643,-10.76025 -6.48071,-12.64329 0,0 -33.9759,-17.94313 -41.16454,-25.32697 -7.18863,-7.38383 -16.89702,-24.84664 -16.89702,-24.84664"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;vector-effect:none;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:8;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="led1"
+         sodipodi:type="arc"
+         sodipodi:cx="-664.05457"
+         sodipodi:cy="598.10364"
+         sodipodi:rx="12.162673"
+         sodipodi:ry="12.162673"
+         sodipodi:start="0.78539816"
+         sodipodi:end="5.4977871"
+         sodipodi:arc-type="arc"
+         d="m -655.45426,606.70395 a 12.162673,12.162673 0 0 1 -17.20061,0 12.162673,12.162673 0 0 1 0,-17.20062 12.162673,12.162673 0 0 1 17.20061,0"
+         sodipodi:open="true"
+         transform="rotate(-90)"
+         inkscape:label="#path1012" />
+      <path
+         sodipodi:nodetypes="ccsccsc"
+         inkscape:connector-curvature="0"
+         id="path1030"
+         d="m 548.10584,591.18781 -1.39021,19.03606 c 0,0 -6.51942,1.07248 -9.54983,9.44719 -3.03041,8.37471 -8.01844,25.6823 -7.19278,55.16199 -3.80454,-3.92381 -8.20043,-7.54825 -7.93855,-14.11229 0.0565,-12.69733 0.50177,-31.56063 5.66468,-49.88965 3.26585,-11.59423 10.35698,-16.87164 20.40669,-19.6433 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button0"
+         d="m 616.72979,453.87813 -43.21475,23.25557 -2.30905,111.85791 -3.27924,2.29913 8.95587,40.68384 43.49634,-20.81641 c 0,0 -6.29272,-57.3948 -6.04248,-82.96182 0.25025,-25.56702 2.39331,-74.31822 2.39331,-74.31822 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="ccccccsc"
+         inkscape:label="#path1060" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button1"
+         d="m 641.35924,447.84438 c 0,0 6.82136,40.56938 7.71833,77.06871 0.89697,36.49932 0.60175,77.20425 0.60175,77.20425 l 43.91543,12.95245 c 0,0 2.9472,-62.03698 1.5412,-81.15454 -1.4061,-19.11755 -6.51723,-50.97735 -8.90483,-54.50845 -2.3876,-3.5311 -44.87188,-31.56242 -44.87188,-31.56242 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cscccsc"
+         inkscape:label="#path1062" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1066"
+         d="m 624.73297,570.54019 2.51941,13.45651 14.86756,-0.0507 1.26654,-13.4599 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="button2"
+         width="17.152637"
+         height="51.954956"
+         x="623.8761"
+         y="503.84464"
+         rx="8.5763187"
+         ry="8.5763187"
+         inkscape:label="#rect1068" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button7"
+         d="m 569.97595,534.59994 -16.73181,-6.63336 13.09595,-44.4487 3.95538,-3.11892 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path1098" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button6"
+         d="m 569.97595,534.59994 -15.81811,4.41446 13.12378,48.26233 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path1100" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 550.97571,556.55099 -1.73137,22.23376 c 0,0 -8.07466,-0.0385 -6.10341,-6.67814 0.79661,-2.68321 1.88213,-11.10134 3.54027,-13.80998 2.44498,-3.99399 4.29451,-1.74564 4.29451,-1.74564 z"
+         id="button5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccsc"
+         inkscape:label="#path1473" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button4"
+         d="m 553.91685,576.77039 3.78851,43.20785 -3.52893,1.40018 -4.18952,-2.67337 -1.94029,-38.13895 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cccccc"
+         inkscape:label="#path1118" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button3"
+         d="m 557.29072,626.42287 -4.13718,-0.69442 -1.90659,6.11048 8.04212,38.1661 3.30713,3.0868 4.6499,-1.78876 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path1120" />
+      <path
+         inkscape:connector-curvature="0"
+         id="led0"
+         d="m 554.07316,558.40614 18.36886,76.63506 -10.78213,5.31523 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path1122" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1138"
+         d="m 561.0357,599.31803 1.68542,4.21409 -3.19735,5.27031 -0.72068,-4.52978 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1140"
+         d="m 564.53845,610.12329 0.75,2.84987 -3.50226,8.03142 -0.75,-4.13156 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1142"
+         d="m 566.94537,619.35785 1.45849,3.46056 -4.29748,11.03294 -1.04318,-4.82295 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 608.6358,526.99557 v 7.97553 l -3.83318,-3.83321 z"
+         id="path1148"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-16.168953)">
+    <g
+       id="button0-path"
+       inkscape:label="#g442">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path954"
+         d="m 234.68702,62.49186 41.9857,-41.98571 H 483"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="62"
+         x="230"
+         height="6.999999"
+         width="6.999999"
+         id="rect952"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect865"
+         y="20"
+         x="483"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+    <g
+       id="button1-path"
+       inkscape:label="#g437">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 275.03741,60.50615 H 483.05562"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="273"
+         y="57" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="483"
+         y="60" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="#g432">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path960"
+         d="M 483.15129,100.50615 H 266.97374 l -7.07445,7.07445"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="106.05299"
+         x="254.86905"
+         height="6.999999"
+         width="6.999999"
+         id="rect970"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect869"
+         y="100"
+         x="483"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+    <g
+       id="button6-path"
+       inkscape:label="#g427">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 483,140.50615 H 189.32589"
+         id="path962"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect972"
+         width="6.999999"
+         height="6.999999"
+         x="188"
+         y="137" />
+      <rect
+         inkscape:label="#rect871"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button6-leader"
+         width="1"
+         height="1"
+         x="483"
+         y="140" />
+    </g>
+    <g
+       id="button4-path"
+       inkscape:label="#g402">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 17.16895,226.39549 151.60272,0.0884 8.22787,-9.92565"
+         id="path896"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         y="-219.98177"
+         x="-181.00188"
+         height="6.999999"
+         width="6.999999"
+         id="rect1297"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)" />
+      <rect
+         inkscape:label="#rect873"
+         y="-226.98393"
+         x="-17.168953"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+    <g
+       id="button7-path"
+       inkscape:label="#g300">
+      <rect
+         inkscape:label="#rect873"
+         y="-62.912788"
+         x="-17.168953"
+         height="1"
+         width="1"
+         id="button7-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path914"
+         d="M 17.317611,62.412787 H 178.90504 l 15.75447,23.87718"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect912"
+         width="6.999999"
+         height="6.999999"
+         x="191.28058"
+         y="85.438072" />
+    </g>
+    <g
+       id="button3-path"
+       inkscape:label="#g407">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path1295"
+         d="m 17.294405,266.46958 168.568675,0.0407"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect1301"
+         width="6.999999"
+         height="6.999999"
+         x="-191.68813"
+         y="-269.40173" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round"
+         id="button3-leader"
+         width="1.1351269"
+         height="1"
+         x="-17.294409"
+         y="-266.98993"
+         inkscape:label="#rect873" />
+    </g>
+    <g
+       id="button5-path"
+       inkscape:label="#g422">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 483.13134,180.50551 -295.64539,-0.25 -14.35505,-20.22553"
+         id="path890"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         y="-163.30751"
+         x="-175.13875"
+         height="6.999999"
+         width="6.999999"
+         id="rect894"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button5-leader"
+         width="1"
+         height="1"
+         x="-484.00677"
+         y="-181.00594"
+         inkscape:label="#rect873" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     style="display:inline"
+     transform="translate(-16.168953)">
+    <g
+       id="led0-path"
+       inkscape:label="#g417">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 191.93858,220.50615 H 483.10224"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="188"
+         y="217" />
+      <rect
+         inkscape:label="#rect875"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="led0-leader"
+         width="1"
+         height="1"
+         x="483"
+         y="220" />
+    </g>
+    <g
+       id="led1-path"
+       inkscape:label="#g412">
+      <path
+         inkscape:connector-curvature="0"
+         id="path877"
+         d="M 214.64438,260.50615 H 483"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="257"
+         x="210"
+         height="6.999999"
+         width="6.999999"
+         id="rect879"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect881"
+         y="260"
+         x="483"
+         height="1"
+         width="1"
+         id="led1-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/logitech-g403.svg
+++ b/data/svgs/logitech-g403.svg
@@ -1,0 +1,380 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="409.2084"
+   height="411.271"
+   viewBox="0 0 409.2084 411.27099"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.1 r"
+   sodipodi:docname="logitech-g403.svg"
+   inkscape:export-filename="/home/jimmac/logitech-g403.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142135"
+     inkscape:cx="223.25242"
+     inkscape:cy="156.77583"
+     inkscape:document-units="px"
+     inkscape:current-layer="LEDs"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="false"
+     showguides="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     fit-margin-top="20"
+     fit-margin-left="20"
+     fit-margin-bottom="20"
+     fit-margin-right="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid956"
+       originx="-68.791593"
+       originy="1.2767161" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     transform="translate(-68.791597,-390.00576)">
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 175.34499,424.02062 c -24.661,4.08226 -60.18056,22.01925 -69.18502,28.18484 -7.932853,5.43184 -10.801193,13.70196 -10.925233,20.94538 -0.72438,42.30084 10.273313,88.0482 7.561093,130.50252 -1.21026,18.94414 -7.437413,51.01218 -9.969593,64.24176 -1.65073,6.85296 -2.50133,13.87513 -2.53464,20.92508 2.7e-4,50.2338 40.610433,90.95628 90.705683,90.95655 45.46938,-0.0495 82.39643,-34.07041 89.82748,-79.05254 10.66083,-64.53278 10.42629,-136.39723 11.98541,-204.91567 0.28464,-12.50912 -1.94334,-23.29335 -8.32377,-31.80289 -13.26086,-21.57098 -66.73071,-40.02924 -66.73071,-40.02924 v 7.19061 h -32.4107 z"
+       id="path870"
+       sodipodi:nodetypes="cssscccssccccc" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 208.56756,431.16702 -3,141.31424 c -0.14923,7.02936 -6.07063,12.69123 -13.61129,12.69123 -7.54065,0 -13.46205,-5.66187 -13.61128,-12.69123 l -3,-141.31424 z"
+       id="rect913"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscc" />
+    <path
+       sodipodi:nodetypes="cscsc"
+       inkscape:connector-curvature="0"
+       id="path950"
+       d="m 95.373251,486.43435 c 38.955159,101.12102 48.667459,140.67087 51.422819,177.84397 2.03646,27.47435 -36.96151,79.62933 -36.96151,79.62933 0,0 -24.033873,-37.15986 -19.463976,-61.45137 10.258966,-54.53208 19.996276,-75.99616 5.002667,-196.02193 z"
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#bfc2bb;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 104.9358,539.80779 c 2.40195,-0.25238 2.7176,0.9048 2.96999,3.30675 l 5.69164,54.1678 c 0.25238,2.40194 -1.47813,4.53882 -3.88008,4.7912 -2.40195,0.25239 -5.44876,-8.75375 -5.55682,-11.1665 l -2.02953,-45.3135 c -0.10806,-2.41275 0.40286,-5.53337 2.8048,-5.78575 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssss"
+       inkscape:label="#rect921" />
+    <path
+       sodipodi:nodetypes="sssssss"
+       inkscape:connector-curvature="0"
+       id="button3"
+       d="m 109.77779,602.64876 c 2.40195,-0.25239 4.53882,1.47813 4.79121,3.88007 l 5.69164,54.1678 c 0.25238,2.40195 -1.47814,4.53883 -3.88008,4.79121 -2.40195,0.25238 -7.77772,-8.87659 -7.89239,-11.28904 l -1.91843,-40.36308 c -0.11466,-2.41244 0.8061,-10.93458 3.20805,-11.18696 z"
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:label="#path924" />
+    <rect
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       id="button2"
+       width="23.155933"
+       height="69.467796"
+       x="180.55382"
+       y="454.99139"
+       rx="11.577967"
+       ry="11.577967"
+       inkscape:label="#rect932" />
+    <path
+       sodipodi:nodetypes="cssscc"
+       inkscape:connector-curvature="0"
+       id="button5"
+       d="m 201.20722,551.97605 -0.65676,17.92859 c -0.16469,4.49569 -3.83301,8.12045 -8.59419,8.12045 -4.76117,0 -8.49995,-3.62273 -8.59417,-8.12045 l -0.65677,-17.92859 z"
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:label="#path942" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#bfc2bb;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 281.45725,491.14612 c -30.15796,102.59778 -42.11413,137.63368 -50.74442,173.1322 -6.50823,26.76995 22.13723,79.62933 22.13723,79.62933 0,0 13.58979,-21.97214 16.0745,-32.60727 16.80373,-71.92371 12.53269,-220.15426 12.53269,-220.15426 z"
+       id="path946"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscsc" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 207.75569,423.97641 -1.77476,128.93066 47.96839,25.54626 27.50793,-87.30721 c 4.86457,-36.68335 -44.6715,-55.30429 -73.70156,-67.16971 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#path944" />
+    <path
+       sodipodi:nodetypes="ccccsc"
+       inkscape:connector-curvature="0"
+       id="button0"
+       d="m 174.78525,423.6101 3.03798,129.76808 -49.23161,25.07515 -33.218369,-92.01898 c -1.039426,-19.85252 -0.81982,-28.05969 15.888469,-37.87541 17.53477,-10.30125 42.4825,-20.7564 63.52353,-24.94884 z"
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:label="#path948" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;vector-effect:none;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:10;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="led0"
+       sodipodi:type="arc"
+       sodipodi:cx="-656.78052"
+       sodipodi:cy="189.57951"
+       sodipodi:rx="19.936752"
+       sodipodi:ry="19.936752"
+       sodipodi:start="0.78539816"
+       sodipodi:end="5.4977871"
+       sodipodi:arc-type="arc"
+       d="m -642.6831,203.67693 a 19.936752,19.936752 0 0 1 -28.19483,0 19.936752,19.936752 0 0 1 0,-28.19483 19.936752,19.936752 0 0 1 28.19482,0"
+       sodipodi:open="true"
+       transform="rotate(-90)"
+       inkscape:label="#path883" />
+    <path
+       style="fill:#babdb6;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 192.13178,454.61765 c 0,70.18035 0,70.18035 0,70.18035"
+       id="led1"
+       inkscape:connector-curvature="0"
+       inkscape:label="#path42" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-68.791597,9.994236)">
+    <g
+       id="button1-path"
+       inkscape:label="#g131">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 242.94764,50.505764 H 477"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="237"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="50.005764" />
+    </g>
+    <g
+       id="button0-path"
+       inkscape:label="#g141">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path960"
+         d="M 477,130.50576 H 161.34398"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="127.00576"
+         x="157"
+         height="6.999999"
+         width="6.999999"
+         id="rect970"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect871"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button0-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="130.00577" />
+    </g>
+    <g
+       id="button4-path"
+       inkscape:label="#g151">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path964"
+         d="M 109.31232,181.51438 137.74787,210.44326 477,210.50576"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect875"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button4-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="210.00577" />
+      <rect
+         y="177"
+         x="105"
+         height="6.999999"
+         width="6.999999"
+         id="rect974"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="#g136">
+      <rect
+         inkscape:label="#rect869"
+         y="90.00576"
+         x="477"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 195.97852,108.49147 17.9857,-17.98571 H 477"
+         id="path908"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect910"
+         width="6.999999"
+         height="6.999999"
+         x="194"
+         y="104" />
+    </g>
+    <g
+       id="button3-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 114.17805,250.50576 H 477"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="108"
+         y="247.00577" />
+      <rect
+         y="250.00575"
+         x="477"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       id="button5-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 476.55132,170.50615 H 193.34398"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="189"
+         y="167" />
+      <rect
+         y="170"
+         x="477"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     style="display:inline"
+     transform="translate(-68.791597,9.994236)">
+    <g
+       id="led0-path"
+       inkscape:label="#g161">
+      <path
+         inkscape:connector-curvature="0"
+         id="path877"
+         d="M 477,290.50577 H 208.64438 l -18.97696,-18.97696"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="271"
+         x="186"
+         height="6.999999"
+         width="6.999999"
+         id="rect879"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect881"
+         y="290.00577"
+         x="477"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+    <g
+       id="led1-path"
+       inkscape:label="#g126">
+      <path
+         sodipodi:nodetypes="ccc"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 476.99745,10.505764 H 247.7728 l -51.03686,51.503873"
+         id="path4525"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="led1-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="10.005764"
+         inkscape:label="#rect881" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect4544"
+         width="6.999999"
+         height="6.999999"
+         x="190.67345"
+         y="59.51358" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/logitech-g500.svg
+++ b/data/svgs/logitech-g500.svg
@@ -1,0 +1,484 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="461.86667"
+   height="437.33334"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92+devel unknown"
+   sodipodi:docname="logitech-g500.svg"
+   viewBox="0 0 433 410">
+  <style
+     id="style5346" />
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.0000004"
+     inkscape:cx="184.69456"
+     inkscape:cy="292.7786"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     showgrid="false"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1853"
+     inkscape:window-height="1016"
+     inkscape:window-x="1507"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     units="px"
+     fit-margin-top="20"
+     fit-margin-left="-40"
+     fit-margin-right="-40"
+     fit-margin-bottom="20"
+     inkscape:document-rotation="0">
+    <sodipodi:guide
+       orientation="-0.98480775,-0.17364818"
+       position="118.1781,220.98096"
+       id="guide4656"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="-0.98480775,-0.17364818"
+       position="124.47548,146.18232"
+       id="guide4658"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-115.05694,410.68446"
+       id="guide5340"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-338.2349,374.49999"
+       id="guide5342"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-411.98489,294.5"
+       id="guide5344"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-447.39711,334.5"
+       id="guide5346"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-458.85989,254.5"
+       id="guide5348"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-443.23489,214.5"
+       id="guide5350"
+       inkscape:locked="false" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid5352"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingx="1"
+       spacingy="1" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-305.47013,174.5"
+       id="guide5354"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Device"
+     id="Device"
+     transform="translate(-39.484902,-592.98552)"
+     style="display:inline"
+     inkscape:groupmode="layer">
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 256.36569,614.54742 c 62.08413,0.89801 96.39946,43.63605 97.13045,100.21395 0.55781,43.17356 -0.71866,53.46001 -1.54175,67.83715 -2.26656,39.59053 13.49465,51.18855 14.64665,88.65081 1.15816,37.66265 -45.5866,110.51959 -94.81782,110.23536 -65.62864,-0.3789 -122.38269,-97.81594 -122.56938,-158.02971 -0.0782,-25.23502 4.46146,-43.80053 13.87577,-79.40029 -9.23186,-76.55096 33.02958,-130.37871 93.27608,-129.50727 z"
+       id="path3154"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssscs" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 256.8125,620.48588 c 65.06567,0.698 86.46352,49.92709 87.43313,85.02498 1.40678,50.92328 -31.00828,141.5762 -14.64667,177.30163 8.51955,18.60234 18.50105,43.3618 18.50105,43.3618 0,0 -32.07332,55.55238 -76.12407,55.3104 -47.75882,-0.26237 -83.25468,-52.61233 -83.25468,-52.61233 0,0 18.17404,-39.75596 19.0792,-60.70654 2.21242,-51.20828 -34.1177,-72.31129 -37.00208,-127.19463 -2.92063,-55.57291 17.50781,-121.18975 83.17598,-120.48531 v 47.86067 h -5.96621 c -1.88766,0 -4.0051,2.17484 -4.0051,4.0625 v 39.96094 c 0,1.86907 2.13603,3.98438 4.0051,3.98438 h 5.96621 v 28.98005 h -4.03271 c -0.93786,0 -1.9335,1.10612 -1.9335,2.04398 v 16.95951 c 0,0.93786 0.99564,2.04398 1.9335,2.04398 h 4.03271 v 46.07243 h 2.83814 v -46.07243 h 3.98434 c 0.95705,0 2.01636,-1.08693 2.01636,-2.04398 V 747.3784 c 0,-0.95705 -1.05931,-2.04398 -2.01636,-2.04398 h -3.98434 v -28.98005 h 6.0007 c 1.88748,0 4.0051,-2.0969 4.0051,-3.98438 v -39.96094 c 0,-1.9059 -2.0992,-4.0625 -4.0051,-4.0625 h -6.0007 z"
+       id="path3156"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csscscssccssssccssssccccssssccsssscc" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2.13333344;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 228.78906,209.52734 v -24.57031 h -4.30273 c -1.00039,0 -2.0625,-1.18126 -2.0625,-2.18164 v -18.08984 c 0,-1.00039 1.06211,-2.17969 2.0625,-2.17969 h 4.30273 v -30.91211 h -6.36523 c -1.99368,0 -4.27149,-2.25633 -4.27149,-4.25 v -42.625 c 0,-2.013504 2.25798,-4.333984 4.27149,-4.333984 h 6.36523 V 29.333984 C 191.43799,28.933309 167.81063,48.64998 154.36133,76.128906 l 6.78125,13.011719 c 0.88314,1.694805 1.15123,3.956361 0.41211,5.71875 -4.4888,10.703155 -7.116,17.605295 -7.34571,28.384765 -0.037,1.73622 -0.81139,4.42706 -1.86718,4.68164 l -8.53907,1.96094 c -2.34577,34.22551 0.78777,54.03726 19.46485,92.625 l 8.17383,0.56055 c 0.9494,0.0651 1.95013,0.3512 2.86523,0.80273"
+       transform="matrix(0.93749999,0,0,0.93749999,39.484902,592.98552)"
+       id="button0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssssccssssccccccccccc" />
+    <path
+       sodipodi:nodetypes="ccssssccssssccsc"
+       inkscape:connector-curvature="0"
+       id="button1"
+       d="m 256.8125,789.41811 v -23.03622 h 3.98434 c 0.95705,0 2.01636,-1.08693 2.01636,-2.04398 V 747.3784 c 0,-0.95705 -1.05931,-2.04398 -2.01636,-2.04398 h -3.98434 v -28.98005 h 6.0007 c 1.88748,0 4.0051,-2.0969 4.0051,-3.98438 v -39.96094 c 0,-1.9059 -2.0992,-4.0625 -4.0051,-4.0625 h -6.0007 v -47.86067 c 65.06567,0.698 86.46353,49.92709 87.43313,85.02498 0.70339,25.46164 -7.04868,60.85569 -12.9314,94.35001"
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#path5337" />
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:2.13333344;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 154.36133,76.128906 c -11.77275,24.053464 -15.7471,54.053924 -14.29297,81.722654 2.85731,54.3682 36.47683,77.66427 39.36719,124.46094 l 10.40625,-11.33594 c 1.8935,-2.06288 1.8635,-5.57497 1.24804,-8.30664 -3.12898,-13.88786 -7.08345,-21.76245 -13.9707,-36.16406 -0.95424,-1.99536 -3.47112,-3.28232 -5.67773,-3.43359 l -8.17383,-0.56055 C 144.5905,183.92398 141.45767,164.11281 143.80344,129.8873 l 8.53836,-1.96152 c 1.05579,-0.25458 1.83017,-2.94542 1.86718,-4.68164 0.22971,-10.77947 2.85691,-17.68161 7.34571,-28.384765 0.73912,-1.762389 0.47103,-4.023945 -0.41211,-5.71875 z"
+       transform="matrix(0.93749999,0,0,0.93749999,39.484902,592.98552)"
+       id="path4640"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscccccccccccc" />
+    <rect
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="button2"
+       width="16"
+       height="40"
+       x="247.44788"
+       y="672.31464"
+       rx="4"
+       ry="4"
+       inkscape:label="#rect4642" />
+    <rect
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:round;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="rect4644"
+       width="8"
+       height="15"
+       x="251.34375"
+       y="748.26843"
+       rx="2"
+       ry="2" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1"
+       d="m 184.45535,669.33767 c -2.23196,5.12412 -4.80484,11.95291 -6.46149,18.61989 l 7.35715,1.95705 c 1.0372,-3.57697 2.03018,-5.75654 2.91825,-7.91351 0.52031,-1.26376 0.20456,-3.91971 -0.38116,-5.19416 z"
+       id="button8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssc"
+       inkscape:label="#path4646" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:bevel;stroke-opacity:1"
+       d="m 174.03907,712.2528 c 0.52083,-6.80199 1.39322,-13.37092 2.65623,-18.35938 l 6.99498,1.53292 c -1.25795,4.82258 -1.66687,8.88981 -1.774,12.75056 -0.0294,1.05941 -0.59464,2.39181 -1.62721,2.6306 z"
+       id="button9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssc"
+       inkscape:label="#path4648" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 159.55083,740.00544 c -1.24751,0.22588 -2.18342,2.00899 -1.96327,3.25754 l 2.97337,16.86281 4.53764,-0.94696 3.46041,18.3604 1.8943,-0.39559 -6.68317,-37.90213 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sscccccs"
+       inkscape:label="#path4650" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#bdbab6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 169.00092,779.7656 1.83239,-0.46666 6.87338,38.98084 -4.17452,1.07194 c -1.15216,0.29585 -2.68927,-0.91399 -2.89583,-2.08545 l -3.45729,-19.60726 4.8521,-1.10345 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssccc"
+       inkscape:label="#path4652" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 162.19674,761.50057 6.01776,34.31296 2.99355,-0.71424 -3.77818,-20.44043 -2.54859,-13.7678 z"
+       id="button5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       inkscape:label="#path4654" />
+    <path
+       inkscape:label="#path1148"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.9375;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 238.49468,688.57611 v 7.47706 l -3.59361,-3.59364 z"
+       id="button6"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:label="#path1146"
+       inkscape:connector-curvature="0"
+       id="button7"
+       d="m 272.40108,688.57611 v 7.47706 l 3.5936,-3.59364 z"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.9375;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+  </g>
+  <g
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-39.484902,-52.623025)"
+     inkscape:groupmode="layer">
+    <g
+       id="button8-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5328"
+         d="M 183.46993,142.07026 170.4849,128.12301 H 40.484902"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-0"
+         width="6.999999"
+         height="6.999999"
+         x="180.25464"
+         y="138.46088" />
+      <rect
+         inkscape:label="#rect5374"
+         y="127.62303"
+         x="39.484901"
+         height="1"
+         width="1"
+         id="button8-leader"
+         style="text-align:end;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button3-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5338"
+         d="m 171.875,267.3125 -20.3901,20.81051 H 40.484902"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-4"
+         width="6.999999"
+         height="6.999999"
+         x="168.53668"
+         y="263.65982" />
+      <rect
+         inkscape:label="#rect5376"
+         transform="translate(39.484902,52.674496)"
+         y="234.94852"
+         x="0"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="text-align:end;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button5-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5334"
+         d="m 166.54255,238.69695 -9.05765,9.42606 H 40.484902"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-3"
+         width="6.999999"
+         height="6.999999"
+         x="163.02351"
+         y="235.40237" />
+      <rect
+         inkscape:label="#rect5378"
+         transform="translate(39.484902,52.674496)"
+         y="194.94852"
+         x="0"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="text-align:end;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button4-path">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path5332"
+         d="M 161.4849,208.12301 H 40.484902"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-68"
+         width="6.999999"
+         height="6.999999"
+         x="158.37202"
+         y="204.55347" />
+      <rect
+         inkscape:label="#rect5380"
+         transform="translate(39.484902,52.674496)"
+         y="154.94852"
+         x="0"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="text-align:end;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button9-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5330"
+         d="m 178.4278,162.96866 -4.9429,5.15435 H 40.484902"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-99"
+         width="6.999999"
+         height="6.999999"
+         x="175.10759"
+         y="159.39299" />
+      <rect
+         inkscape:label="#rect5382"
+         transform="translate(39.484902,52.674496)"
+         y="114.94852"
+         x="0"
+         height="1"
+         width="1"
+         id="button9-leader"
+         style="text-align:end;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button6-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5324"
+         d="m 244.4849,152.62303 95,95.5 132,-2e-5"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-5"
+         width="6.999999"
+         height="6.999999"
+         x="240.37251"
+         y="148.45215" />
+      <rect
+         inkscape:label="#rect5384"
+         transform="translate(39.484902,52.623025)"
+         y="195"
+         x="432"
+         height="1"
+         width="1"
+         id="button6-leader"
+         style="text-align:start;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button7-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5322"
+         d="m 267.4849,152.62303 55,55.5 149,-1e-5"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-1"
+         width="6.999999"
+         height="6.999999"
+         x="263.49133"
+         y="148.45215" />
+      <rect
+         inkscape:label="#rect5386"
+         transform="translate(39.484902,52.623025)"
+         y="155"
+         x="432"
+         height="1"
+         width="1"
+         id="button7-leader"
+         style="text-align:start;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button2-path">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path5326"
+         d="m 255.4849,141.62303 h 39 l 27,26.5 150,-1e-5"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-6"
+         width="6.999999"
+         height="6.999999"
+         x="251.93195"
+         y="138.13458" />
+      <rect
+         inkscape:label="#rect5388"
+         transform="translate(39.484902,52.623025)"
+         y="115"
+         x="432"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="text-align:start;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button1-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5320"
+         d="m 290.625,110.67188 16.8599,17.45114 h 164"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968-9"
+         width="6.999999"
+         height="6.999999"
+         x="287.23676"
+         y="107.42233" />
+      <rect
+         inkscape:label="#rect5390"
+         transform="translate(39.484902,52.623025)"
+         y="75"
+         x="432"
+         height="1"
+         width="1"
+         id="button1-leader"
+         style="text-align:start;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+    <g
+       id="button0-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path5318"
+         d="M 226.27417,106.9604 246.4849,88.123025 h 225"
+         style="fill:none;stroke:#888a85;stroke-width:1px;stroke-linecap:square;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;marker:none"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="222.83652"
+         y="103.6103" />
+      <rect
+         inkscape:label="#rect5392"
+         transform="translate(39.484902,52.623025)"
+         y="35"
+         x="432"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="text-align:start;fill:#888a85;fill-opacity:1;stroke:none" />
+    </g>
+  </g>
+  <g
+     id="LEDs"
+     inkscape:label="LEDs"
+     inkscape:groupmode="layer" />
+</svg>

--- a/data/svgs/logitech-g500s.svg
+++ b/data/svgs/logitech-g500s.svg
@@ -1,0 +1,1 @@
+logitech-g500.svg

--- a/data/svgs/logitech-g502.svg
+++ b/data/svgs/logitech-g502.svg
@@ -1,0 +1,570 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="467.83105"
+   height="400.87393"
+   viewBox="0 0 467.83105 398.87393"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.1 r"
+   sodipodi:docname="logitech-g502.svg"
+   inkscape:export-filename="/home/jimmac/logitech-g403.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4"
+     inkscape:cx="345.48859"
+     inkscape:cy="341.91565"
+     inkscape:document-units="px"
+     inkscape:current-layer="Buttons"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="false"
+     showguides="true"
+     inkscape:window-width="1366"
+     inkscape:window-height="704"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     fit-margin-top="20"
+     fit-margin-bottom="20"
+     fit-margin-left="0"
+     fit-margin-right="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid956"
+       originx="-16.168953"
+       originy="-1.1260801" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     transform="translate(-16.168953,-400)"
+     style="display:inline">
+    <g
+       transform="translate(-374,-4.864278e-6)"
+       id="g1170">
+      <path
+         inkscape:connector-curvature="0"
+         id="path981"
+         d="m 617.52893,453.41998 -49.99065,26.66899 c -2.22449,1.86937 -2.81832,3.35837 -3.6652,5.83317 l -15.9563,53.34684 c -0.49748,2.25523 -0.34218,3.74811 0.48513,6.46679 l 3.99946,10.9325 -3.53186,0.74244 -1.35901,12.37091 -1.50378,2.8507 2.09912,18.55549 c 0,0 -13.03638,4.81768 -18.22998,15.00854 -5.19361,10.19086 -9.29541,53.53534 -6.03613,59.82001 3.25927,6.28467 25.6018,33.9057 28.70703,40.07849 3.10522,6.17279 24.79553,45.22613 30.93054,51.77106 6.13501,6.54492 35.79895,19.27618 35.79895,19.27618 6.39358,-5.0822 15.98738,-6.80155 23.61682,-0.45557 0,0 31.72192,-10.76812 43.56091,-26.60644 11.83899,-15.83832 24.57691,-52.0235 24.57691,-52.0235 0,0 -2.04663,-1.98694 -2.04663,-9.06775 0,-7.08081 3.24377,-9.90655 3.24377,-9.90655 l -7.41565,-77.33204 c 0,0 0.90478,-68.51501 -1.01514,-76.49939 -1.57946,-6.56849 -5.90589,-29.81348 -7.88675,-38.02183 -0.42699,-1.76936 -0.95122,-1.65743 -2.07882,-3.29921 l -52.65222,-36.341 4.00378,32.1344 h -28.47082 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="ccccccccccsccsccscsccssccccc" />
+      <path
+         sodipodi:nodetypes="cccccscssccc"
+         inkscape:connector-curvature="0"
+         id="path1014"
+         d="m 648.06347,618.15601 34.51828,10.05586 c 2.62858,0.8078 3.9256,5.47034 3.9256,5.47034 l -0.44831,35.46611 23.5331,26.29168 c 0,0 -9.4414,38.41029 -27.23181,57.70209 -11.60967,12.58946 -39.46726,23.54443 -39.46726,23.54443 0,0 -4.87562,-48.51623 -9.30469,-56.255 -4.42908,-7.73877 -35.48734,-18.11903 -50.81543,-30.61249 -5.82123,-4.7447 -15.27906,-16.55719 -15.27906,-16.55719 l -4.00329,-23.86047 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         sodipodi:nodetypes="cccsc"
+         inkscape:connector-curvature="0"
+         id="path1144"
+         d="m 620.3461,775.42623 3.91771,-44.34657 c 1.3829,-6.28113 -0.99643,-10.76025 -6.48071,-12.64329 0,0 -33.9759,-17.94313 -41.16454,-25.32697 -7.18863,-7.38383 -16.89702,-24.84664 -16.89702,-24.84664"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;vector-effect:none;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:8;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="led0"
+         sodipodi:type="arc"
+         sodipodi:cx="-664.05457"
+         sodipodi:cy="598.10364"
+         sodipodi:rx="12.162673"
+         sodipodi:ry="12.162673"
+         sodipodi:start="0.78539816"
+         sodipodi:end="5.4977871"
+         sodipodi:arc-type="arc"
+         d="m -655.45426,606.70395 a 12.162673,12.162673 0 0 1 -17.20061,0 12.162673,12.162673 0 0 1 0,-17.20062 12.162673,12.162673 0 0 1 17.20061,0"
+         sodipodi:open="true"
+         transform="rotate(-90)"
+         inkscape:label="#path1012" />
+      <path
+         sodipodi:nodetypes="ccsccsc"
+         inkscape:connector-curvature="0"
+         id="path1030"
+         d="m 548.10584,591.18781 -1.39021,19.03606 c 0,0 -6.51942,1.07248 -9.54983,9.44719 -3.03041,8.37471 -8.01844,25.6823 -7.19278,55.16199 -3.80454,-3.92381 -8.20043,-7.54825 -7.93855,-14.11229 0.0565,-12.69733 0.50177,-31.56063 5.66468,-49.88965 3.26585,-11.59423 10.35698,-16.87164 20.40669,-19.6433 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button0"
+         d="m 616.72979,453.87813 -43.21475,23.25557 -2.30905,111.85791 -3.27924,2.29913 8.95587,40.68384 43.49634,-20.81641 c 0,0 -6.29272,-57.3948 -6.04248,-82.96182 0.25025,-25.56702 2.39331,-74.31822 2.39331,-74.31822 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="ccccccsc"
+         inkscape:label="#path1060" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button1"
+         d="m 641.35924,447.84438 c 0,0 6.82136,40.56938 7.71833,77.06871 0.89697,36.49932 0.60175,77.20425 0.60175,77.20425 l 43.91543,12.95245 c 0,0 2.9472,-62.03698 1.5412,-81.15454 -1.4061,-19.11755 -6.51723,-50.97735 -8.90483,-54.50845 -2.3876,-3.5311 -44.87188,-31.56242 -44.87188,-31.56242 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cscccsc"
+         inkscape:label="#path1062" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button8"
+         d="m 626.36054,592.91458 3.41284,20.82315 12.69293,-3.75027 1.10974,-17.00943 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path1064" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1066"
+         d="m 624.73297,570.54019 2.51941,13.45651 14.86756,-0.0507 1.26654,-13.4599 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="button2"
+         width="17.152637"
+         height="51.954956"
+         x="623.8761"
+         y="503.84464"
+         rx="8.5763187"
+         ry="8.5763187"
+         inkscape:label="#rect1068" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button7"
+         d="m 569.97595,534.59994 -16.73181,-6.63336 13.09595,-44.4487 3.95538,-3.11892 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path1098" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button6"
+         d="m 569.97595,534.59994 -15.81811,4.41446 13.12378,48.26233 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path1100" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 550.97571,556.55099 -1.73137,22.23376 c 0,0 -8.07466,-0.0385 -6.10341,-6.67814 0.79661,-2.68321 1.88213,-11.10134 3.54027,-13.80998 2.44498,-3.99399 4.29451,-1.74564 4.29451,-1.74564 z"
+         id="button5"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccsc"
+         inkscape:label="#path1473" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button4"
+         d="m 553.91685,576.77039 3.78851,43.20785 -3.52893,1.40018 -4.18952,-2.67337 -1.94029,-38.13895 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cccccc"
+         inkscape:label="#path1118" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button3"
+         d="m 557.29072,626.42287 -4.13718,-0.69442 -1.90659,6.11048 8.04212,38.1661 3.30713,3.0868 4.6499,-1.78876 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path1120" />
+      <path
+         inkscape:connector-curvature="0"
+         id="led1"
+         d="m 554.07316,558.40614 18.36886,76.63506 -10.78213,5.31523 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path1122" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1138"
+         d="m 561.0357,599.31803 1.68542,4.21409 -3.19735,5.27031 -0.72068,-4.52978 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1140"
+         d="m 564.53845,610.12329 0.75,2.84987 -3.50226,8.03142 -0.75,-4.13156 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1142"
+         d="m 566.94537,619.35785 1.45849,3.46056 -4.29748,11.03294 -1.04318,-4.82295 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button9"
+         d="m 654.80262,526.99557 v 7.97553 l 3.83318,-3.83321 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path1146" />
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 608.6358,526.99557 v 7.97553 l -3.83318,-3.83321 z"
+         id="button10"
+         inkscape:connector-curvature="0" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-16.168953)">
+    <g
+       id="button0-path"
+       inkscape:label="#g442">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path954"
+         d="m 234.68702,62.49186 41.9857,-41.98571 H 483"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="62"
+         x="230"
+         height="6.999999"
+         width="6.999999"
+         id="rect952"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect865"
+         y="20"
+         x="483"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+    <g
+       id="button1-path"
+       inkscape:label="#g437">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 275.03741,60.50615 H 483.05562"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="273"
+         y="57" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="483"
+         y="60" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="#g432">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path960"
+         d="M 483.15129,100.50615 H 266.97374 l -7.07445,7.07445"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="106.05299"
+         x="254.86905"
+         height="6.999999"
+         width="6.999999"
+         id="rect970"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect869"
+         y="100"
+         x="483"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+    <g
+       id="button6-path"
+       inkscape:label="#g427">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 483,140.50615 H 189.32589"
+         id="path962"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect972"
+         width="6.999999"
+         height="6.999999"
+         x="188"
+         y="137" />
+      <rect
+         inkscape:label="#rect871"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button6-leader"
+         width="1"
+         height="1"
+         x="483"
+         y="140" />
+    </g>
+    <g
+       id="button9-path"
+       inkscape:label="#g305">
+      <rect
+         inkscape:label="button7"
+         y="-106.99028"
+         x="-17.168953"
+         height="1"
+         width="1"
+         id="button9-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 17.16895,106.48415 h 196.02823 l 12.07418,12.07418 h 32.523 l 6.63159,11.48624"
+         id="path902"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect904"
+         width="6.999999"
+         height="6.999999"
+         x="262.93826"
+         y="128.04514" />
+    </g>
+    <g
+       id="button10-path"
+       inkscape:label="#g310">
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button10-leader"
+         width="1"
+         height="1"
+         x="-17.168953"
+         y="-146.9903"
+         inkscape:label="#rect873" />
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path900"
+         d="m 17.16895,146.48415 h 136.64539 l 16.12282,-23.87718 h 74.32285 l 4.99222,8.64678"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="128.03354"
+         x="247.00359"
+         height="6.999999"
+         width="6.999999"
+         id="rect906"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+    <g
+       id="button4-path"
+       inkscape:label="#g402">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 17.16895,226.39549 151.60272,0.0884 8.22787,-9.92565"
+         id="path896"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         y="-219.98177"
+         x="-181.00188"
+         height="6.999999"
+         width="6.999999"
+         id="rect1297"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)" />
+      <rect
+         inkscape:label="#rect873"
+         y="-226.98393"
+         x="-17.168953"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+    <g
+       id="button8-path"
+       inkscape:label="#g397">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path1259"
+         d="m 17.16895,186.48415 h 90.82321 l 16.12282,16.12282 h 132.34309"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="-207.00615"
+         x="-262"
+         height="6.999999"
+         width="6.999999"
+         id="rect1261"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)" />
+      <rect
+         inkscape:label="#rect873"
+         y="-186.98393"
+         x="-17.168953"
+         height="1"
+         width="1"
+         id="button8-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+    <g
+       id="button7-path"
+       inkscape:label="#g300">
+      <rect
+         inkscape:label="#rect873"
+         y="-62.912788"
+         x="-17.168953"
+         height="1"
+         width="1"
+         id="button7-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path914"
+         d="M 17.317611,62.412787 H 178.90504 l 15.75447,23.87718"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect912"
+         width="6.999999"
+         height="6.999999"
+         x="191.28058"
+         y="85.438072" />
+    </g>
+    <g
+       id="button3-path"
+       inkscape:label="#g407">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path1295"
+         d="m 17.294405,266.46958 168.568675,0.0407"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect1301"
+         width="6.999999"
+         height="6.999999"
+         x="-191.68813"
+         y="-269.40173" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round"
+         id="button3-leader"
+         width="1.1351269"
+         height="1"
+         x="-17.294409"
+         y="-266.98993"
+         inkscape:label="#rect873" />
+    </g>
+    <g
+       id="button5-path"
+       inkscape:label="#g422">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 483.13134,180.50551 -295.64539,-0.25 -14.35505,-20.22553"
+         id="path890"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         y="-163.30751"
+         x="-175.13875"
+         height="6.999999"
+         width="6.999999"
+         id="rect894"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button5-leader"
+         width="1"
+         height="1"
+         x="-484.00677"
+         y="-181.00594"
+         inkscape:label="#rect873" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     style="display:inline"
+     transform="translate(-16.168953)">
+    <g
+       id="led1-path"
+       inkscape:label="#g417">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 191.93858,220.50615 H 483.10224"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="188"
+         y="217" />
+      <rect
+         inkscape:label="#rect875"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="led1-leader"
+         width="1"
+         height="1"
+         x="483"
+         y="220" />
+    </g>
+    <g
+       id="led0-path"
+       inkscape:label="#g412">
+      <path
+         inkscape:connector-curvature="0"
+         id="path877"
+         d="M 214.64438,260.50615 H 483"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="257"
+         x="210"
+         height="6.999999"
+         width="6.999999"
+         id="rect879"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect881"
+         y="260"
+         x="483"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/logitech-g600.svg
+++ b/data/svgs/logitech-g600.svg
@@ -1,0 +1,1190 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="467.83105"
+   height="400.87393"
+   viewBox="0 0 467.83105 400.87393"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.2 2405546, 2018-03-11"
+   sodipodi:docname="logitech-g600.svg"
+   inkscape:export-filename="/home/gandalf3/Pictures/Vectors/gnome/logitech-g600.png"
+   inkscape:export-xdpi="90"
+   inkscape:export-ydpi="90">
+  <defs
+     id="defs2">
+    <inkscape:path-effect
+       effect="mirror_symmetry"
+       start_point="-32.949221,642.84217"
+       end_point="-32.949221,665.58085"
+       center_point="-32.949221,654.21151"
+       id="path-effect2141"
+       is_visible="true"
+       mode="free"
+       discard_orig_path="false"
+       fuse_paths="true"
+       oposite_fuse="true" />
+    <inkscape:path-effect
+       effect="mirror_symmetry"
+       start_point="162.36328,617.41819"
+       end_point="162.36328,637.35007"
+       center_point="162.36328,627.38413"
+       id="path-effect2139"
+       is_visible="true"
+       mode="free"
+       discard_orig_path="false"
+       fuse_paths="true"
+       oposite_fuse="true" />
+    <inkscape:path-effect
+       effect="mirror_symmetry"
+       start_point="162.25916,592.64387"
+       end_point="162.4674,612.52243"
+       center_point="162.36328,602.58315"
+       id="path-effect2133"
+       is_visible="true"
+       mode="free"
+       discard_orig_path="false"
+       fuse_paths="true"
+       oposite_fuse="true" />
+    <inkscape:path-effect
+       effect="mirror_symmetry"
+       start_point="162.23558,562.66726"
+       end_point="162.49098,587.0472"
+       center_point="162.36328,574.85723"
+       id="path-effect2131"
+       is_visible="true"
+       mode="free"
+       discard_orig_path="false"
+       fuse_paths="true"
+       oposite_fuse="true" />
+    <inkscape:path-effect
+       oposite_fuse="true"
+       fuse_paths="true"
+       discard_orig_path="false"
+       mode="free"
+       is_visible="true"
+       id="path-effect2141-7"
+       center_point="135.18361,672.00639"
+       end_point="135.18361,688.50517"
+       start_point="135.18361,655.50761"
+       effect="mirror_symmetry" />
+    <inkscape:path-effect
+       oposite_fuse="true"
+       fuse_paths="true"
+       discard_orig_path="false"
+       mode="free"
+       is_visible="true"
+       id="path-effect2139-5"
+       center_point="162.36328,627.38413"
+       end_point="162.36328,637.35007"
+       start_point="162.36328,617.41819"
+       effect="mirror_symmetry" />
+    <inkscape:path-effect
+       oposite_fuse="true"
+       fuse_paths="true"
+       discard_orig_path="false"
+       mode="free"
+       is_visible="true"
+       id="path-effect2133-3"
+       center_point="162.36328,602.58315"
+       end_point="162.4674,612.52243"
+       start_point="162.25916,592.64387"
+       effect="mirror_symmetry" />
+    <inkscape:path-effect
+       oposite_fuse="true"
+       fuse_paths="true"
+       discard_orig_path="false"
+       mode="free"
+       is_visible="true"
+       id="path-effect2131-5"
+       center_point="162.36328,574.85723"
+       end_point="162.49098,587.0472"
+       start_point="162.23558,562.66726"
+       effect="mirror_symmetry" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.1003913"
+     inkscape:cx="128.19759"
+     inkscape:cy="210.15126"
+     inkscape:document-units="px"
+     inkscape:current-layer="LEDs"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="false"
+     showguides="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1080"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="0"
+     inkscape:snap-global="true"
+     inkscape:guide-bbox="true"
+     fit-margin-top="20"
+     fit-margin-bottom="20"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     inkscape:snap-nodes="true"
+     inkscape:snap-to-guides="true"
+     inkscape:snap-others="false"
+     inkscape:object-paths="true"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="false"
+     inkscape:bbox-nodes="false"
+     inkscape:snap-bbox-edge-midpoints="false"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:snap-midpoints="false"
+     inkscape:snap-center="true"
+     inkscape:snap-text-baseline="true"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-page="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid956"
+       originx="-16.168953"
+       originy="1.9872821" />
+    <sodipodi:guide
+       position="384.37499,269.33811"
+       orientation="0,1"
+       id="guide1063"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="415.42968,285.42013"
+       orientation="1,0"
+       id="guide1065"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="364.87814,257.98348"
+       orientation="0,1"
+       id="guide1067"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="288.64319,257.98348"
+       orientation="-0.70710678,-0.70710678"
+       id="guide1069"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="290.80674,285.21409"
+       orientation="1,0"
+       id="guide1071"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="427.3024,188.37766"
+       orientation="1,0"
+       id="guide1077"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="290.70103,242.42289"
+       orientation="0,1"
+       id="guide1079"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="150.56881,253.87108"
+       orientation="1,0"
+       id="guide1083"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="87.315913,253.87108"
+       orientation="1,0"
+       id="guide1085"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="52.825143,363.33747"
+       orientation="1,0"
+       id="guide1087"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="119.01466,260.61287"
+       orientation="1,0"
+       id="guide1089"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="12.5,290.5"
+       orientation="1,0"
+       id="guide1101"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="137.09033,224.59479"
+       orientation="0,1"
+       id="guide1109"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="71.359374,152.375"
+       orientation="0,1"
+       id="guide1111"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     transform="translate(-16.168953,-401.11334)"
+     style="display:inline"
+     sodipodi:insensitive="true">
+    <path
+       style="fill:#d3d3ce;fill-opacity:0.96808543;fill-rule:evenodd;stroke:#babdb6;stroke-width:3.00094485;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 373.4187,476.07566 c 3.02297,2.70603 5.6584,10.20454 12.125,16.78661 7.67562,7.81268 15.79723,11.4209 17.25,14.5 1.45277,3.0791 4.3436,13.30151 6.08201,23.63224 2.08088,12.36588 3.91014,33.37614 3.16799,50.36776 -0.74215,16.99162 -4.92696,41.17485 -7.82549,53.25984 -2.89854,12.085 -8.94197,37.46413 -15.18815,56.6472 -11.39282,34.98926 -15.98921,41.84599 -18.48636,44.65546 -8.98794,10.11206 -28.22253,19.14144 -44.75,24.3125 -16.52747,5.17106 -42.91421,10.08579 -52.16421,3.83579 -9.25,-6.25 -21.76463,-18.87042 -35.87348,-43.80026 -8.81835,-15.58171 -16.07719,-30.35613 -17.6302,-37.02772 -0.18177,-0.78086 -1.49089,-8.31458 -2.2757,-17.52792 -0.78481,-9.21335 -0.38228,-34.00819 -0.92621,-52.2258 -0.54593,-18.2846 -2.80242,-56.6523 1.63404,-65.1745 0,0 -2.2169,-7.85094 -1.86335,-12.62391 0.13258,-2.20971 0.95227,-8.55534 4.93612,-26.56824 2.86224,-12.94153 8.06806,-29.82835 9.91299,-32.63747 4.02438,-6.12757 24.91051,-8.21668 38.875,-12.75 8.4338,-2.73788 27.97597,-8.87889 31.21729,-9.7474 2.86151,-0.76674 7.46115,-0.82707 10.06673,0.0719 3.17217,1.09445 20.20745,7.47311 29.51777,10.80936 9.16905,3.28563 27.78726,8.46404 27.78726,8.46404 l 0.086,7.00877 4.33969,0.3933 z"
+       id="path4776"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cszszzsszssscsccsssssscccc" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.95744683"
+       d="m 362.80471,657.82916 -3.41697,-0.38193 c 0,0 8.48946,-61.89132 10.13089,-93.04711 1.59315,-30.23938 -0.61042,-64.68009 -0.28888,-90.84348 0,0 -18.83877,-5.39992 -28.00782,-8.68555 -9.31074,-3.33623 -29.51974,-10.84765 -29.51974,-10.84765 h -2.65429 v 36.29687 c 6.01123,1.61071 10.35351,5.08295 10.35351,12.60352 l -0.0879,25.875 c 0,7.72285 -5.57149,10.39065 -10.26562,11.64844 v 8.63597 c 11.09371,0 11.13526,2.31927 11.13526,8.32968 v 30.90854 c 0,6.37637 -4.59396,8.07114 -11.13526,8.07114 v 16.62107 H 304.7139 V 596.3926 c -6.54611,0 -11.59712,-1.08449 -11.59712,-8.07114 v -30.90854 c 0,-6.19186 0.61782,-8.32968 11.59712,-8.32968 v -8.63597 c -4.98633,-1.61457 -9.62702,-3.28799 -9.97265,-11.64844 l -0.17579,-25.875 c 0.14132,-7.63929 4.65137,-11.13058 10.14844,-12.60352 v -36.29687 h -3.07811 c 0,0 -22.783,6.97501 -31.2168,9.71289 -13.96449,4.53332 -34.85062,6.62243 -38.875,12.75 -1.84493,2.80912 -7.04987,19.69714 -9.91211,32.63867 -3.98385,18.0129 -4.80492,24.35865 -4.9375,26.56836 -1.70941,12.19785 4.61002,20.46944 6.11854,30.13476 0.77914,5.15941 1.58279,17.99189 1.93164,29.67579 0.24832,8.31696 0.0663,42.58411 -0.61328,55.60351 -0.77777,16.45063 -5.54792,27.85559 0.30724,42.32422 0.91969,2.10178 4.50001,11.26009 13.31836,26.8418 14.10885,24.92984 26.62305,37.54883 35.87305,43.79883 9.25,6.25 35.63659,1.33512 52.16406,-3.83594 16.52747,-5.17106 35.76206,-14.20044 44.75,-24.3125 2.49715,-2.80947 7.09351,-9.66504 18.48633,-44.6543 6.24618,-19.18307 12.28896,-44.56148 15.1875,-56.64648 2.89853,-12.08499 7.08402,-36.2701 7.82617,-53.26172 0.74215,-16.99162 -1.08709,-38.00131 -3.16797,-50.36719 -1.73841,-10.33073 -4.62926,-20.55371 -6.08203,-23.63281 -1.45277,-3.0791 -9.57438,-6.68732 -17.25,-14.5 -6.4666,-6.58207 -7.72703,-11.95413 -12.5,-16.28516 0.15263,30.33982 1.29199,58.44309 -0.255,87.8223 -2.07414,31.07314 -5.94662,62.55655 -9.98428,93.43069 z"
+       id="path4823"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccaccccccccccccccccccccccccscsccsccssssssssssccc" />
+    <path
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+       d="m 310.04786,455.0235 v 34.61523 c 2.79993,0.846 5.32775,2.0788 7.16797,4.0918 2.01094,2.19978 3.18554,5.24061 3.18554,9.19336 v 0.002 l -0.0879,25.87305 v 0.004 c -10e-4,4.09973 -1.54019,7.03111 -3.70312,8.98633 -1.94955,1.76233 -4.33456,2.70749 -6.5625,3.36328 v 7 c 4.84117,0.0729 7.77689,0.55548 9.41601,2.11719 0.88621,0.84435 1.32712,1.95378 1.52539,3.14258 0.19836,1.1888 0.19336,2.49624 0.19336,4 v 30.91015 c 0,0.99455 -0.12386,1.89776 -0.33984,2.72657 h 45.49414 c 0.98282,-9.82875 1.78529,-19.17808 2.18164,-26.70117 1.57411,-29.87793 -0.5598,-63.90231 -0.28516,-90.04102 -1.20742,-0.3466 -18.41399,-5.29215 -27.34961,-8.49414 -9.27321,-3.32278 -29.13115,-10.70346 -29.36132,-10.78906 z"
+       id="button1"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+       d="m 374.0752,479.25396 c 0.20274,29.27316 1.21406,56.65111 -0.28906,85.19727 v 0.008 0.006 c -1.13665,17.02839 -2.82145,34.17251 -4.76758,51.26953 l 31.43945,30.1875 c 1.09941,-4.48701 2.04761,-8.44799 2.78711,-11.53125 2.87888,-12.00305 7.06203,-36.20306 7.79883,-53.07226 0.73746,-16.88415 -1.08826,-37.88054 -3.1543,-50.1582 -0.8631,-5.12915 -2.015,-10.24244 -3.1289,-14.44532 -1.1139,-4.20287 -2.21968,-7.54294 -2.87305,-8.92773 -0.48385,-1.0255 -2.79121,-2.81946 -5.9668,-5.08594 -3.1756,-2.26648 -7.18435,-5.16145 -11.09179,-9.13867 -5.64956,-5.75043 -7.52696,-10.47257 -10.75391,-14.30859 z"
+       id="button5"
+       inkscape:connector-curvature="0" />
+    <path
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+       d="m 301.78809,455.0235 c -0.2041,0.0625 -22.69138,6.94779 -31.05859,9.66406 -7.0786,2.29794 -15.80567,3.95226 -23.23438,5.79687 -3.71436,0.9223 -7.10255,1.89212 -9.76172,2.98633 -2.65917,1.09421 -4.55098,2.34251 -5.35351,3.56445 -0.32729,0.49833 -1.03707,2.10181 -1.82032,4.25782 -0.78323,2.15601 -1.69172,4.92266 -2.63281,8.00586 -1.88217,6.16639 -3.89503,13.60744 -5.31836,20.04297 -3.97941,17.99283 -4.78941,24.33452 -4.91406,26.4121 l -0.004,0.0391 -0.006,0.0391 c -1.65377,11.80086 4.55451,19.84194 6.11524,29.8418 v 0.002 0.004 c 0.70045,4.6383 1.37647,15.00633 1.77344,25.36914 h 66.86132 c -0.20242,-0.82316 -0.31835,-1.72663 -0.31835,-2.72657 v -30.91015 c 0,-1.5646 0.0298,-2.91299 0.28906,-4.12305 0.25923,-1.21006 0.79041,-2.30911 1.74023,-3.12305 1.75691,-1.50557 4.76419,-1.95047 9.56836,-2.01757 v -7.00391 c -2.27566,-0.74891 -4.55999,-1.57421 -6.40039,-3.25195 -2.02877,-1.84947 -3.39193,-4.69071 -3.57226,-9.05274 v -0.0176 l -0.17774,-25.90429 0.002,-0.0117 c 0.0742,-4.01352 1.3266,-7.07402 3.32618,-9.26953 1.81952,-1.99781 4.24144,-3.20154 6.82226,-3.99414 V 455.0235 h -1.92383 z"
+       id="button0"
+       inkscape:connector-curvature="0" />
+    <rect
+       inkscape:label="#rect932"
+       ry="9.3904476"
+       rx="9.3904476"
+       y="493.13071"
+       x="297.58524"
+       height="44.649994"
+       width="18.780895"
+       id="button2"
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:0.95555294;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 317.54607,570.04977 v -14.86768 c 0,-3.32226 -2.53923,-3.17407 -10.93958,-3.17407 -8.40035,0 -10.75737,-0.17634 -10.75737,3.17407 v 14.99268 c 0,0.8228 0.29258,1.29021 0.94502,1.28789 l 19.59359,-0.0698 c 0.59119,-0.002 1.15834,-0.75189 1.15834,-1.34309 z"
+       id="button7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sszsssss" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 296.79395,573.25201 c -0.65244,0 -0.94531,0.46626 -0.94531,1.28906 v 13.6836 c 0.125,3.125 1.04518,4.18009 3.82812,4.92578 1.12947,0.30264 3.08418,0.75 6.92969,0.75 3.81789,0 6.10173,-0.5475 7.0957,-0.8125 2.12312,-0.56604 3.84375,-1.86328 3.84375,-4.48828 v -13.9336 c 0,-1.00605 -0.19935,-1.34375 -1.1582,-1.34375 z"
+       id="button6"
+       inkscape:connector-curvature="0" />
+    <g
+       id="button6_display"
+       transform="translate(9.375)">
+      <path
+         style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:1.00157475;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 308.17107,574.66517 v 13.93462 c 0,2.625 -1.72177,3.92183 -3.84489,4.48787 -0.99397,0.265 -3.2768,0.8125 -7.09469,0.8125 -3.84551,0 -5.80056,-0.44736 -6.93003,-0.75 -2.78294,-0.74569 -3.70234,-1.80037 -3.82734,-4.92537 v -13.68462 c 0,-0.8228 0.29258,-1.28789 0.94502,-1.28789 l 19.59359,0.0698 c 0.95885,0 1.15834,0.33708 1.15834,1.34313 z"
+         id="path881"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccsssccccc" />
+      <path
+         sodipodi:nodetypes="ccssscccccc"
+         inkscape:connector-curvature="0"
+         id="path887"
+         d="m 305.94925,578.41236 v 11.44465 c 0,1.89399 -1.36914,2.82964 -3.05745,3.23806 -0.79039,0.19121 -2.6057,0.58622 -5.64165,0.58622 -3.05794,0 -4.61258,-0.32275 -5.51073,-0.54111 -2.21298,-0.53804 -2.94407,-1.299 -3.04348,-3.55374 v -11.26427 c 0,-0.59365 0.23266,-0.92923 0.75146,-0.92923 l 15.58075,0.0504 c 0.76248,0 0.9211,0.24322 0.9211,0.96912 z"
+         style="fill:#ffffff;fill-opacity:0.96808543;fill-rule:evenodd;stroke:#babdb6;stroke-width:1.07756317;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    </g>
+    <path
+       style="fill:#ffffff;fill-opacity:0.95744683;fill-rule:evenodd;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 209.62423,568.36356 4.38194,16.06189 c 0.13731,0.50331 0.96886,1.08051 1.80175,1.07101 l 4.97687,-0.0568 c 0,-4.59959 -0.79551,-19.47653 -1.85616,-21.33269 l -7.80182,0.91593 c -1.68398,0.69611 -1.84744,2.07658 -1.50258,3.34066 z"
+       id="path1034"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ssscccs" />
+    <path
+       sodipodi:nodetypes="ssscccs"
+       inkscape:connector-curvature="0"
+       id="path1040"
+       d="m 211.08263,606.38285 2.92354,-16.06189 c 0.0934,-0.51328 0.96886,-1.08051 1.80175,-1.07101 l 4.97687,0.0568 v 21.86302 l -8.19958,-1.44626 c -1.68398,-0.69611 -1.73721,-2.05156 -1.50258,-3.34066 z"
+       style="fill:#ffffff;fill-opacity:0.95744683;fill-rule:evenodd;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#ffffff;fill-opacity:0.95744683;fill-rule:evenodd;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 211.03844,619.90775 2.96773,16.06189 c 0.0948,0.51302 0.96886,1.08051 1.80175,1.07101 l 4.97687,-0.0568 v -21.86302 l -8.24377,1.44626 c -1.68398,0.69611 -1.74064,2.05219 -1.50258,3.34066 z"
+       id="path1046"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ssscccs" />
+    <path
+       sodipodi:nodetypes="csscccsc"
+       inkscape:connector-curvature="0"
+       id="path1052"
+       d="m 209.62423,657.92703 4.38194,-16.06189 c 0.13731,-0.50331 0.96886,-1.08051 1.80175,-1.07101 l 4.97687,0.0568 c 0,12.5754 -1.75,21.07013 -1.75,21.07013 l -7.90798,-0.65341 c -1.68398,-0.69611 -1.84744,-2.07658 -1.50258,-3.34066 z"
+       style="fill:#ffffff;fill-opacity:0.95744683;fill-rule:evenodd;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 115.88754,540.26219 c -4.80719,0.51565 -14.31496,3.6734 -21.42959,10.8135 -7.11462,7.1401 -10.45897,19.07742 -10.49068,20.94911 -0.0315,1.87171 1.62169,2.54594 3.50717,2.58156 l 27.61447,0.25899 c 1.56447,0.0296 2.10245,-0.63388 2.19024,-1.55013 l 2.05208,-31.1727 c 0.13612,-1.96151 -1.65745,-2.07195 -3.44369,-1.88033 z"
+       id="button8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 135.18361,575.03681 13.9245,-0.0548 c 0.95181,-0.006 1.91769,-0.64275 1.83538,-1.50171 l -2.08271,-31.55134 c -0.10579,-1.52411 -1.21573,-2.47425 -2.4445,-2.46754 l -11.23267,0.0614 -11.23267,-0.0614 c -1.22877,-0.007 -2.33871,0.94343 -2.4445,2.46754 l -2.08271,31.55134 c -0.0823,0.85896 0.88357,1.49571 1.83538,1.50171 z"
+       id="button9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 154.47968,540.26219 c 4.80719,0.51565 14.31496,3.6734 21.42959,10.8135 7.11462,7.1401 10.45897,19.07742 10.49068,20.94911 0.0315,1.87171 -1.62169,2.54594 -3.50717,2.58156 l -27.61447,0.25899 c -1.56447,0.0296 -2.10245,-0.63388 -2.19024,-1.55013 l -2.05208,-31.1727 c -0.13612,-1.96151 1.65745,-2.07195 3.44369,-1.88033 z"
+       id="button10"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 85.82494,579.88024 c -2.16094,-0.0408 -4.32261,1.33038 -4.43564,3.19961 l -1.36888,22.63753 c -0.17186,2.84203 0.11,4.55771 4.49267,4.58243 l 29.4679,0.17168 c 1.37626,0.0247 1.98363,-0.70072 1.98862,-1.40478 l -0.0758,-27.28653 c -0.003,-1.01454 -0.53451,-1.73969 -2.14545,-1.74815 z"
+       id="button11"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 135.18361,610.76445 15.07974,-0.18321 c 0.99312,-0.0116 1.81361,-0.51191 1.81675,-1.19446 l 0.0752,-27.03406 c 0.006,-1.26023 -0.61167,-2.22478 -2.65418,-2.18619 h -5e-5 l -14.31746,-0.0531 -14.31746,0.0531 h -5e-5 c -2.04251,-0.0386 -2.66018,0.92596 -2.65418,2.18619 l 0.0752,27.03406 c 0.003,0.68255 0.82363,1.18286 1.81675,1.19446 z"
+       id="button12"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 184.54228,579.88024 c 2.16094,-0.0408 4.32261,1.33038 4.43564,3.19961 l 1.36888,22.63753 c 0.17186,2.84203 -0.11,4.55771 -4.49267,4.58243 l -29.4679,0.17168 c -1.37626,0.0247 -1.98363,-0.70072 -1.98862,-1.40478 l 0.0758,-27.28653 c 0.003,-1.01454 0.53451,-1.73969 2.14545,-1.74815 z"
+       id="button13"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 80.50582,643.04662 79.37069,619.9328 c -0.24173,-2.48253 1.33364,-4.13562 4.89289,-4.07182 l 29.57569,0.0489 c 1.94508,0.0348 2.59435,1.17588 2.62067,2.70772 l 0.28732,26.82168 c 0.0101,0.5859 -0.67745,1.26303 -1.71098,1.24491 l -29.11335,-0.0398 c -4.17072,-0.073 -5.23962,-1.81604 -5.41711,-3.59787 z"
+       id="button14"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 135.18361,646.89171 14.52026,-0.10891 c 0.99322,-0.007 1.58396,-0.88183 1.59477,-1.54896 l 0.25382,-26.4228 c 0,-1.65769 -1.45683,-2.75487 -3.18546,-2.75487 h -2e-5 l -13.18337,0.0687 -13.18337,-0.0687 h -2e-5 c -1.72863,0 -3.18546,1.09718 -3.18546,2.75487 l 0.25382,26.4228 c 0.0108,0.66713 0.60155,1.54196 1.59477,1.54896 z"
+       id="button15"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 189.8614,643.04662 1.13513,-23.11382 c 0.24173,-2.48253 -1.33364,-4.13562 -4.89289,-4.07182 l -29.57569,0.0489 c -1.94508,0.0348 -2.59435,1.17588 -2.62067,2.70772 l -0.28732,26.82168 c -0.0101,0.5859 0.67745,1.26303 1.71098,1.24491 l 29.11335,-0.0398 c 4.17072,-0.073 5.23962,-1.81604 5.41711,-3.59787 z"
+       id="button16"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 116.48518,685.17935 c -4.77115,-0.78167 -18.24679,-2.41108 -25.31793,-10.40346 -7.07116,-7.99239 -8.74824,-18.08146 -8.63646,-19.81545 0.11174,-1.73398 1.07559,-2.61519 2.96106,-2.58216 l 29.30706,0.0261 c 2.05074,0.0358 2.50413,0.83976 2.56363,1.65636 l 1.57605,28.79352 c 0.0961,1.9639 -0.68056,2.61555 -2.45341,2.32504 z"
+       id="button17"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 135.18361,652.57963 13.80437,-0.0599 c 0.95179,-0.004 1.77573,0.31134 1.70695,1.10833 l -1.60072,29.8687 c -0.0884,1.52525 -1.61326,2.56485 -2.84205,2.56909 v -2e-5 l -11.06855,0.0382 -11.06855,-0.0382 v 2e-5 c -1.22879,-0.004 -2.75365,-1.04384 -2.84205,-2.56909 l -1.60072,-29.8687 c -0.0688,-0.79699 0.75516,-1.11233 1.70695,-1.10833 z"
+       id="button18"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 153.88204,685.17935 c 4.77115,-0.78167 18.24679,-2.41108 25.31793,-10.40346 7.07116,-7.99239 8.74824,-18.08146 8.63646,-19.81545 -0.11174,-1.73398 -1.07559,-2.61519 -2.96106,-2.58216 l -29.30706,0.0261 c -2.05074,0.0358 -2.50413,0.83976 -2.56363,1.65636 l -1.57605,28.79352 c -0.0961,1.9639 0.68056,2.61555 2.45341,2.32504 z"
+       id="button19"
+       inkscape:connector-curvature="0" />
+    <g
+       id="led0">
+      <g
+         transform="matrix(1.4511635,0,0,1.4511635,182.99832,-277.36148)"
+         aria-label="G9"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.03525925px;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.62751919;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="text9308">
+        <path
+           d="m -60.264331,579.04744 v -3.1611 q 0,-0.71251 0.291023,-1.22431 0.250881,-0.43151 0.692433,-0.68239 0.481692,-0.28099 1.16409,-0.28099 0.682397,0 1.16409,0.28099 0.431516,0.25088 0.692433,0.69243 0.180634,0.31109 0.240846,0.66233 l -1.16409,0.27095 q -0.03011,-0.21074 -0.130459,-0.38134 -0.120423,-0.21074 -0.321128,-0.32113 -0.200705,-0.12042 -0.481692,-0.12042 -0.270952,0 -0.471657,0.12042 -0.19067,0.11039 -0.311094,0.32113 -0.160564,0.27095 -0.160564,0.66233 v 3.1611 q 0,0.40141 0.160564,0.67236 0.120424,0.21074 0.311094,0.32113 0.190669,0.11039 0.451586,0.11039 0.230811,0 0.401411,-0.10035 0.180634,-0.10035 0.301057,-0.30106 0.160564,-0.28099 0.160564,-0.70247 v -0.91321 h -0.852997 v -1.0838 h 2.057229 v 1.99701 q 0,0.73258 -0.301058,1.24437 -0.250882,0.43152 -0.672363,0.6824 -0.451586,0.26092 -1.093843,0.26092 -0.672362,0 -1.144019,-0.28099 -0.441552,-0.25088 -0.692433,-0.6824 -0.291023,-0.51179 -0.291023,-1.2243 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1176"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -55.246701,576.35799 v -0.3713 q 0,-0.77272 0.311093,-1.31462 0.260917,-0.45159 0.702468,-0.70247 0.471657,-0.27095 1.113914,-0.27095 0.622186,0 1.083808,0.26092 0.451586,0.26091 0.712503,0.73257 0.351234,0.60211 0.351234,1.47518 v 2.40846 q 0,0.98346 -0.38134,1.63575 -0.291022,0.49173 -0.742609,0.76268 -0.451586,0.26092 -1.063737,0.26092 -0.602116,0 -1.053702,-0.26092 -0.461622,-0.26092 -0.752645,-0.76268 -0.160564,-0.28099 -0.250881,-0.61215 l 1.093843,-0.46162 q 0.06021,0.30106 0.19067,0.53187 0.150529,0.26091 0.361269,0.38134 0.180635,0.10035 0.411446,0.10035 0.220775,0 0.391375,-0.10035 0.200705,-0.12043 0.351234,-0.36127 0.240846,-0.42148 0.240846,-1.11392 v -0.32112 q -0.130458,0.13045 -0.291022,0.23081 -0.280988,0.16056 -0.692433,0.16056 -0.602116,0 -1.073773,-0.28099 -0.441551,-0.25088 -0.702468,-0.70246 -0.311093,-0.54191 -0.311093,-1.30459 z m 1.204231,0 q 0,0.47166 0.180635,0.77272 0.120423,0.21074 0.311093,0.32113 0.180634,0.10035 0.421481,0.11038 0.250881,0 0.451586,-0.11038 0.200705,-0.12043 0.331164,-0.3412 0.170599,-0.30106 0.170599,-0.75265 v -0.19067 q 0,-0.58204 -0.21074,-0.94331 -0.130459,-0.23081 -0.331164,-0.3412 -0.170599,-0.10035 -0.40141,-0.10035 -0.240846,0 -0.421481,0.11038 -0.200705,0.11039 -0.321128,0.33117 -0.180635,0.30106 -0.180635,0.76268 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1178"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(1.4511635,0,0,1.4511635,182.99832,-277.36148)"
+         aria-label="G11"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.03525925px;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.62751919;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="text2158">
+        <path
+           d="m -17.484378,579.22426 v -3.16111 q 0,-0.7125 0.291023,-1.2243 0.250881,-0.43151 0.692433,-0.6824 0.481692,-0.28098 1.16409,-0.28098 0.682397,0 1.16409,0.28098 0.431516,0.25089 0.692433,0.69244 0.180634,0.31109 0.240846,0.66232 l -1.16409,0.27096 q -0.03011,-0.21074 -0.130459,-0.38134 -0.120423,-0.21074 -0.321128,-0.32113 -0.200705,-0.12042 -0.481692,-0.12042 -0.270952,0 -0.471657,0.12042 -0.19067,0.11039 -0.311094,0.32113 -0.160564,0.27095 -0.160564,0.66232 v 3.16111 q 0,0.40141 0.160564,0.67236 0.120424,0.21074 0.311094,0.32113 0.190669,0.11039 0.451586,0.11039 0.230811,0 0.401411,-0.10035 0.180634,-0.10036 0.301057,-0.30106 0.160564,-0.28099 0.160564,-0.70247 v -0.91321 h -0.852997 v -1.08381 h 2.057229 v 1.99702 q 0,0.73257 -0.301058,1.24437 -0.250882,0.43152 -0.672363,0.6824 -0.451586,0.26092 -1.093843,0.26092 -0.672362,0 -1.144019,-0.28099 -0.441552,-0.25088 -0.692433,-0.6824 -0.291023,-0.5118 -0.291023,-1.2243 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1162"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -12.155655,575.11984 1.525359,-1.16409 h 1.2042314 v 7.37592 h -1.2042314 v -5.96095 l -0.80282,0.61215 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1164"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -7.1380255,575.11984 1.5253594,-1.16409 h 1.2042311 v 7.37592 h -1.2042311 v -5.96095 l -0.8028207,0.61215 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1166"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(1.4511635,0,0,1.4511635,182.99832,-277.36148)"
+         aria-label="G12"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.03525925px;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.62751919;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="text2162">
+        <path
+           d="m -64.153415,602.57418 v -3.16111 q 0,-0.7125 0.291023,-1.2243 0.250881,-0.43152 0.692433,-0.6824 0.481692,-0.28099 1.16409,-0.28099 0.682397,0 1.16409,0.28099 0.431516,0.25088 0.692433,0.69243 0.180634,0.3111 0.240846,0.66233 l -1.16409,0.27095 q -0.03011,-0.21074 -0.130458,-0.38134 -0.120424,-0.21074 -0.321129,-0.32113 -0.200705,-0.12042 -0.481692,-0.12042 -0.270952,0 -0.471657,0.12042 -0.19067,0.11039 -0.311093,0.32113 -0.160565,0.27095 -0.160565,0.66233 v 3.16111 q 0,0.40141 0.160565,0.67236 0.120423,0.21074 0.311093,0.32113 0.19067,0.11038 0.451586,0.11038 0.230811,0 0.401411,-0.10035 0.180634,-0.10035 0.301057,-0.30106 0.160565,-0.28098 0.160565,-0.70246 v -0.91321 h -0.852997 v -1.08381 h 2.057228 v 1.99702 q 0,0.73257 -0.301058,1.24437 -0.250882,0.43151 -0.672362,0.68239 -0.451587,0.26092 -1.093844,0.26092 -0.672362,0 -1.144019,-0.28099 -0.441552,-0.25088 -0.692433,-0.68239 -0.291023,-0.5118 -0.291023,-1.2243 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1181"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -58.824692,598.46975 1.525359,-1.16409 h 1.204232 v 7.37592 h -1.204232 v -5.96094 l -0.80282,0.61215 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1183"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -54.08805,598.86113 q 0.06021,-0.36127 0.240847,-0.67236 0.250881,-0.43152 0.682397,-0.6824 0.481693,-0.28099 1.154055,-0.28099 0.672362,0 1.154055,0.28099 0.431516,0.25088 0.682397,0.6824 0.291023,0.50176 0.291023,1.10388 0,0.59208 -0.331164,1.16409 -0.280987,0.49172 -1.113913,1.21426 -0.832927,0.72254 -1.133985,1.23434 -0.170599,0.29102 -0.260916,0.69243 h 2.799837 v 1.08381 h -4.114456 v -0.01 q 0,-1.425 0.451586,-2.20775 0.341199,-0.59208 1.274478,-1.35476 0.76268,-0.63222 1.003526,-1.04367 0.220776,-0.39137 0.220776,-0.77271 0,-0.3111 -0.140494,-0.56198 -0.110388,-0.2007 -0.301058,-0.30106 -0.200705,-0.12042 -0.481692,-0.12042 -0.270952,0 -0.461622,0.11039 -0.19067,0.11039 -0.311093,0.32113 -0.100353,0.1706 -0.130458,0.38134 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1185"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(1.4511635,0,0,1.4511635,182.99832,-277.36148)"
+         aria-label="G13"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.03525925px;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.62751919;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="text2166">
+        <path
+           d="m -39.916858,602.57418 v -3.16111 q 0,-0.7125 0.291023,-1.2243 0.250881,-0.43152 0.692433,-0.6824 0.481692,-0.28099 1.16409,-0.28099 0.682397,0 1.16409,0.28099 0.431516,0.25088 0.692433,0.69243 0.180634,0.3111 0.240846,0.66233 l -1.16409,0.27095 q -0.03011,-0.21074 -0.130458,-0.38134 -0.120424,-0.21074 -0.321129,-0.32113 -0.200705,-0.12042 -0.481692,-0.12042 -0.270952,0 -0.471657,0.12042 -0.19067,0.11039 -0.311093,0.32113 -0.160565,0.27095 -0.160565,0.66233 v 3.16111 q 0,0.40141 0.160565,0.67236 0.120423,0.21074 0.311093,0.32113 0.19067,0.11038 0.451586,0.11038 0.230811,0 0.401411,-0.10035 0.180634,-0.10035 0.301057,-0.30106 0.160565,-0.28098 0.160565,-0.70246 v -0.91321 h -0.852997 v -1.08381 h 2.057228 v 1.99702 q 0,0.73257 -0.301058,1.24437 -0.250882,0.43151 -0.672362,0.68239 -0.451587,0.26092 -1.093844,0.26092 -0.672362,0 -1.144019,-0.28099 -0.441552,-0.25088 -0.692433,-0.68239 -0.291023,-0.5118 -0.291023,-1.2243 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1188"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -34.588135,598.46975 1.525359,-1.16409 h 1.204232 v 7.37592 h -1.204232 v -5.96094 l -0.80282,0.61215 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1190"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -29.931775,603.12611 1.154055,-0.31109 q 0.04014,0.21074 0.140494,0.37131 0.130458,0.23081 0.351234,0.36127 0.220776,0.13045 0.521833,0.13045 0.592081,0 0.873068,-0.48169 0.160564,-0.28099 0.160564,-0.64226 0,-0.34119 -0.160564,-0.61215 -0.160564,-0.27095 -0.431516,-0.43151 -0.341199,-0.20071 -1.013561,-0.20071 v -1.08381 q 0.632221,0 0.943314,-0.18063 0.240846,-0.14049 0.371304,-0.36127 0.130459,-0.23081 0.130459,-0.49173 0,-0.27095 -0.120423,-0.49172 -0.100353,-0.18064 -0.280988,-0.28099 -0.190669,-0.11039 -0.451586,-0.11039 -0.491728,0 -0.722539,0.40141 -0.100352,0.1706 -0.120423,0.3713 l -1.184161,-0.22077 q 0.05018,-0.38134 0.240847,-0.7125 0.240846,-0.41145 0.662327,-0.6523 0.471657,-0.27095 1.123949,-0.27095 0.662327,0 1.123949,0.27095 0.411445,0.24085 0.662327,0.6523 0.280987,0.48169 0.270952,1.03363 0,0.48169 -0.230811,0.8831 -0.230811,0.40141 -0.652292,0.65229 -0.05018,0.0301 -0.100352,0.0502 0.09032,0.0401 0.160564,0.0803 0.461622,0.27095 0.722538,0.7125 0.260917,0.45159 0.260917,1.00353 0,0.64226 -0.311093,1.18416 -0.270952,0.46162 -0.722539,0.72254 -0.501763,0.29102 -1.204231,0.29102 -0.702468,0 -1.204231,-0.29102 -0.451586,-0.26092 -0.722538,-0.72254 -0.1706,-0.29102 -0.240847,-0.62219 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1192"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(1.4511635,0,0,1.4511635,182.99832,-277.36148)"
+         aria-label="G14"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.03525925px;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.62751919;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="text2170">
+        <path
+           d="m -15.539815,602.57418 v -3.16111 q 0,-0.7125 0.291023,-1.2243 0.250881,-0.43152 0.692433,-0.6824 0.481692,-0.28099 1.16409,-0.28099 0.682397,0 1.16409,0.28099 0.431516,0.25088 0.692433,0.69243 0.180634,0.3111 0.240846,0.66233 l -1.16409,0.27095 q -0.03011,-0.21074 -0.130459,-0.38134 -0.120423,-0.21074 -0.321128,-0.32113 -0.200705,-0.12042 -0.481692,-0.12042 -0.270952,0 -0.471658,0.12042 -0.19067,0.11039 -0.311093,0.32113 -0.160564,0.27095 -0.160564,0.66233 v 3.16111 q 0,0.40141 0.160564,0.67236 0.120423,0.21074 0.311093,0.32113 0.19067,0.11038 0.451587,0.11038 0.230811,0 0.40141,-0.10035 0.180635,-0.10035 0.301058,-0.30106 0.160564,-0.28098 0.160564,-0.70246 v -0.91321 h -0.852997 v -1.08381 h 2.057228 v 1.99702 q 0,0.73257 -0.301057,1.24437 -0.250882,0.43151 -0.672363,0.68239 -0.451586,0.26092 -1.093843,0.26092 -0.672362,0 -1.144019,-0.28099 -0.441552,-0.25088 -0.692433,-0.68239 -0.291023,-0.5118 -0.291023,-1.2243 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1155"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -10.211092,598.46975 1.5253592,-1.16409 h 1.2042311 v 7.37592 h -1.2042311 v -5.96094 l -0.8028207,0.61215 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1157"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -5.5045556,602.81502 v -1.08381 l 1.9970166,-4.42555 h 1.4751831 v 4.42555 h 0.7225386 v 1.08381 h -0.7225386 v 1.86656 H -3.236587 v -1.86656 z m 1.1741253,-1.08381 h 1.0938433 v -2.40846 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1159"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(1.4511635,0,0,1.4511635,182.99832,-277.36148)"
+         aria-label="G15"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.03525925px;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.62751919;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="text2174">
+        <path
+           d="m -64.506976,628.01467 v -3.16111 q 0,-0.7125 0.291022,-1.2243 0.250882,-0.43152 0.692433,-0.6824 0.481693,-0.28099 1.16409,-0.28099 0.682398,0 1.164091,0.28099 0.431516,0.25088 0.692432,0.69243 0.180635,0.3111 0.240847,0.66233 l -1.16409,0.27095 q -0.03011,-0.21074 -0.130459,-0.38134 -0.120423,-0.21074 -0.321128,-0.32113 -0.200705,-0.12042 -0.481693,-0.12042 -0.270952,0 -0.471657,0.12042 -0.19067,0.11039 -0.311093,0.32113 -0.160564,0.27095 -0.160564,0.66233 v 3.16111 q 0,0.40141 0.160564,0.67236 0.120423,0.21074 0.311093,0.32113 0.19067,0.11038 0.451587,0.11038 0.230811,0 0.40141,-0.10035 0.180635,-0.10035 0.301058,-0.30106 0.160564,-0.28098 0.160564,-0.70246 v -0.91321 h -0.852997 v -1.08381 h 2.057228 v 1.99702 q 0,0.73257 -0.301057,1.24437 -0.250882,0.43151 -0.672363,0.6824 -0.451586,0.26091 -1.093843,0.26091 -0.672362,0 -1.14402,-0.28098 -0.441551,-0.25089 -0.692433,-0.6824 -0.291022,-0.5118 -0.291022,-1.2243 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1134"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -59.178253,623.91024 1.525359,-1.16409 h 1.204231 v 7.37592 h -1.204231 v -5.96094 l -0.802821,0.61215 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1136"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -54.441611,628.56661 1.123949,-0.38134 q 0.05018,0.26091 0.170599,0.46162 0.140494,0.24084 0.351234,0.36127 0.19067,0.11038 0.431517,0.11038 0.240846,0 0.421481,-0.10035 0.200705,-0.12042 0.341198,-0.35123 0.200706,-0.35124 0.200706,-0.91321 0,-0.56198 -0.200706,-0.91321 -0.130458,-0.23081 -0.331163,-0.3412 -0.1706,-0.10035 -0.391375,-0.0903 -0.230811,0 -0.411446,0.10036 -0.200705,0.12042 -0.341199,0.35123 -0.09032,0.15053 -0.130458,0.33116 l -1.083808,-0.48169 v -3.96393 h 3.803363 v 1.08381 h -2.599132 v 1.61568 q 0.341199,-0.12042 0.76268,-0.12042 0.61215,0 1.073772,0.26091 0.441552,0.25088 0.712504,0.72254 0.341199,0.59208 0.341199,1.45511 0,0.853 -0.341199,1.43505 -0.270952,0.47165 -0.722539,0.73257 -0.471657,0.27095 -1.103878,0.27095 -0.632222,0 -1.103879,-0.27095 -0.451587,-0.26092 -0.722539,-0.73257 -0.170599,-0.29103 -0.250881,-0.63222 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1138"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(1.4511635,0,0,1.4511635,182.99832,-277.36148)"
+         aria-label="G16"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.03525925px;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.62751919;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="text2178">
+        <path
+           d="m -40.200168,628.01467 v -3.16111 q 0,-0.7125 0.291023,-1.2243 0.250881,-0.43152 0.692433,-0.6824 0.481692,-0.28099 1.16409,-0.28099 0.682398,0 1.16409,0.28099 0.431516,0.25088 0.692433,0.69243 0.180635,0.3111 0.240846,0.66233 l -1.16409,0.27095 q -0.03011,-0.21074 -0.130458,-0.38134 -0.120423,-0.21074 -0.321129,-0.32113 -0.200705,-0.12042 -0.481692,-0.12042 -0.270952,0 -0.471657,0.12042 -0.19067,0.11039 -0.311093,0.32113 -0.160564,0.27095 -0.160564,0.66233 v 3.16111 q 0,0.40141 0.160564,0.67236 0.120423,0.21074 0.311093,0.32113 0.19067,0.11038 0.451586,0.11038 0.230811,0 0.401411,-0.10035 0.180634,-0.10035 0.301058,-0.30106 0.160564,-0.28098 0.160564,-0.70246 v -0.91321 h -0.852997 v -1.08381 h 2.057228 v 1.99702 q 0,0.73257 -0.301058,1.24437 -0.250881,0.43151 -0.672362,0.6824 -0.451587,0.26091 -1.093844,0.26091 -0.672362,0 -1.144019,-0.28098 -0.441552,-0.25089 -0.692433,-0.6824 -0.291023,-0.5118 -0.291023,-1.2243 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1141"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -34.871445,623.91024 1.525359,-1.16409 h 1.204232 v 7.37592 h -1.204232 v -5.96094 l -0.80282,0.61215 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1143"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -30.164908,627.91431 v -0.0201 q 0,-2.05723 0.742609,-3.34174 0.541904,-0.94331 1.455112,-1.46515 0.38134,-0.21074 0.782751,-0.3412 l 0.351234,1.03364 q -0.230811,0.0803 -0.431516,0.21074 -0.672363,0.39137 -1.083808,1.09384 -0.160565,0.27095 -0.280988,0.60212 0.280988,-0.0703 0.602116,-0.0703 0.652292,0 1.123949,0.27095 0.441551,0.25088 0.702468,0.70247 0.311093,0.5419 0.311093,1.31462 v 0.01 q 0,0.77272 -0.311093,1.31462 -0.260917,0.45159 -0.702468,0.70247 -0.471657,0.27095 -1.123949,0.27095 -0.652292,0 -1.123949,-0.27095 -0.441552,-0.25088 -0.702468,-0.70247 -0.311093,-0.5419 -0.311093,-1.31462 z m 1.204231,0 q 0,0.46163 0.170599,0.76268 0.130459,0.22078 0.331164,0.33117 0.19067,0.11038 0.431516,0.11038 0.250881,0 0.431516,-0.11038 0.200705,-0.11039 0.331164,-0.33117 0.170599,-0.30105 0.170599,-0.76268 v -0.01 q 0,-0.46162 -0.170599,-0.76268 -0.130459,-0.22078 -0.331164,-0.33117 -0.19067,-0.11038 -0.441551,-0.11038 -0.240847,0 -0.421481,0.11038 -0.200705,0.11039 -0.331164,0.33117 -0.170599,0.29102 -0.170599,0.76268 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1145"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(1.4511635,0,0,1.4511635,182.99832,-277.36148)"
+         aria-label="G17"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.03525925px;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.62751919;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="text2182">
+        <path
+           d="m -15.893374,628.01467 v -3.16111 q 0,-0.7125 0.291022,-1.2243 0.250882,-0.43152 0.692433,-0.6824 0.481692,-0.28099 1.16409,-0.28099 0.682398,0 1.16409,0.28099 0.431516,0.25088 0.692433,0.69243 0.180635,0.3111 0.240846,0.66233 l -1.16409,0.27095 q -0.03011,-0.21074 -0.130458,-0.38134 -0.120423,-0.21074 -0.321128,-0.32113 -0.200706,-0.12042 -0.481693,-0.12042 -0.270952,0 -0.471657,0.12042 -0.19067,0.11039 -0.311093,0.32113 -0.160564,0.27095 -0.160564,0.66233 v 3.16111 q 0,0.40141 0.160564,0.67236 0.120423,0.21074 0.311093,0.32113 0.19067,0.11038 0.451587,0.11038 0.230811,0 0.40141,-0.10035 0.180635,-0.10035 0.301058,-0.30106 0.160564,-0.28098 0.160564,-0.70246 v -0.91321 h -0.852997 v -1.08381 h 2.057228 v 1.99702 q 0,0.73257 -0.301058,1.24437 -0.250881,0.43151 -0.672362,0.6824 -0.451587,0.26091 -1.093843,0.26091 -0.672363,0 -1.14402,-0.28098 -0.441551,-0.25089 -0.692433,-0.6824 -0.291022,-0.5118 -0.291022,-1.2243 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1148"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -10.564652,623.91024 1.5253597,-1.16409 h 1.2042311 v 7.37592 h -1.2042311 v -5.96094 l -0.8028207,0.61215 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1150"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -5.777833,623.82996 v -1.08381 h 4.1144562 v 1.08381 l -2.3181448,6.29211 h -1.2845132 l 2.3081096,-6.29211 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1152"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(1.4511635,0,0,1.4511635,182.99832,-277.36148)"
+         aria-label="G18"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.03525925px;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.62751919;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="text2186">
+        <path
+           d="m -62.20888,651.87953 v -3.1611 q 0,-0.71251 0.291022,-1.2243 0.250882,-0.43152 0.692433,-0.6824 0.481693,-0.28099 1.16409,-0.28099 0.682398,0 1.16409,0.28099 0.431516,0.25088 0.692433,0.69243 0.180635,0.31109 0.240846,0.66233 l -1.16409,0.27095 q -0.03011,-0.21074 -0.130458,-0.38134 -0.120423,-0.21074 -0.321128,-0.32113 -0.200706,-0.12042 -0.481693,-0.12042 -0.270952,0 -0.471657,0.12042 -0.19067,0.11039 -0.311093,0.32113 -0.160564,0.27095 -0.160564,0.66233 v 3.1611 q 0,0.40141 0.160564,0.67237 0.120423,0.21074 0.311093,0.32112 0.19067,0.11039 0.451587,0.11039 0.230811,0 0.40141,-0.10035 0.180635,-0.10035 0.301058,-0.30106 0.160564,-0.28099 0.160564,-0.70247 v -0.9132 h -0.852997 v -1.08381 h 2.057228 v 1.99701 q 0,0.73258 -0.301058,1.24438 -0.250881,0.43151 -0.672362,0.68239 -0.451587,0.26092 -1.093843,0.26092 -0.672363,0 -1.14402,-0.28099 -0.441551,-0.25088 -0.692433,-0.68239 -0.291022,-0.5118 -0.291022,-1.22431 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1127"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -56.880158,647.77511 1.52536,-1.16409 h 1.204231 v 7.37592 h -1.204231 v -5.96095 l -0.802821,0.61216 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1129"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -52.173621,652.0401 q 0,-0.54191 0.280987,-1.03363 0.260917,-0.45159 0.812856,-0.81286 -0.421481,-0.31109 -0.642256,-0.69243 -0.280988,-0.48169 -0.280988,-1.0236 0,-0.59208 0.270952,-1.0537 0.230811,-0.40141 0.632222,-0.64226 0.441551,-0.25088 1.063737,-0.25088 0.622186,0 1.063738,0.25088 0.40141,0.23081 0.632221,0.64226 0.270952,0.47166 0.270952,1.0537 0,0.54191 -0.280987,1.0236 -0.220776,0.38134 -0.642257,0.69243 0.551939,0.36127 0.812856,0.81286 0.280987,0.48169 0.280987,1.03363 0,0.59208 -0.280987,1.07377 -0.240846,0.42148 -0.672362,0.67236 -0.491728,0.28099 -1.184161,0.28099 -0.692433,0 -1.18416,-0.28099 -0.431517,-0.25088 -0.672363,-0.67236 -0.280987,-0.48169 -0.280987,-1.07377 z m 1.204231,0.01 q 0,0.28099 0.130458,0.5118 0.110388,0.19067 0.301058,0.30106 0.210741,0.12042 0.501763,0.12042 0.291023,0 0.501763,-0.12042 0.19067,-0.11039 0.301058,-0.30106 0.130458,-0.22077 0.130458,-0.5118 0,-0.29102 -0.150529,-0.56197 -0.200705,-0.35124 -0.722538,-0.65229 -0.03011,-0.01 -0.06021,-0.0301 -0.03011,0.0201 -0.06021,0.0301 -0.521834,0.30105 -0.722539,0.65229 -0.160564,0.27095 -0.150529,0.56197 z m 0.291023,-4.08435 q -0.120424,0.21074 -0.120424,0.50177 0,0.29102 0.150529,0.56197 0.180635,0.31109 0.612151,0.58205 0.431516,-0.27096 0.612151,-0.58205 0.160564,-0.27095 0.150529,-0.56197 0,-0.28099 -0.120423,-0.50177 -0.100353,-0.1706 -0.260917,-0.26091 -0.160564,-0.0903 -0.38134,-0.0903 -0.220776,0 -0.38134,0.0903 -0.160564,0.0903 -0.260916,0.26091 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1131"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="matrix(1.4511635,0,0,1.4511635,182.99832,-277.36148)"
+         aria-label="G19"
+         style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:10.03525925px;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.62751919;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         id="text2190">
+        <path
+           d="m -40.023395,654.37953 v -3.1611 q 0,-0.71251 0.291023,-1.2243 0.250881,-0.43152 0.692433,-0.6824 0.481692,-0.28099 1.16409,-0.28099 0.682398,0 1.16409,0.28099 0.431516,0.25088 0.692433,0.69243 0.180635,0.31109 0.240846,0.66233 l -1.16409,0.27095 q -0.03011,-0.21074 -0.130458,-0.38134 -0.120423,-0.21074 -0.321129,-0.32113 -0.200705,-0.12042 -0.481692,-0.12042 -0.270952,0 -0.471657,0.12042 -0.19067,0.11039 -0.311093,0.32113 -0.160564,0.27095 -0.160564,0.66233 v 3.1611 q 0,0.40141 0.160564,0.67237 0.120423,0.21074 0.311093,0.32112 0.19067,0.11039 0.451586,0.11039 0.230811,0 0.401411,-0.10035 0.180634,-0.10035 0.301058,-0.30106 0.160564,-0.28099 0.160564,-0.70247 v -0.9132 h -0.852997 v -1.08381 h 2.057228 v 1.99701 q 0,0.73258 -0.301058,1.24438 -0.250881,0.43151 -0.672362,0.68239 -0.451587,0.26092 -1.093844,0.26092 -0.672362,0 -1.144019,-0.28099 -0.441552,-0.25088 -0.692433,-0.68239 -0.291023,-0.5118 -0.291023,-1.22431 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1120"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -34.694672,650.27511 1.52536,-1.16409 h 1.204231 v 7.37592 h -1.204231 v -5.96095 l -0.802821,0.61216 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1122"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m -29.988135,651.69008 v -0.3713 q 0,-0.77271 0.311093,-1.31462 0.260917,-0.45159 0.702468,-0.70247 0.471657,-0.27095 1.113914,-0.27095 0.622186,0 1.083808,0.26092 0.451586,0.26091 0.712503,0.73257 0.351234,0.60212 0.351234,1.47518 v 2.40847 q 0,0.98345 -0.38134,1.63574 -0.291022,0.49173 -0.742609,0.76268 -0.451587,0.26092 -1.063737,0.26092 -0.602116,0 -1.053703,-0.26092 -0.461621,-0.26091 -0.752644,-0.76268 -0.160564,-0.28098 -0.250881,-0.61215 l 1.093843,-0.46162 q 0.06021,0.30106 0.19067,0.53187 0.150529,0.26092 0.361269,0.38134 0.180635,0.10035 0.411446,0.10035 0.220775,0 0.391375,-0.10035 0.200705,-0.12042 0.351234,-0.36127 0.240846,-0.42148 0.240846,-1.11391 v -0.32113 q -0.130458,0.13046 -0.291022,0.23081 -0.280988,0.16056 -0.692433,0.16056 -0.602116,0 -1.073773,-0.28098 -0.441551,-0.25089 -0.702468,-0.70247 -0.311093,-0.54191 -0.311093,-1.30459 z m 1.204231,0 q 0,0.47166 0.180635,0.77272 0.120423,0.21074 0.311093,0.32113 0.180634,0.10035 0.42148,0.11039 0.250882,0 0.451587,-0.11039 0.200705,-0.12043 0.331164,-0.3412 0.170599,-0.30106 0.170599,-0.75265 v -0.19067 q 0,-0.58204 -0.21074,-0.94331 -0.130459,-0.23081 -0.331164,-0.3412 -0.170599,-0.10035 -0.40141,-0.10035 -0.240847,0 -0.421481,0.11039 -0.200705,0.11038 -0.321128,0.33116 -0.180635,0.30106 -0.180635,0.76268 z"
+           style="fill:#babdb6;fill-opacity:1;stroke-width:0.62751919;stroke-miterlimit:4;stroke-dasharray:none"
+           id="path1124"
+           inkscape:connector-curvature="0" />
+      </g>
+      <g
+         transform="translate(0,399.99999)"
+         id="g1255">
+        <path
+           d="m 157.1126,268.62231 v -4.58727 q 0,-1.03397 0.42232,-1.77666 0.36407,-0.62621 1.00483,-0.99028 0.69902,-0.40776 1.68929,-0.40776 0.99027,0 1.68928,0.40776 0.6262,0.36407 1.00484,1.00483 0.26213,0.45145 0.3495,0.96115 l -1.68928,0.39319 q -0.0437,-0.30581 -0.18932,-0.55338 -0.17475,-0.30582 -0.46601,-0.46601 -0.29125,-0.17475 -0.69901,-0.17475 -0.3932,0 -0.68445,0.17475 -0.2767,0.16019 -0.45145,0.46601 -0.23301,0.39319 -0.23301,0.96115 v 4.58727 q 0,0.58251 0.23301,0.97572 0.17475,0.30582 0.45145,0.466 0.27669,0.16019 0.65532,0.16019 0.33495,0 0.58251,-0.14562 0.26213,-0.14563 0.43689,-0.43689 0.233,-0.40776 0.233,-1.0194 v -1.3252 h -1.23783 v -1.57279 h 2.98537 v 2.89799 q 0,1.06309 -0.43688,1.8058 -0.36408,0.62619 -0.97571,0.99026 -0.65533,0.37864 -1.58735,0.37864 -0.97571,0 -1.66016,-0.40777 -0.64076,-0.36406 -1.00483,-0.99026 -0.42232,-0.7427 -0.42232,-1.77667 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path1113"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 164.43769,263.23408 q 0.0874,-0.52426 0.3495,-0.9757 0.36407,-0.62621 0.99028,-0.99028 0.69901,-0.40776 1.67472,-0.40776 0.97571,0 1.67472,0.40776 0.6262,0.36407 0.99027,0.99028 0.42232,0.72813 0.42232,1.60189 0,0.85921 -0.48057,1.68929 -0.40776,0.71358 -1.61647,1.7621 -1.20871,1.04853 -1.6456,1.79123 -0.24757,0.42232 -0.37863,1.00483 h 4.06302 v 1.57279 h -5.97075 v -0.0145 q 0,-2.06791 0.65533,-3.20381 0.49513,-0.85921 1.84947,-1.96598 1.10678,-0.91747 1.45628,-1.51454 0.32039,-0.56795 0.32039,-1.12134 0,-0.45144 -0.20388,-0.81551 -0.16019,-0.29126 -0.43689,-0.43689 -0.29125,-0.17474 -0.69901,-0.17474 -0.3932,0 -0.66989,0.16019 -0.27669,0.16018 -0.45145,0.46601 -0.14563,0.24756 -0.18931,0.55337 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path1115"
+           inkscape:connector-curvature="0" />
+        <path
+           sodipodi:nodetypes="ssccsccssccsccscccsccsccccsccscc"
+           inkscape:connector-curvature="0"
+           id="path220"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.36408421px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           d="m 171.6754,268.47698 v -4.29619 c 0,-0.74758 0.15049,-1.38352 0.45146,-1.9078 0.25244,-0.43689 0.59225,-0.77671 1.01943,-1.01943 0.45633,-0.26215 1.00003,-0.39322 1.6311,-0.39322 0.63109,0 1.17478,0.13104 1.6311,0.39322 0.4272,0.24272 0.76701,0.58254 1.01945,1.01943 0.30096,0.52428 0.45146,1.16022 0.45146,1.9078 v 4.29619 c 0,0.7476 -0.1505,1.38352 -0.45146,1.90781 -0.25244,0.4369 -0.59225,0.77672 -1.01945,1.01943 -0.45632,0.26214 -1.00001,0.39321 -1.6311,0.39321 -0.63107,0 -1.17477,-0.13104 -1.6311,-0.39321 -0.42718,-0.24271 -0.76699,-0.58253 -1.01943,-1.01943 -0.30097,-0.52429 -0.45146,-1.16021 -0.45146,-1.90781 z m 4.38357,-4.93698 c -0.0389,-0.17475 -0.0971,-0.33009 -0.17476,-0.46603 -0.12625,-0.21358 -0.28641,-0.37379 -0.48058,-0.48058 -0.17477,-0.10681 -0.38351,-0.1602 -0.62624,-0.1602 -0.24271,0 -0.45145,0.0534 -0.62621,0.1602 -0.19419,0.10681 -0.35439,0.267 -0.48059,0.48058 -0.16506,0.29128 -0.24758,0.66021 -0.24758,1.10682 v 2.82529 l 0.0729,2.1117 c 0.0389,0.17476 0.0971,0.3301 0.17477,0.46602 0.12626,0.2136 0.28641,0.37381 0.48058,0.4806 0.18447,0.10681 0.39321,0.1602 0.62622,0.1602 0.24273,0 0.45147,-0.0534 0.62623,-0.1602 0.19417,-0.10681 0.35438,-0.267 0.48058,-0.4806 0.16506,-0.29126 0.24758,-0.66021 0.24758,-1.10682 v -2.82529 z" />
+      </g>
+      <g
+         transform="translate(0,399.99999)"
+         id="g1248">
+        <path
+           d="m 125.30261,160.10922 v -4.58727 q 0,-1.03397 0.42232,-1.77667 0.36407,-0.6262 1.00483,-0.99026 0.69902,-0.40777 1.68929,-0.40777 0.99027,0 1.68928,0.40777 0.6262,0.36406 1.00484,1.00483 0.26213,0.45144 0.3495,0.96115 l -1.68928,0.39319 q -0.0437,-0.30582 -0.18932,-0.55339 -0.17475,-0.30582 -0.46601,-0.46601 -0.29125,-0.17475 -0.69901,-0.17475 -0.3932,0 -0.68445,0.17475 -0.2767,0.16019 -0.45145,0.46601 -0.233,0.39319 -0.233,0.96115 v 4.58727 q 0,0.58251 0.233,0.97572 0.17475,0.30582 0.45145,0.466 0.27669,0.16019 0.65532,0.16019 0.33495,0 0.58252,-0.14562 0.26213,-0.14562 0.43688,-0.43689 0.233,-0.40776 0.233,-1.0194 v -1.32521 h -1.23783 v -1.57277 h 2.98537 v 2.89798 q 0,1.0631 -0.43688,1.80579 -0.36407,0.6262 -0.97571,0.99027 -0.65533,0.37864 -1.58735,0.37864 -0.9757,0 -1.66016,-0.40776 -0.64076,-0.36407 -1.00483,-0.99028 -0.42232,-0.74269 -0.42232,-1.77666 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path1169"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 133.03546,154.15304 2.21354,-1.68929 h 1.74754 v 10.70367 H 135.249 v -8.65031 l -1.16502,0.88833 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.91063297;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+           id="path1171"
+           inkscape:connector-curvature="0" />
+        <path
+           d="m 139.86541,159.96389 v -4.29619 c 0,-0.74758 0.15049,-1.38352 0.45146,-1.9078 0.25244,-0.43689 0.59225,-0.77671 1.01943,-1.01943 0.45633,-0.26215 1.00003,-0.39322 1.6311,-0.39322 0.63109,0 1.17478,0.13104 1.6311,0.39322 0.4272,0.24272 0.76701,0.58254 1.01945,1.01943 0.30096,0.52428 0.45146,1.16022 0.45146,1.9078 v 4.29619 c 0,0.7476 -0.1505,1.38352 -0.45146,1.90781 -0.25244,0.4369 -0.59225,0.77672 -1.01945,1.01943 -0.45632,0.26214 -1.00001,0.39321 -1.6311,0.39321 -0.63107,0 -1.17477,-0.13104 -1.6311,-0.39321 -0.42718,-0.24271 -0.76699,-0.58253 -1.01943,-1.01943 -0.30097,-0.52429 -0.45146,-1.16021 -0.45146,-1.90781 z m 4.38357,-4.93698 c -0.0389,-0.17475 -0.0971,-0.33009 -0.17476,-0.46603 -0.12625,-0.21358 -0.28641,-0.37379 -0.48058,-0.48058 -0.17477,-0.10681 -0.38351,-0.1602 -0.62624,-0.1602 -0.24271,0 -0.45145,0.0534 -0.62621,0.1602 -0.19419,0.10681 -0.35439,0.267 -0.48059,0.48058 -0.16506,0.29128 -0.24758,0.66021 -0.24758,1.10682 v 2.82529 l 0.0729,2.1117 c 0.0389,0.17476 0.0971,0.3301 0.17477,0.46602 0.12626,0.2136 0.28641,0.37381 0.48058,0.4806 0.18447,0.10681 0.39321,0.1602 0.62622,0.1602 0.24273,0 0.45147,-0.0534 0.62623,-0.1602 0.19417,-0.10681 0.35438,-0.267 0.48058,-0.4806 0.16506,-0.29126 0.24758,-0.66021 0.24758,-1.10682 v -2.82529 z"
+           style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:6.27203655px;font-family:'Iosevka Nerd Font';-inkscape-font-specification:'Iosevka Nerd Font, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-feature-settings:normal;text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:lr-tb;text-anchor:start;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.36408421px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+           id="path1195"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ssccsccssccsccscccsccsccccsccscc" />
+      </g>
+    </g>
+    <g
+       id="button3">
+      <path
+         id="path1002"
+         transform="translate(16.168953,401.11334)"
+         d="m 290.80664,92.496094 c -4.94588,0 -8.91406,3.966229 -8.91406,8.912106 v 25.86914 c 0,4.94589 3.96818,8.91211 8.91406,8.91211 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.95555294;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path1016"
+         transform="translate(16.168953,401.11334)"
+         d="m 274.78516,110.49805 a 0.24906273,0.24906273 0 0 0 -0.17383,0.0781 l -4.3086,4.6543 a 0.24906273,0.24906273 0 0 0 0.008,0.3457 l 4.30664,4.30664 a 0.24906273,0.24906273 0 0 0 0.40429,-0.27734 l -1.90429,-4.20899 1.9082,-4.55468 a 0.24906273,0.24906273 0 0 0 -0.24023,-0.34375 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.95555294;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:connector-curvature="0" />
+    </g>
+    <g
+       id="button4">
+      <path
+         id="path1010"
+         transform="translate(16.168953,401.11334)"
+         d="m 290.80664,92.496094 v 43.693356 c 4.94589,0 8.91211,-3.96622 8.91211,-8.91211 V 101.4082 c 0,-4.945877 -3.96622,-8.912106 -8.91211,-8.912106 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:0.95555294;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:connector-curvature="0" />
+      <path
+         id="path1018"
+         d="m 306.69922,110.49805 a 0.24906273,0.24906273 0 0 0 -0.21484,0.34375 l 1.90624,4.55468 -1.90234,4.20899 a 0.24906273,0.24906273 0 0 0 0.40234,0.27734 l 4.3086,-4.30664 a 0.24906273,0.24906273 0 0 0 0.006,-0.3457 l -4.30664,-4.6543 a 0.24906273,0.24906273 0 0 0 -0.17578,-0.0781 0.24906273,0.24906273 0 0 0 -0.0234,0 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.95555294;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:connector-curvature="0"
+         transform="translate(16.168953,401.11334)" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-16.168953,-1.1133461)"
+     sodipodi:insensitive="true">
+    <g
+       id="button0-path"
+       transform="translate(9.3749998)">
+      <path
+         id="path2139"
+         d="M 474.62501,2.4496332 342.58718,2.4497772 258.12494,86.912022"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="rect1803"
+         width="7.2257466"
+         height="7.2257476"
+         x="255.31589"
+         y="82.485825" />
+      <rect
+         style="text-align:start;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button0-leader"
+         width="1"
+         height="1"
+         x="473.625"
+         y="1.9497052" />
+    </g>
+    <g
+       id="button1-path"
+       transform="translate(9.3749998)">
+      <path
+         id="path2137"
+         d="M 474.62501,38.649805 H 383.16173 L 334.69582,87.11572"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         y="82.485825"
+         x="332.24747"
+         height="7.2257476"
+         width="7.2257466"
+         id="rect1801"
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal" />
+      <rect
+         style="text-align:start;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="473.625"
+         y="38.149807" />
+    </g>
+    <g
+       id="button2-path"
+       transform="translate(9.3749998)">
+      <path
+         id="path2135"
+         d="m 474.62501,74.849906 h -51.81484 l -25.96455,25.964554 h -83.14774 l -16.20851,16.2085"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="rect1720"
+         width="7.2257466"
+         height="7.2257476"
+         x="293.98782"
+         y="113.16031" />
+      <rect
+         style="text-align:start;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button2-leader"
+         width="1"
+         height="1"
+         x="473.625"
+         y="74.349907" />
+    </g>
+    <g
+       id="button3-path"
+       transform="translate(9.3749998)">
+      <path
+         id="path2133"
+         d="m 474.62501,153.21473 h -52.59609 l -9.20777,-9.20777 h -116.0858 l -26.47859,-26.47859"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         y="113.31364"
+         x="265.98987"
+         height="7.2257476"
+         width="7.2257466"
+         id="rect1797"
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal" />
+      <rect
+         style="text-align:start;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button3-leader"
+         width="1"
+         height="1"
+         x="473.625"
+         y="152.71472" />
+    </g>
+    <g
+       id="button4-path"
+       transform="translate(9.2196297,0.24168689)">
+      <path
+         id="path2131"
+         d="M 474.78038,116.82546 H 326.99094"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="rect1799"
+         width="7.2257466"
+         height="7.2257476"
+         x="322.53781"
+         y="113.07195" />
+      <rect
+         y="116.32545"
+         x="473.78036"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="text-align:start;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal" />
+    </g>
+    <g
+       id="button5-path"
+       transform="translate(12.965777,-10.982106)">
+      <path
+         id="curva_3D.Curve.052-2"
+         d="m 471.03423,205.39703 -60.12242,2.9e-4 -32.00528,-32.00528"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         y="169.94836"
+         x="375.50232"
+         height="7.2257476"
+         width="7.2257466"
+         id="rect1805"
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal" />
+      <rect
+         style="text-align:start;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button5-leader"
+         width="1"
+         height="1"
+         x="470.03424"
+         y="204.89717" />
+    </g>
+    <g
+       id="button7-path"
+       transform="translate(9.3749998)">
+      <path
+         id="path2125"
+         d="M 474.62501,235.61517 H 422.81017 L 346.77434,159.57934 H 297.61426"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="155.95151"
+         x="293.88211"
+         height="7.2257476"
+         width="7.2257466"
+         id="rect1789"
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal" />
+      <rect
+         style="text-align:start;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button7-leader"
+         width="1"
+         height="1"
+         x="473.625"
+         y="235.11517" />
+    </g>
+    <g
+       id="button6-path"
+       transform="translate(9.3749998)">
+      <path
+         id="path2127"
+         d="m 474.62501,271.81531 -51.81484,-7e-5 -86.28147,-86.28147 h -38.96327"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="rect1791"
+         width="7.2257466"
+         height="7.2257476"
+         x="293.88211"
+         y="181.92424" />
+      <rect
+         style="text-align:start;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button6-leader"
+         width="1"
+         height="1"
+         x="473.625"
+         y="271.31528" />
+    </g>
+    <g
+       id="button8-path">
+      <path
+         inkscape:connector-curvature="0"
+         style="display:inline;fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 16.575719,42.353863 h 12.4999 l 74.815911,75.125547 v 70.56069"
+         id="path2157"
+         sodipodi:nodetypes="cccc"
+         transform="translate(-0.406666,-39.904158)" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button8-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="1.9497054" />
+      <rect
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="rect162"
+         width="7.2257466"
+         height="7.2257476"
+         x="99.871994"
+         y="144.50333" />
+    </g>
+    <g
+       id="button9-path">
+      <path
+         sodipodi:nodetypes="cc"
+         id="path2155"
+         d="m 16.169053,38.649805 h 12.4999 L 86.46269,96.443546 h 48.72092 v 45.106234"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button9-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="38.149807" />
+      <rect
+         y="137.76154"
+         x="131.57074"
+         height="7.2257476"
+         width="7.2257466"
+         id="rect1035"
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal" />
+    </g>
+    <g
+       id="button10-path">
+      <path
+         sodipodi:nodetypes="cc"
+         id="path2153"
+         d="m 16.169053,74.849906 h 12.4999 l 40.325143,40.325144 h 97.743664 v 32.96089"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button10-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="74.349953" />
+      <rect
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="rect1037"
+         width="7.2257466"
+         height="7.2257476"
+         x="163.12489"
+         y="144.50333" />
+    </g>
+    <g
+       id="button11-path">
+      <path
+         sodipodi:nodetypes="cccccc"
+         id="path2163"
+         d="m 16.169053,111.05006 h 12.4999 l 40.325143,40.32514 v 26.01729 h 26.35904 l 5.530214,5.53021"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button11-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="110.55006" />
+      <rect
+         y="178.29239"
+         x="99.871994"
+         height="7.2257476"
+         width="7.2257466"
+         id="rect1041"
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal" />
+    </g>
+    <g
+       id="button12-path">
+      <path
+         sodipodi:nodetypes="cccccc"
+         id="path2161"
+         d="m 16.169053,147.25016 h 12.4999 l 17.950105,15.5 v 14.64233 h 80.630872 l 5.43563,5.43563"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button12-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="146.75017" />
+      <rect
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="rect1043"
+         width="7.2257466"
+         height="7.2257476"
+         x="131.57074"
+         y="178.29239" />
+    </g>
+    <g
+       id="button13-path">
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path2159"
+         d="m 16.169053,183.45026 h 12.4999 l 6.057778,-6.05778 H 159.40227 l 4.68384,4.68385"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button13-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="182.95027" />
+      <rect
+         y="178.29239"
+         x="163.12489"
+         height="7.2257476"
+         width="7.2257466"
+         id="rect1045"
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal" />
+    </g>
+    <g
+       id="button14-path">
+      <path
+         sodipodi:nodetypes="cccccc"
+         id="path2147"
+         d="m 16.169053,219.65037 h 12.4999 l 18.168455,18.16846 v 11.79345 h 49.340047 l 4.440905,-4.44092"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button14-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="219.15038" />
+      <rect
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="rect1047"
+         width="7.2257466"
+         height="7.2257476"
+         x="99.871994"
+         y="241.18301" />
+    </g>
+    <g
+       id="button15-path">
+      <path
+         sodipodi:nodetypes="ccccc"
+         id="path2149"
+         d="m 16.169053,255.85047 h 12.4999 l 6.238195,-6.23819 h 92.322892 l 5.01466,-5.01467"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button15-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="255.35048" />
+      <rect
+         y="241.18301"
+         x="131.57074"
+         height="7.2257476"
+         width="7.2257466"
+         id="rect1049"
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal" />
+    </g>
+    <g
+       id="button16-path">
+      <path
+         sodipodi:nodetypes="cccccc"
+         id="path2151"
+         d="m 16.169053,292.05059 h 12.4999 l 31.942971,-31.94297 v -10.49534 h 98.790346 l 4.30819,-4.30819"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button16-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="291.55057" />
+      <rect
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="rect1051"
+         width="7.2257466"
+         height="7.2257476"
+         x="163.12489"
+         y="241.18301" />
+    </g>
+    <g
+       id="button17-path">
+      <path
+         sodipodi:nodetypes="cc"
+         id="path2165"
+         d="m 16.169053,328.25069 h 12.87351 l 31.194901,-31.1949 h 43.247396 v -17.19911"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button17-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="327.7507" />
+      <rect
+         y="276.38397"
+         x="99.871994"
+         height="7.2257476"
+         width="7.2257466"
+         id="rect1053"
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal" />
+    </g>
+    <g
+       id="button18-path">
+      <path
+         sodipodi:nodetypes="cc"
+         id="path2143"
+         d="m 16.169053,364.45079 h 12.87351 l 52.60771,-52.60771 h 53.533337 v -27.94574"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button18-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="363.95081" />
+      <rect
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="rect1055"
+         width="7.2257466"
+         height="7.2257476"
+         x="131.57074"
+         y="280.74683" />
+    </g>
+    <g
+       id="button19-path">
+      <path
+         sodipodi:nodetypes="cccccc"
+         id="path2145"
+         d="m 16.169053,400.65091 h 12.87351 l 74.442297,-74.4423 h 43.47403 19.77887 v -46.23888"
+         style="fill:none;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="button19-leader"
+         width="1"
+         height="1"
+         x="16.169052"
+         y="400.15091" />
+      <rect
+         y="276.38397"
+         x="163.12489"
+         height="7.2257476"
+         width="7.2257466"
+         id="rect1057"
+         style="display:inline;opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     style="display:inline"
+     transform="translate(-16.168953,-1.1133461)">
+    <g
+       id="led0-path"
+       transform="translate(-227.87737,-0.70864333)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path1140"
+         d="M 363.08924,213.9475 H 244.04632"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="opacity:1;fill:#2e3436;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+         id="rect1145"
+         width="7.2257466"
+         height="7.2257476"
+         x="359.44812"
+         y="209.87848" />
+    </g>
+    <rect
+       style="text-align:end;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:5;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:9.99999905;stroke-opacity:1;paint-order:normal"
+       id="led0-leader"
+       width="1"
+       height="1"
+       x="16.168953"
+       y="212.73886" />
+  </g>
+</svg>

--- a/data/svgs/logitech-g603.svg
+++ b/data/svgs/logitech-g603.svg
@@ -1,0 +1,331 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="409.2084"
+   height="411.271"
+   viewBox="0 0 409.2084 411.27099"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   sodipodi:docname="logitech-g603.svg"
+   inkscape:export-filename="/home/jimmac/logitech-g403.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="5.656854"
+     inkscape:cx="141.15425"
+     inkscape:cy="248.38223"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="false"
+     showguides="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1017"
+     inkscape:window-x="-4"
+     inkscape:window-y="-4"
+     inkscape:window-maximized="1"
+     fit-margin-top="20"
+     fit-margin-left="20"
+     fit-margin-bottom="20"
+     fit-margin-right="0"
+     inkscape:snap-smooth-nodes="false"
+     inkscape:object-nodes="true"
+     inkscape:snap-nodes="true"
+     inkscape:guide-bbox="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid956"
+       originx="-68.791593"
+       originy="1.2767161" />
+    <sodipodi:guide
+       position="126.53125,259.03126"
+       orientation="0,1"
+       id="guide4772"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     transform="translate(-68.791597,-390.00576)"
+     style="display:inline">
+    <path
+       inkscape:connector-curvature="0"
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 175.34499,424.02062 c -24.661,4.08226 -60.18056,22.01925 -69.18502,28.18484 -7.932853,5.43184 -10.801193,13.70196 -10.925233,20.94538 -0.72438,42.30084 10.273313,88.0482 7.561093,130.50252 -1.21026,18.94414 -7.437413,51.01218 -9.969593,64.24176 -1.65073,6.85296 -2.50133,13.87513 -2.53464,20.92508 2.7e-4,50.2338 40.610433,90.95628 90.705683,90.95655 45.46938,-0.0495 82.39643,-34.07041 89.82748,-79.05254 10.66083,-64.53278 10.42629,-136.39723 11.98541,-204.91567 0.28464,-12.50912 -1.94334,-23.29335 -8.32377,-31.80289 -13.26086,-21.57098 -66.73071,-40.02924 -66.73071,-40.02924 v 7.19061 h -32.4107 z"
+       id="path870"
+       sodipodi:nodetypes="cssscccssccccc" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 208.56756,431.16702 -3,141.31424 c -0.14923,7.02936 -6.07063,12.69123 -13.61129,12.69123 -7.54065,0 -13.46205,-5.66187 -13.61128,-12.69123 l -3,-141.31424 z"
+       id="rect913"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscc" />
+    <path
+       sodipodi:nodetypes="cscsc"
+       inkscape:connector-curvature="0"
+       id="path950"
+       d="m 95.373251,486.43435 c 38.955159,101.12102 48.667459,140.67087 51.422819,177.84397 2.03646,27.47435 -36.96151,79.62933 -36.96151,79.62933 0,0 -24.033873,-37.15986 -19.463976,-61.45137 10.258966,-54.53208 19.996276,-75.99616 5.002667,-196.02193 z"
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#bfc2bb;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 104.9358,539.80779 c 2.40195,-0.25238 2.7176,0.9048 2.96999,3.30675 l 5.69164,54.1678 c 0.25238,2.40194 -1.47813,4.53882 -3.88008,4.7912 -2.40195,0.25239 -5.44876,-8.75375 -5.55682,-11.1665 l -2.02953,-45.3135 c -0.10806,-2.41275 0.40286,-5.53337 2.8048,-5.78575 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssss"
+       inkscape:label="#rect921" />
+    <path
+       sodipodi:nodetypes="sssssss"
+       inkscape:connector-curvature="0"
+       id="button3"
+       d="m 109.77779,602.64876 c 2.40195,-0.25239 4.53882,1.47813 4.79121,3.88007 l 5.69164,54.1678 c 0.25238,2.40195 -1.47814,4.53883 -3.88008,4.79121 -2.40195,0.25238 -7.77772,-8.87659 -7.89239,-11.28904 l -1.91843,-40.36308 c -0.11466,-2.41244 0.8061,-10.93458 3.20805,-11.18696 z"
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:label="#path924" />
+    <rect
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       id="button2"
+       width="23.155933"
+       height="69.467796"
+       x="180.55382"
+       y="454.99139"
+       rx="11.577967"
+       ry="11.577967"
+       inkscape:label="#rect932" />
+    <path
+       sodipodi:nodetypes="cssscc"
+       inkscape:connector-curvature="0"
+       id="button5"
+       d="m 201.20722,545.97605 -0.65676,17.92859 c -0.16469,4.49569 -3.83301,8.12045 -8.59419,8.12045 -4.76117,0 -8.49995,-3.62273 -8.59417,-8.12045 l -0.65677,-17.92859 z"
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:label="#path942" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#bfc2bb;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 281.45725,491.14612 c -30.15796,102.59778 -42.11413,137.63368 -50.74442,173.1322 -6.50823,26.76995 22.13723,79.62933 22.13723,79.62933 0,0 13.58979,-21.97214 16.0745,-32.60727 16.80373,-71.92371 12.53269,-220.15426 12.53269,-220.15426 z"
+       id="path946"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscsc" />
+    <path
+       sodipodi:nodetypes="ccccsc"
+       inkscape:connector-curvature="0"
+       id="button0"
+       d="m 174.91314,423.64614 3.0021,129.78071 -48.65044,25.07759 -32.826242,-92.02794 c -1.027151,-19.85446 -0.810142,-28.0624 15.700932,-37.87909 17.32775,-10.30224 41.981,-20.75843 62.77365,-24.95127 z"
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:1.98825693;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:label="#path948" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 207.75569,423.97641 -1.77476,128.93066 47.9684,25.54626 27.50793,-87.30721 c 4.86457,-36.68335 -44.6715,-55.30429 -73.70157,-67.16971 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#path944" />
+    <g
+       style="display:inline"
+       id="g1304"
+       transform="translate(337.51617,-37.32483)">
+      <ellipse
+         ry="1.9375004"
+         rx="1.8137393"
+         cy="614.46423"
+         cx="-145.51083"
+         id="ellipse1298"
+         style="fill:#babdb6;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-miterlimit:4;stroke-dasharray:none" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-68.791597,9.994236)">
+    <g
+       id="button1-path"
+       inkscape:label="#g131">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 242.94764,50.505764 H 477"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="237"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="50.005764" />
+    </g>
+    <g
+       id="button0-path"
+       inkscape:label="#g141">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path960"
+         d="M 477,130.50576 H 161.34398"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="127.00576"
+         x="157"
+         height="6.999999"
+         width="6.999999"
+         id="rect970"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect871"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button0-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="130.00577" />
+    </g>
+    <g
+       id="button4-path"
+       inkscape:label="#g151">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path964"
+         d="M 109.31232,181.51438 137.74787,210.44326 477,210.50576"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect875"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button4-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="210.00577" />
+      <rect
+         y="177"
+         x="105"
+         height="6.999999"
+         width="6.999999"
+         id="rect974"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="#g136">
+      <rect
+         inkscape:label="#rect869"
+         y="90.00576"
+         x="477"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 195.97852,108.49147 17.9857,-17.98571 H 477"
+         id="path908"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect910"
+         width="6.999999"
+         height="6.999999"
+         x="194"
+         y="104" />
+    </g>
+    <g
+       id="button3-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 114.17805,250.50576 H 477"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="108"
+         y="247.00577" />
+      <rect
+         y="250.00575"
+         x="477"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       id="button5-path"
+       inkscape:label="#g146"
+       transform="translate(0,-6)">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 476.55132,170.50615 H 193.34398"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="189"
+         y="167" />
+      <rect
+         y="170"
+         x="477"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     style="display:inline"
+     transform="translate(-68.791597,9.994236)" />
+</svg>

--- a/data/svgs/logitech-g700.svg
+++ b/data/svgs/logitech-g700.svg
@@ -1,0 +1,576 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="467.83105"
+   height="401.98727"
+   viewBox="0 0 467.83105 401.98727"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92+devel unknown"
+   sodipodi:docname="logitech-g700.svg"
+   inkscape:export-filename="/home/jimmac/logitech-g403.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="187.43137"
+     inkscape:cy="258.73512"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="false"
+     showguides="true"
+     inkscape:window-width="1853"
+     inkscape:window-height="1016"
+     inkscape:window-x="1507"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     inkscape:guide-bbox="true"
+     fit-margin-top="20"
+     fit-margin-bottom="20"
+     fit-margin-left="0"
+     fit-margin-right="0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid956"
+       originx="-16.168953"
+       originy="1.9872821" />
+    <sodipodi:guide
+       position="566.49402,250.15413"
+       orientation="0.70710678,0.70710678"
+       id="guide1516"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="345.16261,205.63403"
+       orientation="1,0"
+       id="guide1518"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="-91.863214,42.700431"
+       orientation="-0.70710678,0.70710678"
+       id="guide1524"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     transform="translate(-16.168953,-400)"
+     style="display:inline">
+    <g
+       id="g372">
+      <g
+         transform="translate(-407.70972)"
+         id="g1433">
+        <path
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 637.21276,442.13269 -7.36914,-7.47852 c 0,0 -28.8291,0.88227 -39.76196,5.88251 -10.93286,5.00025 -25.81714,43.44409 -27.22974,60.10694 -1.41259,16.66284 5.59131,79.27301 5.59131,79.27301 0,0 -24.91552,52.53601 -25.32446,75.27893 -0.76329,42.44959 68.62109,128.5404 134.36865,125.19647 65.74756,-3.34394 84.87379,-61.25208 83.01639,-96.18292 -1.85745,-34.93085 -24.0347,-104.81464 -24.0347,-104.81464 0,0 3.22168,-38.68249 0.51367,-55.62091 -2.708,-16.93842 -11.71606,-56.80554 -18.39038,-64.55786 -6.67431,-7.75232 -37.8457,-17.78882 -37.8457,-17.78882 l -6.53735,7.85638 c -12.1313,-4.07352 -24.5562,-5.43098 -36.99659,-7.15057 z"
+           id="path1375"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccsscssccssccc" />
+        <path
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 612.41098,758.14269 c 0,0 26.76334,-11.80523 23.71829,-39.47179 -3.04504,-27.66657 -32.98144,-79.07678 -45.64611,-110.1203 -12.66468,-31.04352 -15.74874,-51.61667 -15.74874,-51.61667 l 23.05147,-8.93851 c 0,0 -7.96118,-20.18219 -6.17273,-34.80102 1.78845,-14.61884 8.3562,-33.93274 8.3562,-33.93274 l -21.43054,-2.36243 c 0,0 5.83261,-22.58934 16.60092,-28.15233 10.76831,-5.56298 19.23914,-5.81466 28.58237,-6.42699 7.5605,-0.4955 15.97198,18.16221 15.97198,18.16221 l 16.26808,2.17394 -0.32704,18.44984 -5.25454,-0.5654 c -3.67431,-0.56751 -4.4221,1.65708 -4.4841,3.99801 l 0.59236,44.46703 c 0.17877,3.31112 2.72713,6.15312 5.36572,6.27812 l 5.67576,0.87203 1.14008,17.91322 -11.71232,-0.0529 c 0,0 0.46941,10.73577 1.62541,15.95522 0.58121,2.62422 2.64643,7.61678 2.64643,7.61678 l -5.41105,14.14438 c -0.3143,4.44983 3.4652,8.4858 6.87092,8.70703 l 5.74669,0.1166 0.0229,11.90123 4.43947,0.27181 0.57583,-12.38929 6.31564,-0.49459 c 3.86404,0 5.05122,-6.48394 4.39517,-9.41658 l -4.08726,-12.49046 c 0,0 2.54921,-4.39682 3.08963,-6.83936 1.19851,-5.41691 0.18619,-16.64269 0.18619,-16.64269 l -10.87259,-0.44848 -0.60938,-17.27195 6.24524,-0.76363 c 4.06456,0.38511 6.77965,-4.10902 6.66305,-6.86494 l -0.33252,-39.01044 c 0.28048,-3.6366 -2.07788,-7.62472 -5.83705,-7.98954 l -8.47677,-0.49546 0.62854,-18.36184 13.79884,0.89971 c 0,0 6.34522,-14.40167 10.99085,-13.74957 4.64563,0.6521 24.41467,6.6986 27.51233,10.86999 3.09765,4.17138 18.99438,49.84112 18.07202,75.55481 -0.92237,25.71368 -9.57337,116.68359 -9.57337,139.14441 0,22.46081 21.64884,69.89563 21.64884,69.89563 -10.48167,14.90232 -31.78702,34.56021 -69.45713,34.56021 -21.63533,0 -42.34124,-8.87714 -61.36398,-22.28231 z"
+           id="path1382"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cssccsccssccccccccccsccccccccccsccccccccccsssscsc" />
+        <path
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="M 142.66406 158.2168 L 130.64258 163.35547 C 130.64258 163.35547 129.76172 163.91431 128.76172 167.41406 C 127.76172 170.91382 137.07617 201.45703 137.07617 201.45703 L 149.06055 210.76562 L 152.07422 210.875 L 152.07227 210.86523 L 149.33594 210.76562 L 144.33008 201.45703 C 144.33008 201.45703 133.88281 169.16187 134.88281 165.66211 C 135.88281 162.16236 137.75195 160.85547 137.75195 160.85547 L 142.72266 158.54492 L 142.66406 158.2168 z "
+           transform="translate(423.87867,400)"
+           id="button4" />
+        <path
+           inkscape:label="#path1389"
+           sodipodi:nodetypes="ccccscc"
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 567.30901,558.21712 8.91914,52.65846 -3.01355,-0.10922 -5.00602,-9.30922 c 0,0 -10.4463,-32.29576 -9.4463,-35.79552 1,-3.49975 2.86811,-4.80649 2.86811,-4.80649 z"
+           id="button6"
+           inkscape:connector-curvature="0" />
+        <path
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="M 150.2168 212.87695 C 150.2168 212.87695 142.38943 214.63751 142.22656 219.33398 C 142.06369 224.03045 149.80475 253.7071 153.02734 256.68164 C 156.24994 259.65617 168.61133 259.91016 168.61133 259.91016 L 168.60352 259.88281 C 167.54083 259.83165 160.96579 259.42094 157.99805 256.68164 C 154.77546 253.7071 147.0344 224.03045 147.19727 219.33398 C 147.35939 214.65909 150.57195 212.89894 150.60156 212.88281 L 150.2168 212.87695 z "
+           transform="translate(423.87867,400)"
+           id="button3" />
+        <path
+           inkscape:label="#path1396"
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 578.07507,612.93874 -3.58529,-0.0618 c 0,0 -3.25129,1.76049 -3.41416,6.45696 -0.16287,4.69647 7.57883,34.3726 10.80142,37.34714 3.2226,2.97453 11.00647,3.22825 11.00647,3.22825 z"
+           id="button5"
+           inkscape:connector-curvature="0" />
+        <path
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 571.80821,529.2887 16.75168,-1.61745 2.26709,2.47905 2.96588,16.7467 -19.4389,7.16674 -3.05292,-21.38677 z"
+           id="path1398"
+           inkscape:connector-curvature="0" />
+        <path
+           inkscape:label="#path1400"
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 572.64727,529.77417 1.93371,12.46355 c 0.17435,1.34405 1.04887,1.97653 2.60016,1.83535 l 12.20529,-1.49705 c 0.75646,-0.10483 2.09687,-1.30513 1.66048,-2.69895 l -1.85475,-11.61027 z"
+           id="button7"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+        <rect
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           id="button2"
+           width="19.65448"
+           height="46.726868"
+           x="650.44757"
+           y="485.83923"
+           rx="9.82724"
+           ry="9.82724"
+           inkscape:label="#rect932" />
+        <path
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 590.00589,504.70809 c 0,0 -1.03484,5.10473 -1.28213,12.10321 -0.16329,4.62125 0.88242,10.235 0.88242,10.235 l -16.1009,0.81035 c -1.3428,0.0627 -2.62237,-0.55688 -2.44997,-2.19533 l -0.0873,-14.82945 1.66055,-5.2578 z"
+           id="path1408"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cscccccc" />
+        <path
+           inkscape:label="#path1410"
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 573.0899,505.40318 0.20623,15.85869 c -0.0713,1.05397 -0.0531,1.75142 1.13489,1.61532 l 12.98495,-0.46789 c 0,0 -0.15978,-5.93198 0.18903,-8.06114 0.34882,-2.12917 2.24487,-9.58433 2.24487,-9.58433 z"
+           id="button8"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccc" />
+        <path
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 572.95934,499.38009 c -0.23891,1.10591 0.96351,2.11782 2.59219,2.20621 l 11.93492,0.43018 c 1.44453,-0.125 3.244,-1.82045 3.95047,-4.53981 l 3.64306,-15.04301 c 0.17855,-1.27163 -0.13707,-2.71932 -1.86683,-2.77546 l -13.72539,-1.45781 c -1.4456,-0.0958 -2.68982,1.02632 -2.93832,2.65451 z"
+           id="path1412"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+        <path
+           inkscape:label="#path1414"
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 581.62245,478.87309 c -1.41933,-0.125 -3.23079,0.15096 -3.56732,1.46211 l -2.1321,13.50026 c -0.54179,1.66011 0.55078,2.48769 2.41358,2.75904 l 8.73161,1.00413 c 2.00999,0.16125 2.98232,-1.37377 3.2488,-2.60043 l 3.35525,-12.3699 c 0.31909,-1.42149 0.0372,-2.70382 -1.81709,-2.80852 z"
+           id="button9"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccccccccc" />
+        <path
+           inkscape:label="#path1416"
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 667.01457,578.34297 c 0,0 2.43437,5.37905 2.21672,7.83622 -0.21765,2.45717 0.057,8.12536 0.057,8.12536 -0.084,0.82971 -0.54395,1.59363 -2.16234,1.87243 l -13.39023,-0.0774 c -0.78452,-0.28984 -1.84803,-0.88996 -1.76233,-2.03309 0,0 -0.61952,-8.35025 0.0674,-10.32185 0.68693,-1.97161 1.63297,-5.64161 1.63297,-5.64161 0,0 8.03972,0.11155 13.34081,0.23994 z"
+           id="button10"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="csccccscc" />
+        <path
+           inkscape:label="#path1418"
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 653.91725,575.19687 13.46749,0.34741 c 0,0 3.20643,-8.97326 3.20643,-11.33956 0,-2.36631 -0.24059,-5.29814 -0.24059,-5.29814 0.14618,-1.05058 -1.20836,-1.93243 -2.12238,-1.98332 h -15.76925 c -1.30503,-0.0224 -1.73401,1.14136 -1.93921,2.31117 0,0 0.0841,7.54347 0.60793,9.21094 0.52379,1.66747 2.78958,6.7515 2.78958,6.7515 z"
+           id="path1418"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="ccscccccc" />
+        <path
+           sodipodi:nodetypes="ccsccccccccccsssc"
+           inkscape:connector-curvature="0"
+           id="button1"
+           d="m 674.1855,590.4286 -4.08726,-12.49046 c 0,0 2.54921,-4.39682 3.08963,-6.83936 1.19851,-5.41691 0.18619,-16.64269 0.18619,-16.64269 l -10.87259,-0.44848 -0.60938,-17.27195 6.24524,-0.76363 c 4.06456,0.38511 6.77965,-4.10902 6.66305,-6.86494 l -0.33252,-39.01044 c 0.28048,-3.6366 -2.07788,-7.62472 -5.83705,-7.98954 l -8.47677,-0.49546 0.62854,-18.36184 13.79884,0.89971 c 0,0 6.34522,-14.40167 10.99085,-13.74957 4.64563,0.6521 24.41467,6.6986 27.51233,10.86999 3.09765,4.17138 18.99439,49.84112 18.07202,75.55481 -0.46118,12.85684 -2.85453,42.02774 -5.13257,70.79203"
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+        <path
+           style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+           d="m 590.48316,608.5506 c -12.66468,-31.04352 -15.74874,-51.61667 -15.74874,-51.61667 l 23.05147,-8.93851 c 0,0 -7.96118,-20.18219 -6.17273,-34.80102 1.78845,-14.61884 8.3562,-33.93274 8.3562,-33.93274 l -21.43054,-2.36243 c 0,0 5.83261,-22.58934 16.60092,-28.15233 10.76831,-5.56298 19.23914,-5.81466 28.58237,-6.42699 7.5605,-0.4955 15.97198,18.16221 15.97198,18.16221 l 16.26808,2.17394 -0.32704,18.44984 -5.25454,-0.5654 c -3.67431,-0.56751 -4.4221,1.65708 -4.4841,3.99801 l 0.59236,44.46703 c 0.17877,3.31112 2.72713,6.15312 5.36572,6.27812 l 5.67576,0.87203 1.14008,17.91322 -11.71232,-0.0529 c 0,0 0.46941,10.73577 1.62541,15.95522 0.58121,2.62422 2.64643,7.61678 2.64643,7.61678 l -5.41105,14.14438"
+           id="button0"
+           inkscape:connector-curvature="0"
+           sodipodi:nodetypes="cccsccssccccccccccscc" />
+      </g>
+      <path
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 274.29495,505.2149 v 7.97553 l 3.83318,-3.83321 z"
+         id="button12"
+         inkscape:connector-curvature="0"
+         inkscape:label="#path1146" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button11"
+         d="m 230.83554,505.2149 v 7.97553 l -3.83318,-3.83321 z"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path1148" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-16.168953)">
+    <g
+       id="button0-path"
+       inkscape:label="#g226">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path954"
+         d="m 234.68702,62.49186 41.9857,-41.98571 H 483"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="62"
+         x="230"
+         height="6.999999"
+         width="6.999999"
+         id="rect952"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect865"
+         y="20"
+         x="483"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+    <g
+       id="button1-path"
+       inkscape:label="#g221">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 275.03741,60.50615 H 483.05562"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="273"
+         y="57" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="483"
+         y="60" />
+    </g>
+    <g
+       id="button9-path"
+       inkscape:label="#g216">
+      <path
+         sodipodi:nodetypes="ccccc"
+         inkscape:connector-curvature="0"
+         id="path960"
+         d="M 483,100.50615 H 361.43709 L 336.37251,75.396706 H 189.62772 l -8.6513,10"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="82.008446"
+         x="177.07306"
+         height="6.999999"
+         width="6.999999"
+         id="rect970"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect869"
+         y="100"
+         x="483"
+         height="1"
+         width="1"
+         id="button9-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+    <g
+       id="button12-path"
+       inkscape:label="#g206">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path964"
+         d="M 483.5,180.00615 H 360.68314 l -59.54024,-65.8551 -33.2008,0.0451"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="109.90022"
+         x="264.5123"
+         height="6.999999"
+         width="6.999999"
+         id="rect974"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect873"
+         y="179.50615"
+         x="483"
+         height="1"
+         width="1"
+         id="button12-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+    <g
+       id="button7-path"
+       inkscape:label="#g171">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 17.151054,140.50027 H 182.33834"
+         id="path76"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect972"
+         width="6.999999"
+         height="6.999999"
+         x="176.04955"
+         y="136.99055" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button7-leader"
+         width="1"
+         height="1"
+         x="-17.168953"
+         y="-141.00027"
+         inkscape:label="#rect873" />
+    </g>
+    <g
+       id="button10-path"
+       inkscape:label="#g176">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path1259"
+         d="M 17.16895,180.50027 H 246.82196"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="-184.26186"
+         x="-252.73283"
+         height="6.999999"
+         width="6.999999"
+         id="rect1261"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)" />
+      <rect
+         inkscape:label="#rect873"
+         y="-181.00027"
+         x="-17.168953"
+         height="1"
+         width="1"
+         id="button10-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+    <g
+       id="button6-path"
+       inkscape:label="#g181">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path1295"
+         d="m 17.16895,220.50027 h 33.151095 l 30.12282,-29.87718 h 81.709115"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="-194.0271"
+         x="-167.2599"
+         height="6.999999"
+         width="6.999999"
+         id="rect1297"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button6-leader"
+         width="1"
+         height="1"
+         x="-17.168953"
+         y="-221.00027"
+         inkscape:label="#rect873" />
+    </g>
+    <g
+       id="button4-path"
+       inkscape:label="#g186">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 17.16895,260.50027 h 42.566708 l 60.284632,-61.94843 h 31.82975"
+         id="path1299"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect1301"
+         width="6.999999"
+         height="6.999999"
+         x="-156.24265"
+         y="-202.01924" />
+      <rect
+         inkscape:label="#rect873"
+         y="-261.00027"
+         x="-17.168953"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+    <g
+       id="button11-path"
+       inkscape:label="#g211">
+      <rect
+         inkscape:label="#rect871"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button11-leader"
+         width="1"
+         height="1"
+         x="483"
+         y="140" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1512"
+         d="M 482.98501,140.50615 H 359.31376 l -34.84984,-39.6734 -82.25306,-0.004"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect1514"
+         width="6.999999"
+         height="6.999999"
+         x="235.83218"
+         y="99.10099" />
+    </g>
+    <g
+       id="button3-path"
+       inkscape:label="#g191">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 17.16895,300.50027 h 51.327469 l 81.344411,-79.98695 h 10.85261"
+         id="path1502"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect1504"
+         width="6.999999"
+         height="6.999999"
+         x="-164.00285"
+         y="-223.98463" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button3-leader"
+         width="1"
+         height="1"
+         x="-17.168953"
+         y="-301.00027"
+         inkscape:label="#rect873" />
+    </g>
+    <g
+       id="button5-path"
+       inkscape:label="#g196">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path1506"
+         d="M 17.16895,340.50027 H 97.369601 L 183.06798,252.94705"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="-253.98224"
+         x="-185.04956"
+         height="6.999999"
+         width="6.999999"
+         id="rect1508"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)" />
+      <rect
+         inkscape:label="#rect873"
+         y="-341.00027"
+         x="-17.168953"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="#g201">
+      <path
+         sodipodi:nodetypes="ccc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 482.7753,220.37357 -139.89827,-0.0147 -91.18642,-98.70563"
+         id="path962"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="219.87363"
+         x="483"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect436"
+         width="6.999999"
+         height="6.999999"
+         x="246.30431"
+         y="116.44096" />
+    </g>
+    <g
+       id="button8-path"
+       inkscape:label="#g166">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path438"
+         d="m 17.282046,100.50073 138.615124,0.125 20.88991,20.36764"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999988;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="116.02772"
+         x="174.8121"
+         height="6.999999"
+         width="6.999999"
+         id="rect1435"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect873"
+         y="-101.00027"
+         x="-17.168953"
+         height="1"
+         width="1"
+         id="button8-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     style="display:inline"
+     transform="translate(-16.168953)" />
+</svg>

--- a/data/svgs/logitech-g703.svg
+++ b/data/svgs/logitech-g703.svg
@@ -1,0 +1,1 @@
+logitech-g403.svg

--- a/data/svgs/logitech-g9.svg
+++ b/data/svgs/logitech-g9.svg
@@ -1,0 +1,509 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="490"
+   height="490"
+   viewBox="0 0 129.64583 129.64583"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="logitech-g9.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)"
+   enable-background="new">
+  <defs
+     id="defs2">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath145">
+      <rect
+         id="rect147"
+         width="82.020836"
+         height="120.65"
+         x="20.902082"
+         y="3.174999"
+         style="stroke-width:0.26458332" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="8.0000004"
+     inkscape:cx="264.58829"
+     inkscape:cy="370.72481"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     showguides="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     showborder="true"
+     inkscape:guide-bbox="true"
+     units="px"
+     inkscape:snap-global="false"
+     inkscape:measure-start="296.875,398.125"
+     inkscape:measure-end="288.375,379.75">
+    <inkscape:grid
+       type="xygrid"
+       id="grid78" />
+    <sodipodi:guide
+       position="58.722772,112.40709"
+       orientation="0,1"
+       id="guide79"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="39.611923,100.54373"
+       orientation="0,1"
+       id="guide81"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="-0.18708866,88.492936"
+       orientation="0,1"
+       id="guide83"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="13.758333,76.993746"
+       orientation="0,1"
+       id="guide85"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="45.047078,64.795712"
+       orientation="0,1"
+       inkscape:locked="false"
+       id="guide87" />
+    <sodipodi:guide
+       position="57.646696,52.899321"
+       orientation="0,1"
+       id="guide89"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="64.822916,108.74375"
+       orientation="1,0"
+       id="guide141"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline;opacity:1"
+     transform="translate(0,-167.35416)">
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 94.675437,179.69604 c 3.984039,23.55769 3.665039,48.23792 2.691228,71.79562 -2.08441,12.87379 -9.220213,24.06379 -17.197916,34.13125 -5.788734,2.89177 -12.325823,4.09974 -19.05,5.02708 -6.713477,-0.22178 -12.6786,-0.44356 -19.579166,-2.91041 -7.729571,-8.24539 -13.148669,-16.741 -17.727083,-25.4 -0.02339,-1.79858 0,-5.84224 0,-8.20209 -1.45391,-5.19812 -2.159466,-9.36726 -2.116667,-15.875 3.006557,-20.49321 9.287166,-40.14452 13.977522,-59.88937 2.143416,-0.99154 2.603034,-1.14118 4.278728,-1.75854 8.680505,-0.97549 16.051389,-1.76389 24.077083,-2.64584 h 7.14375 z"
+       id="path4643"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc" />
+    <path
+       sodipodi:type="arc"
+       style="display:inline;opacity:0.72399998;fill:none;fill-opacity:0.39215686;stroke:#eeeeec;stroke-width:2.089679;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="logo"
+       sodipodi:cx="62.113438"
+       sodipodi:cy="277.58575"
+       sodipodi:rx="3.7614744"
+       sodipodi:ry="3.7614779"
+       d="m 64.773202,274.92599 a 3.7614744,3.7614779 0 0 1 0,5.31953 3.7614744,3.7614779 0 0 1 -5.319528,0 3.7614744,3.7614779 0 0 1 -10e-7,-5.31953"
+       sodipodi:start="5.4977871"
+       sodipodi:end="3.9269907"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       inkscape:label="path" />
+    <path
+       style="fill:none;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="M 36.247916,178.59895 C 31.541511,203.86131 25.993208,228.84304 23.8125,254.66666"
+       id="path4820"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.61647916;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 90.83155,179.22767 c 1.340802,7.60827 2.120337,15.21655 2.338607,22.82482 -0.06236,15.27891 -0.685992,30.65136 -2.15152,45.27546 -0.124725,1.27845 -0.997805,2.18271 -2.057974,2.71279 -9.011437,2.99341 -16.339078,5.7062 -27.595579,6.73519 -10.523737,-0.10917 -22.099849,-1.22387 -25.537604,-3.27405 -1.656483,-1.67598 -2.466318,-3.00581 -2.899876,-5.23849 -0.200352,-25.84328 2.343475,-44.91236 8.699625,-71.28078 7.577091,-0.93544 15.154181,-1.87089 22.731272,-2.80633 l 7.296459,0.0936 c 6.392197,1.6526 12.784393,3.30519 19.17659,4.95779 z"
+       id="path4822"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.61647916;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34.237226,219.26465 30.09955,-1.86805 -0.492771,5.00179 c -0.904262,2.26065 -1.153714,2.27624 -3.554685,3.55468 -3.25846,1.27844 -3.710591,1.10694 -7.249684,1.44994 -6.485741,0.3274 -12.971481,0.65481 -19.457222,0.98221 z"
+       id="led0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc"
+       inkscape:label="#path894" />
+    <path
+       style="fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.61647916;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34.611402,214.21326 -0.467722,5.00462 16.18317,-1.07576 0.04677,-4.77076 z"
+       id="button9"
+       inkscape:connector-curvature="0"
+       inkscape:label="#path896" />
+    <path
+       style="fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.61647916;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 64.405272,212.43591 -14.066729,0.93544 0.02888,4.76741 13.98589,-0.84138 z"
+       id="button8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#path898" />
+    <path
+       style="fill:none;stroke:#babdb6;stroke-width:0.61647916;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 64.624478,173.96874 -0.264583,38.43073 z"
+       id="path4589"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="display:inline;opacity:1;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.6744734;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="button2"
+       width="8.6420469"
+       height="17.819014"
+       x="64.999809"
+       y="187.58092"
+       ry="1.5417958"
+       inkscape:label="#rect4615"
+       rx="1.752861" />
+    <path
+       style="fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.61647916;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 24.274755,248.26339 c -0.124726,-9.60388 -0.342996,-10.78877 0.748354,-17.86696 0.576857,0.0935 1.153713,0.18709 1.73057,0.28063 -0.826308,5.86211 -1.652616,11.72422 -2.478924,17.58633 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       inkscape:label="#path4606" />
+    <path
+       style="fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.61647916;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 27.104469,228.7594 c -0.561265,-0.0779 -1.122531,-0.15591 -1.683796,-0.23386 0.919852,-4.78635 2.120338,-8.77758 3.671614,-12.95589 -0.662606,4.39658 -1.325212,8.79317 -1.987818,13.18975 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       inkscape:label="#path4608" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 41.814318,177.35679 -6.781966,36.38874 28.764883,-1.68379 0.467722,-37.41774 z"
+       id="button0"
+       inkscape:connector-curvature="0"
+       inkscape:label="#path4610" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 65.054426,174.53098 -0.09922,12.60078 9.128124,-0.0661 0.03307,18.88463 -9.293489,-0.13229 -0.03307,6.15156 27.78125,-0.85989 0.132291,-9.1612 -0.959114,-13.32838 -1.35599,-9.09506 -18.884635,-4.89479 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       inkscape:label="#path4612" />
+    <path
+       transform="translate(0,164.70833)"
+       id="button6"
+       d="m 62.980849,30.452818 a 0.06589785,0.06589785 0 0 0 -0.046,0.02066 l -1.13998,1.23145 a 0.06589785,0.06589785 0 0 0 0.002,0.09147 l 1.13947,1.139465 a 0.06589785,0.06589785 0 0 0 0.10697,-0.07338 l -0.50385,-1.113628 0.50488,-1.205093 a 0.06589785,0.06589785 0 0 0 -0.0636,-0.09095 z"
+       style="display:inline;color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.25282338;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:connector-curvature="0"
+       inkscape:label="#path1016" />
+    <path
+       transform="translate(0,164.70833)"
+       id="button7"
+       d="m 75.28463,30.433444 a 0.06589785,0.06589785 0 0 1 0.046,0.02066 l 1.13998,1.23145 a 0.06589785,0.06589785 0 0 1 -0.002,0.09147 l -1.13947,1.139465 a 0.06589785,0.06589785 0 0 1 -0.10697,-0.07338 l 0.50385,-1.113628 -0.50488,-1.205093 a 0.06589785,0.06589785 0 0 1 0.0636,-0.09095 z"
+       style="display:inline;color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.25282338;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:connector-curvature="0"
+       inkscape:label="#path1016-3" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,40.502648,-1.1017221)"
+       style="display:inline"
+       id="button2-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 336.91912,169.83277 147.21994,169.67013 109.21898,124.50618"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="106.00334"
+         y="120.59612" />
+      <rect
+         y="169.31075"
+         x="336.56558"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(-0.26458333,0,0,-0.26458333,116.08398,94.455601)"
+       style="display:inline"
+       id="button9-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 438.04598,191.7488 H 311.48839 l -34.64441,-29.86762"
+         id="path51-1-9-6-8"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-2-3-2-7"
+         width="6.999999"
+         height="6.999999"
+         x="273.625"
+         y="158.5" />
+      <rect
+         y="191.3428"
+         x="438.04599"
+         height="1"
+         width="1"
+         id="button9-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.284218,-46.390214)"
+       style="display:inline"
+       id="button0-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 58.180682,250.50576 181.443538,0.0352"
+         id="path966-9"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-8"
+         width="6.999999"
+         height="6.999999"
+         x="55.471279"
+         y="247.18254" />
+      <rect
+         y="250.00575"
+         x="238.62422"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,40.402294,-25.12739)"
+       style="display:inline"
+       id="button1-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 336.91912,170.14213 -189.57514,0.36405"
+         id="path51-1"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-0"
+         width="6.999999"
+         height="6.999999"
+         x="143.59541"
+         y="166.59467" />
+      <rect
+         y="169.75269"
+         x="336.91913"
+         height="1"
+         width="1"
+         id="button1-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,13.573867,4.9859563)"
+       style="display:inline"
+       id="button8-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 438.04598,191.7488 -249.80759,-0.5 -23.58191,-19.43012"
+         id="path51-1-9-6-8-4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-2-3-2-7-4"
+         width="6.999999"
+         height="6.999999"
+         x="161.75937"
+         y="169.05698" />
+      <rect
+         y="191.3428"
+         x="438.04599"
+         height="1"
+         width="1"
+         id="button8-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(-0.26458333,0,0,-0.26458333,116.07548,106.30868)"
+       style="display:inline"
+       id="button4-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 438.04598,191.7488 H 359.48839 L 337.39512,173.19489"
+         id="path51-1-9-6-8-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-2-3-2-7-6"
+         width="6.999999"
+         height="6.999999"
+         x="333.90585"
+         y="169.28337" />
+      <rect
+         y="191.3428"
+         x="438.04599"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(-0.26458333,0,0,-0.26458333,116.05287,118.29899)"
+       style="display:inline"
+       id="button3-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 438.04598,191.7488 H 359.48839 L 344.11263,179.02852"
+         id="path51-1-9-6-8-7-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-2-3-2-7-6-5"
+         width="6.999999"
+         height="6.999999"
+         x="340.26981"
+         y="174.94023" />
+      <rect
+         y="191.3428"
+         x="438.04599"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.05035,-34.688457)"
+       style="display:inline"
+       id="button6-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 33.59277,251.21287 205.11339,-0.0974"
+         id="path966-9-6"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-8-7"
+         width="6.999999"
+         height="6.999999"
+         x="29.446411"
+         y="247.53609" />
+      <rect
+         y="250.62447"
+         x="238.5843"
+         height="1"
+         width="1"
+         id="button6-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,40.372307,-13.288752)"
+       style="display:inline"
+       id="button7-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 336.91912,170.14213 -196.70014,0.23905"
+         id="path51-1-6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-0-7"
+         width="6.999999"
+         height="6.999999"
+         x="137.97041"
+         y="166.84467" />
+      <rect
+         y="169.75269"
+         x="336.91913"
+         height="1"
+         width="1"
+         id="button7-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,13.592814,20.269951)"
+       style="display:inline"
+       id="led0-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 438.04598,178.25732 -267.54159,0.25 -31.41041,-32.75114"
+         id="path51-1-9-6-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-2-3-2-2"
+         width="6.999999"
+         height="6.999999"
+         x="135.77765"
+         y="141.93933" />
+      <rect
+         y="177.79317"
+         x="438.04599"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/logitech-g900.svg
+++ b/data/svgs/logitech-g900.svg
@@ -1,0 +1,554 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="460"
+   height="440"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.92+devel unknown"
+   sodipodi:docname="logitech-g900.svg"
+   viewBox="0 0 460 440">
+  <style
+     id="style5346" />
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2.8284271"
+     inkscape:cx="333.51156"
+     inkscape:cy="187.93422"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     showgrid="true"
+     showguides="true"
+     inkscape:guide-bbox="true"
+     inkscape:window-width="1853"
+     inkscape:window-height="1016"
+     inkscape:window-x="1507"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     units="px"
+     fit-margin-top="20"
+     fit-margin-left="-40"
+     fit-margin-right="-40"
+     fit-margin-bottom="20"
+     inkscape:document-rotation="0"
+     inkscape:pagecheckerboard="false">
+    <sodipodi:guide
+       orientation="0,1"
+       position="-115.05694,356.25"
+       id="guide5340"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-338.2349,318.75"
+       id="guide5342"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-411.98489,243.75"
+       id="guide5344"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-447.39711,281.25"
+       id="guide5346"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-458.85989,206.25"
+       id="guide5348"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-443.23489,168.75"
+       id="guide5350"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <inkscape:grid
+       type="xygrid"
+       id="grid5352"
+       empspacing="4"
+       visible="true"
+       enabled="true"
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingx="0.93749999"
+       spacingy="0.93749999" />
+    <sodipodi:guide
+       orientation="0,1"
+       position="-305.47013,131.25"
+       id="guide5354"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       orientation="1,0"
+       position="230,443.73334"
+       id="guide3885"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="160,100"
+       orientation="0,1"
+       id="guide5247"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline"
+     transform="translate(0,2.6666495)">
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 321.875,220.80227 -17.8125,-0.9375 10.3125,-93.75 c 7.5,33.75 8.4375,56.71875 7.5,94.6875 z"
+       id="button6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc" />
+    <path
+       sodipodi:nodetypes="cccc"
+       inkscape:connector-curvature="0"
+       id="button4"
+       d="m 137.20625,220.80227 17.8125,-0.9375 -10.3125,-93.75 c -7.5,33.75 -8.4375,56.71875 -7.5,94.6875 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="path3894"
+       style="display:inline;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 145.625,141.11478 c 0,0 -3.75,59.99999 0,84.37499 3.75,24.375 -9.375,25.82353 -9.375,61.875 0,67.5 39.375,116.25001 93.75,116.25 54.375,0 93.75,-48.75 93.75,-116.25 0,-36.05147 -13.125,-33.75 -9.375,-61.875 3.75,-28.125 0,-84.37499 0,-84.37499"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czszszc" />
+    <path
+       id="path3891"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#d9dad7;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 254.375,134.55227 22.5,49.21875 -17.8125,46.40625 c -1.65577,5.51921 -10.3125,15 -16.875,15 h -24.375 c -6.5625,0 -15.21923,-9.48079 -16.875,-15 l -17.8125,-46.40625 22.5,-49.21875"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccssccc" />
+    <path
+       id="path3887"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#d3d3ce;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 220.625,231.11477 c -3.75,0 -5.82083,-5.76156 -8.4375,-15.9375 l -8.4375,-32.8125 c -0.9643,-3.75 -1.17686,-11.25 -0.9375,-15 L 211.25,35.177274 c 0.29859,-4.678 0.9375,-4.6875 2.8125,-4.6875 1.875,0 1.875,1.875 1.875,1.875 h 28.125 c 0,0 0,-1.875 1.875,-1.875 1.875,-1e-6 2.5139,0.0095 2.8125,4.6875 l 8.4375,132.187496 c 0.23936,3.75 0.0268,11.25 -0.9375,15 l -8.4375,32.8125 c -2.61667,10.17593 -4.6875,15.9375 -8.4375,15.9375 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ssssszcczssssss" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 248.75,36.114773 h 5.625 l 43.125,30 c 2.8125,1.956522 3.99101,3.729263 5.625,7.5 l 12.1875,28.124997 c 1.625,3.75 2.01562,9.375 1.875,13.125 l -2.8125,75 -3.75,3.75 -7.5,30 -41.25,-7.5 5.625,-28.125 c 1.125,-5.625 0.225,-9.375 -1.875,-15.9375 l -10.3125,-23.4375 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssssccccsscc" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 320.9375,229.23977 -7.5,-0.9375 -15.9375,58.125 c -0.77117,2.8125 -1.53214,6.12475 0,6.5625 2.01565,0.57591 4.42284,-1.09513 5.625,-2.8125 l 6.5625,-9.375 c 1.6522,-2.3603 3.09783,-5.625 3.75,-9.375 z"
+       id="button5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsssssc" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 232.8125,176.73977 v 7.5 c 0,1.875 0.36208,2.76945 0.9375,4.6875 l 2.8125,9.375 c 0.5625,1.875 0.92837,1.875 2.8125,1.875 h 0.9375 c 1.875,0 2.37981,0 2.8125,-1.875 l 2.8125,-12.1875 c 0.43118,-1.86846 0.9375,-3.75 0.9375,-5.625 v -3.75 c 0,-1.875 -0.9375,-2.8125 -2.8125,-2.8125 h -8.4375 c -1.875,0 -2.8125,0.9375 -2.8125,2.8125 z"
+       id="button8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssssssss" />
+    <path
+       sodipodi:nodetypes="ccsssssc"
+       inkscape:connector-curvature="0"
+       id="button3"
+       d="m 139.0625,229.23977 7.5,-0.9375 15.9375,58.125 c 0.77117,2.8125 1.53214,6.12476 0,6.5625 -2.01565,0.57591 -4.42284,-1.09513 -5.625,-2.8125 l -6.5625,-9.375 c -1.6522,-2.36028 -3.08377,-5.62747 -3.75,-9.375 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       sodipodi:nodetypes="ccssssccccsscc"
+       inkscape:connector-curvature="0"
+       id="button0"
+       d="m 211.25,36.114774 h -5.625 L 162.5,66.114773 c -2.8125,1.956522 -3.99101,3.729262 -5.625,7.5 l -12.1875,28.124997 c -1.625,3.75 -2.02163,9.37524 -1.875,13.12501 l 2.8125,74.99999 3.75,3.75 7.5,30 41.25,-7.5 -5.625,-28.125 c -1.125,-5.625 -0.25547,-9.38482 1.875,-15.9375 l 10.3125,-23.43749 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="path4352"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:9.375;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 220.625,206.73977 c 1.875,0 2.68807,0.75516 2.8125,1.875 l 1.875,16.875 c 0.10424,0.93821 0,1.875 -0.9375,1.875 -1.875,0 -2.48162,-0.9375 -2.8125,-2.8125 l -2.8125,-15.9375 c -0.19581,-1.10959 0,-1.875 1.875,-1.875 z m 18.75,0 c -1.875,0 -2.68808,0.75516 -2.8125,1.875 l -1.875,16.875 c -0.10424,0.93821 0,1.875 0.9375,1.875 1.875,0 2.48162,-0.9375 2.8125,-2.8125 l 2.8125,-15.9375 c 0.19581,-1.10959 0,-1.875 -1.875,-1.875 z m -7.5,18.75 0.9375,-16.875 c 0.049,-0.88251 0.0604,-1.875 -2.78231,-1.875 -2.84269,0 -2.89172,0.99249 -2.84269,1.875 l 0.9375,16.875 c 0.049,0.88253 0,1.875 1.90519,1.875 1.90518,0 1.79581,-0.99247 1.84481,-1.875 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssssssssscszsczc" />
+    <path
+       id="button2"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 236.5625,135.48978 c 2.8125,0 5.625,-2.8125 5.625,-5.625 V 79.239773 c 0,-2.8125 -2.8125,-5.625 -5.625,-5.625 h -13.125 c -2.8125,0 -5.625,2.8125 -5.625,5.625 v 50.625007 c 0,2.8125 2.8125,5.625 5.625,5.625 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
+    <path
+       id="path3927"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 221.5625,142.98978 c -1.875,0 -2.70684,0.94013 -2.80606,2.81249 l -0.94394,17.81251 c -0.0992,1.87237 0.9375,2.81249 2.8125,2.81249 h 18.75 c 1.875,0 2.911,-0.94009 2.8125,-2.8125 l -0.9375,-17.8125 c -0.0985,-1.8724 -0.9375,-2.8125 -2.8125,-2.8125 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sscsscsss" />
+    <path
+       sodipodi:nodetypes="sssssssssssss"
+       inkscape:connector-curvature="0"
+       id="button7"
+       d="m 227.1875,176.73977 v 7.5 c 0,1.875 -0.36208,2.76945 -0.9375,4.6875 l -2.8125,9.375 c -0.5625,1.875 -0.92837,1.875 -2.8125,1.875 h -0.9375 c -1.875,0 -2.37981,0 -2.8125,-1.875 l -2.8125,-12.1875 c -0.43118,-1.86845 -0.9375,-3.75 -0.9375,-5.625 v -3.75 c 0,-1.875 0.9375,-2.8125 2.8125,-2.8125 h 8.4375 c 1.875,0 2.8125,0.9375 2.8125,2.8125 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1.875;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       sodipodi:type="arc"
+       style="fill:none;fill-opacity:0.39215686;stroke:#babdb6;stroke-width:9.375;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="led0"
+       sodipodi:cx="230"
+       sodipodi:cy="317.36478"
+       sodipodi:rx="16.875"
+       sodipodi:ry="16.875002"
+       d="m 241.93243,305.43235 a 16.875,16.875002 0 0 1 0,23.86485 16.875,16.875002 0 0 1 -23.86486,1e-5 16.875,16.875002 0 0 1 0,-23.86486"
+       sodipodi:start="5.4977871"
+       sodipodi:end="3.9269907"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.375;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 202,104 v 2 l -2,2 2,2 v 2 l -4,-4 z"
+       id="button9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc"
+       transform="translate(0,-2.6666495)" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:9.375;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 258,104 v 2 l 2,2 -2,2 v 2 l 4,-4 z"
+       id="button10"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc"
+       transform="translate(0,-2.6666495)" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline">
+    <g
+       id="button0-path">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4699"
+         d="M 180,99.999995 H 1"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="96.5"
+         x="176.5"
+         height="7"
+         width="7"
+         id="rect4744-7"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="text-align:end;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="button0-leader"
+         width="1"
+         height="1"
+         x="-6.0989584e-07"
+         y="99.5"
+         inkscape:label="#rect5374" />
+    </g>
+    <g
+       id="button9-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4697"
+         d="m 212,108 -32,32 H 1"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="104.5"
+         x="208.5"
+         height="7"
+         width="7"
+         id="rect4744"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="text-align:end;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="button9-leader"
+         width="1"
+         height="1"
+         x="-6.0989584e-07"
+         y="139.5"
+         inkscape:label="#rect5374" />
+    </g>
+    <g
+       id="button7-path">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4695"
+         d="M 221,180 H 1"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="176.5"
+         x="216.5"
+         height="7"
+         width="7"
+         id="rect4744-0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="text-align:end;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="button7-leader"
+         width="1"
+         height="1"
+         x="-6.0989584e-07"
+         y="179.5"
+         inkscape:label="#rect5374" />
+    </g>
+    <g
+       id="button4-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4693"
+         d="m 140,200 -20,20 H 1"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="196.5"
+         x="136.5"
+         height="7"
+         width="7"
+         id="rect4744-9"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="text-align:end;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="button4-leader"
+         width="1"
+         height="1"
+         x="-6.0989584e-07"
+         y="219.5"
+         inkscape:label="#rect5374" />
+    </g>
+    <g
+       id="button3-path">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4691"
+         d="M 148,260 H 1"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="256.5"
+         x="144.5"
+         height="7"
+         width="7"
+         id="rect4744-1"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="text-align:end;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="button3-leader"
+         width="1"
+         height="1"
+         x="-6.0989584e-07"
+         y="259.5"
+         inkscape:label="#rect5374" />
+    </g>
+    <g
+       id="button5-path">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4711"
+         d="M 312,260 H 459"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="256.5"
+         x="308.5"
+         height="7"
+         width="7"
+         id="rect4744-27"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="text-align:start;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="button5-leader"
+         width="1"
+         height="1"
+         x="459"
+         y="259.5"
+         inkscape:label="#rect5374" />
+    </g>
+    <g
+       id="button6-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4709"
+         d="m 320,200 20,20 h 119"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="196.5"
+         x="316.5"
+         height="7"
+         width="7"
+         id="rect4744-2"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="text-align:start;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="button6-leader"
+         width="1"
+         height="1"
+         x="459"
+         y="219.5"
+         inkscape:label="#rect5374" />
+    </g>
+    <g
+       id="button8-path">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4707"
+         d="M 240,180 H 459"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="176.5"
+         x="236.5"
+         height="7"
+         width="7"
+         id="rect4744-93"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="text-align:start;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="button8-leader"
+         width="1"
+         height="1"
+         x="459"
+         y="179.5"
+         inkscape:label="#rect5374" />
+    </g>
+    <g
+       id="button10-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4701"
+         d="m 248,108 32,32 h 179"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="104.5"
+         x="244.5"
+         height="7"
+         width="7"
+         id="rect4744-56"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="text-align:start;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="button10-leader"
+         width="1"
+         height="1"
+         x="459"
+         y="139.5"
+         inkscape:label="#rect5374" />
+    </g>
+    <g
+       id="button1-path">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4703"
+         d="M 280,99.999995 H 459"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="96.5"
+         x="276.5"
+         height="7"
+         width="7"
+         id="rect4744-3"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="text-align:start;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="459"
+         y="99.5"
+         inkscape:label="#rect5374" />
+    </g>
+    <g
+       id="button2-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path4705"
+         d="M 230,87.999999 258,59.999995 H 459"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="84.5"
+         x="226.5"
+         height="7"
+         width="7"
+         id="rect4744-5"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+      <rect
+         style="text-align:start;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="button2-leader"
+         width="1"
+         height="1"
+         x="459"
+         y="59.5"
+         inkscape:label="#rect5374" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs">
+    <g
+       id="led0-path">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path4705-0"
+         d="m 230,320 229.375,0"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="text-align:start;display:inline;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.99999994"
+         id="led0-leader"
+         width="1"
+         height="1"
+         x="459"
+         y="319.5"
+         inkscape:label="#rect5374" />
+      <rect
+         y="316.5"
+         x="226.5"
+         height="7"
+         width="7"
+         id="rect4744-5-3"
+         style="display:inline;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/logitech-mx-anywhere2.svg
+++ b/data/svgs/logitech-mx-anywhere2.svg
@@ -1,0 +1,349 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg942"
+   width="450"
+   height="450"
+   viewBox="0 0 450 450.00001"
+   sodipodi:docname="logitech-mx-anywhere2.svg"
+   inkscape:version="0.92.2 2405546, 2018-03-11">
+  <metadata
+     id="metadata948">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs946" />
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="3200"
+     inkscape:window-height="1677"
+     id="namedview944"
+     showgrid="true"
+     inkscape:object-paths="true"
+     inkscape:object-nodes="false"
+     inkscape:snap-intersection-paths="true"
+     inkscape:zoom="5.6568542"
+     inkscape:cx="132.29246"
+     inkscape:cy="334.55769"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="Device"
+     inkscape:snap-object-midpoints="true"
+     inkscape:snap-grids="false"
+     inkscape:snap-to-guides="false"
+     inkscape:snap-others="true"
+     inkscape:snap-nodes="true"
+     inkscape:snap-bbox="true"
+     inkscape:snap-bbox-midpoints="true">
+    <inkscape:grid
+       type="xygrid"
+       id="grid880" />
+  </sodipodi:namedview>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline"
+     transform="translate(0,321.03999)">
+    <path
+       style="opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:3.41371107px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 218.69405,-299.42426 c 23.35649,1.73474 46.18087,5.06587 68.35514,10.34733 23.75734,6.5434 34.95965,18.75684 40.44869,33.55046 14.75489,46.96997 14.92489,97.01791 12.09878,148.09014 -0.22053,69.160277 9.88471,151.952398 -41.25946,193.685563 C 257.44112,119.62007 184.10794,116.48359 139.99157,87.503464 100.63876,61.652557 96.65491,4.57244 95.843246,-38.897519 c -0.639505,-34.2499 -4.904947,-68.500891 -3.243152,-102.716411 1.744881,-35.9262 7.356301,-78.71605 13.841016,-107.01431 3.99526,-15.72475 12.19144,-29.89698 35.27502,-38.56736 23.0293,-5.08776 48.5148,-9.23085 76.97792,-12.22866 z"
+       id="path958"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccassaccc" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.04822683;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 219.40508,-294.00752 67.6238,14.41163 c 10.27506,3.52994 19.61317,7.79609 21.7283,17.7374 34.47843,139.54316 2.38187,235.179053 -22.17174,337.675524 -2.70961,6.974963 -4.75518,14.198956 -16.6288,17.737404 -33.62713,9.347182 -67.25427,11.307342 -100.8814,0 C 159.63341,88.719872 154.6317,82.405292 150.45098,75.817034 125.18112,-36.599477 94.771098,-127.54074 128.50096,-260.97161 c 1.682,-10.88963 9.98626,-14.60515 18.62426,-17.95912 z"
+       id="path970"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccc" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.38959765;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 191.52096,-288.19118 c 1.4779,64.07686 0.63073,131.09048 4.38208,189.294959 0.53834,8.352647 23.14409,12.010754 23.14409,12.010754 0,0 22.57181,-3.520747 23.2016,-11.833881 4.83394,-63.807432 1.5673,-125.647242 3.26713,-189.723552"
+       id="path960"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscsc" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.04822683;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 300.42159,70.944985 C 339.27478,43.967826 336.69108,-80.871179 335.23506,-108.90368 325.41759,-45.455804 296.49373,32.142014 300.42159,70.944985 Z"
+       id="path974"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:3.41371107px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 91.703995,-152.38566 c -7.529254,25.22562 -5.874086,43.32648 -5.814066,51.60811 l 5.653792,1.441169 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       inkscape:label="" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:3.41371107px;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 86.425202,-87.164219 c 1.984551,13.294118 0.345072,23.115228 8.757835,42.569729 l -2.771465,-46.006346 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccc"
+       inkscape:label="" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.38959765;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="M 219.40508,-293.35803 V -87.543322"
+       id="path1908"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <rect
+       style="display:inline;opacity:1;vector-effect:none;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:3.07234001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+       id="rect972"
+       width="10.198998"
+       height="20.619715"
+       x="214.33723"
+       y="-122.47431"
+       ry="5.0994992" />
+    <rect
+       style="display:inline;opacity:1;vector-effect:none;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:3.07234001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+       id="button2"
+       width="23.3599"
+       height="23.830233"
+       x="207.57869"
+       y="-163.18437"
+       ry="4.7033353"
+       inkscape:label="" />
+    <rect
+       style="display:inline;opacity:1;vector-effect:none;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:3.07234001;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+       id="rect966"
+       width="30.414902"
+       height="60.202698"
+       x="203.64337"
+       y="-248.47151"
+       ry="8.4660034" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.04822683;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 136.54246,-257.72138 -16.3049,112.56651 63.0247,-0.6271 1.25422,-131.0663 z"
+       id="button0"
+       inkscape:connector-curvature="0"
+       inkscape:label="" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:2.04822683;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 299.43465,-259.28913 16.30489,112.56648 -63.0247,-0.6271 -1.25422,-131.0663 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       inkscape:label="" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.56880355px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="m 199.80869,-221.82015 -3.90101,2.25227 3.90101,2.25225"
+       id="button5"
+       inkscape:connector-curvature="0"
+       inkscape:label="" />
+    <path
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#babdb6;stroke-width:2.56880355px;stroke-linecap:round;stroke-linejoin:round;stroke-opacity:1"
+       d="m 237.6341,-221.8517 3.90101,2.25227 -3.90101,2.25225"
+       id="button6"
+       inkscape:connector-curvature="0"
+       inkscape:label="" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     transform="translate(0,321.03999)"
+     style="display:inline">
+    <g
+       id="button5-path"
+       inkscape:label="">
+      <path
+         inkscape:connector-curvature="0"
+         id="path884"
+         d="m 198.00952,-210.78264 -29.43205,29.43205 H 0.35355339"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         inkscape:label=""
+         y="-181.85059"
+         x="0.10401335"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="text-align:end;display:inline;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         y="-214.28264"
+         x="194.50952"
+         height="7"
+         width="7"
+         id="rect2047"
+         style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       id="button3-path"
+       inkscape:label="">
+      <rect
+         inkscape:label=""
+         y="-125.62335"
+         x="0.05242718"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="text-align:end;display:inline;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2119"
+         d="M 80.53685,-125.12076 H 0.51959257"
+         style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="-128.62076"
+         x="77.03685"
+         height="7"
+         width="7"
+         id="rect2047-9"
+         style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       id="button4-path"
+       inkscape:label="">
+      <rect
+         inkscape:label=""
+         y="-74.184525"
+         x="0.0703125"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="text-align:end;display:inline;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path2121"
+         d="M 81.835831,-73.68108 H 0.51959257"
+         style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="-77.181084"
+         x="78.335831"
+         height="7"
+         width="7"
+         id="rect2047-87"
+         style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       style="display:inline"
+       id="button0-path"
+       inkscape:label="">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2117"
+         d="M 154.83858,-230.33824 96.384414,-288.7924 H 0.51959257"
+         style="display:inline;fill:none;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         inkscape:label=""
+         y="-289.29233"
+         x="0.25592589"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="text-align:end;display:inline;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         y="-233.83824"
+         x="151.33858"
+         height="7"
+         width="7"
+         id="rect2047-7"
+         style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       id="button1-path"
+       inkscape:label="">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path2125"
+         d="m 284.47693,-230.07844 55.72631,-55.72631 h 109.63402"
+         style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="-233.57845"
+         x="280.97693"
+         height="7"
+         width="7"
+         id="rect2047-0"
+         style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         y="-286.3056"
+         x="448.96484"
+         height="1"
+         width="1"
+         id="button1-leader"
+         style="text-align:start;display:inline;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill"
+         inkscape:label="" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="">
+      <path
+         inkscape:connector-curvature="0"
+         id="path2129"
+         d="m 219.25864,-151.26926 42.56584,42.56585 h 187.62309"
+         style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         y="-154.76926"
+         x="215.75864"
+         height="7"
+         width="7"
+         id="rect2047-08"
+         style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         inkscape:label=""
+         y="-109.20406"
+         x="448.96875"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="text-align:start;display:inline;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+    <g
+       id="button6-path"
+       inkscape:label="">
+      <path
+         inkscape:connector-curvature="0"
+         id="path891"
+         d="m 239.67007,-210.78999 29.97581,29.97581 h 180.25081"
+         style="fill:none;fill-rule:evenodd;stroke:#888a85;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         inkscape:label=""
+         y="-181.31418"
+         x="448.96875"
+         height="1"
+         width="1"
+         id="button6-leader"
+         style="text-align:start;display:inline;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+      <rect
+         y="-214.28999"
+         x="236.17007"
+         height="7"
+         width="7"
+         id="rect2047-8"
+         style="display:inline;opacity:1;vector-effect:none;fill:#000000;fill-opacity:1;stroke:none;stroke-width:0.60000002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers stroke fill" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     style="display:inline" />
+</svg>

--- a/data/svgs/logitech-mx-anywhere2s.svg
+++ b/data/svgs/logitech-mx-anywhere2s.svg
@@ -1,0 +1,1 @@
+logitech-mx-anywhere2.svg

--- a/data/svgs/logitech-mx-master-2s.svg
+++ b/data/svgs/logitech-mx-master-2s.svg
@@ -1,0 +1,359 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="485"
+   height="445"
+   viewBox="0 0 128.32296 117.73977"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="logitech-mx-master-2s.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.979899"
+     inkscape:cx="189.95565"
+     inkscape:cy="227.78986"
+     inkscape:document-units="px"
+     inkscape:current-layer="Buttons"
+     showgrid="true"
+     inkscape:window-width="2560"
+     inkscape:window-height="1376"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     units="px"
+     showguides="false"
+     inkscape:snap-global="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid5521"
+       spacingy="10.583333"
+       spacingx="264583.33"
+       originy="5.2916751" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline"
+     transform="translate(0,-179.26022)">
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 19.866021,223.53772 c 0,0 -0.785103,0.71829 -2.204974,1.68714 -1.419868,0.96885 -3.558026,2.2885 -4.877667,3.35758 -1.319644,1.06907 -2.004523,2.37202 -2.622585,3.77518 -0.6180575,1.40317 -1.4031635,5.06142 -2.121448,9.92238 -0.718287,4.86097 -1.102486,9.43796 -1.2194155,13.69757 -0.11693,4.2596 -0.451017,4.79414 0.868623,8.76978 1.5191735,3.4768 3.2046955,4.45805 4.2429035,5.41221 1.085782,0.83521 6.965712,5.3955 11.72645,8.30206 4.760738,2.90655 11.225936,6.8707 14.699824,8.16842 1.860286,0.69493 2.586897,1.04147 4.032189,1.46211 1.219513,0.35492 2.417778,0.58726 4.971452,0.8765 4.324451,0.48981 9.010044,-0.72432 11.943604,-2.20498 2.83974,-1.63702 7.75082,-4.94448 11.04158,-8.70296 3.29075,-3.75848 4.17608,-4.69392 4.91107,-7.76752 0.73499,-3.0736 1.23612,-9.6217 1.11919,-15.31788 -0.11693,-5.69619 -0.7851,-13.64745 -1.41987,-18.67546 -0.63476,-5.02801 -1.26952,-7.684 -1.26952,-7.684"
+       id="path5225"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csccsscccsssccsscc" />
+    <path
+       sodipodi:nodetypes="cscssscsc"
+       inkscape:connector-curvature="0"
+       id="button5"
+       d="m 19.676541,228.60285 c 0,0 -5.707153,4.07215 -6.676005,5.10782 -0.968853,1.03567 -1.5368,2.70611 -1.703845,3.74178 -0.167042,1.03567 -1.169302,7.58377 -1.5702065,12.56167 -0.4009035,4.97789 -0.7015815,6.98241 -0.233862,9.32102 0.467722,2.33861 1.4365735,3.64155 2.2383825,4.30972 0.801809,0.66817 13.229842,9.2208 15.969354,10.7576 0.342743,-3.52158 1.597747,-7.89241 -0.165219,-10.5636 -4.912482,-7.44322 -8.870526,-19.92797 -7.858599,-35.23601 z"
+       style="fill:#d3d3ce;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       inkscape:label="#path5657" />
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 19.676541,228.60285 c 0,0 -5.707153,4.07215 -6.676005,5.10782 -0.968853,1.03567 -1.5368,2.70611 -1.703845,3.74178 -0.167042,1.03567 -1.169302,7.58377 -1.5702065,12.56167 -0.4009035,4.97789 -0.7015815,6.98241 -0.233862,9.32102 0.467722,2.33861 1.4365735,3.64155 2.2383825,4.30972 0.801809,0.66817 14.365737,9.78875 17.105249,11.32555 2.739514,1.5368 8.352173,4.57699 12.127356,5.34539 3.775181,0.7684 7.249684,1.20271 12.127357,0.93544 4.87767,-0.26727 11.35895,-4.00904 13.0962,-5.57925 1.73725,-1.57021 6.38106,-7.18287 7.38333,-10.08942 1.00226,-2.90656 1.77066,-11.42578 1.26952,-20.21226 -0.50113,-8.78649 -1.06907,-15.30119 -1.1693,-16.5039 -0.10022,-1.20271 -0.0334,-7.58377 -0.93544,-18.40819 -0.90204,-10.82441 -1.36976,-11.99372 -2.20498,-14.26551 -0.83522,-2.27179 -7.85104,-5.47902 -11.22532,-6.84878 -3.37427,-1.36976 -9.585632,-3.70469 -11.541371,-3.84016 -1.955737,-0.13547 -8.938152,2.40359 -11.944935,3.77334 -3.006783,1.36976 -8.073472,4.0577 -8.073472,4.0577 -4.468114,9.08817 -5.960983,22.63921 -8.068658,35.26804 z"
+       id="path78"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscssssssscccsscsscc" />
+    <rect
+       id="button6"
+       width="5.315289"
+       height="5.3152866"
+       x="45.235897"
+       y="221.81316"
+       style="opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       rx="0.69999999"
+       ry="0.69999999"
+       inkscape:label="#rect5215" />
+    <rect
+       style="opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       id="button2"
+       width="7.0870538"
+       height="14.552083"
+       x="44.220081"
+       y="199.01646"
+       rx="0.70000017"
+       ry="0.70000017"
+       inkscape:label="#rect5217" />
+    <path
+       id="button0"
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 47.762508,195.6666 c -1.892311,0.0167 -3.873176,0.0377 -4.226442,0.0417 -0.709932,0.008 -1.720551,0.96885 -1.737251,1.72054 -0.0141,0.63483 -0.159624,28.13451 -0.171424,28.86684 -0.01181,0.73233 -0.563567,1.23439 -0.747315,1.40144 -0.183748,0.16704 -17.283331,6.12265 -17.708555,6.24077 -0.425221,0.11811 -0.761454,0.3511 -1.039434,-0.40751 -0.347226,-0.94758 -0.07087,-7.39416 0.87407,-17.9775 0.944941,-10.58333 4.739037,-22.21806 4.739037,-22.21806 0,0 5.066694,-2.68795 8.073477,-4.05771 3.006783,-1.36975 9.989198,-3.90881 11.944936,-3.77211 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccscccc"
+       inkscape:label="#path5627" />
+    <path
+       id="button1"
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 47.763608,185.50377 v 10.08368 m -0.01842,0.0784 c 1.690105,-0.0156 3.321588,-0.0284 3.692045,-0.0244 0.944073,0.0103 2.438833,1.06072 2.488943,2.38872 0.0535,1.41886 0.18375,26.82718 0.23387,27.92966 0.0501,1.10249 0.14727,1.2276 0.71424,1.66464 0.56696,0.43703 13.97331,5.5279 14.74107,5.65783 0.76776,0.12993 0.88588,-0.14174 0.95675,-0.68508 0.0709,-0.54334 0.50944,-11.58187 0.27558,-14.7557 -0.23387,-3.17383 -1.089962,-16.77534 -2.799869,-24.09699 -2.565285,-1.75722 -6.479518,-3.48182 -8.74284,-4.4006 -3.37427,-1.36976 -9.585632,-3.70469 -11.541371,-3.84016"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccsccccc"
+       inkscape:label="#path5631" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 24.70574,258.91885 c 0,0 -2.944259,-4.70523 -3.525604,-7.81361 0.07137,0.16032 1.142052,1.76828 1.374962,1.88086"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc"
+       inkscape:label="#path5636" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 20.347215,244.33435 c 0,0 0.503997,5.22172 0.804675,6.62488 0.300678,1.40317 1.186008,1.85418 1.186008,1.85418"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc"
+       inkscape:label="#path5634" />
+    <path
+       style="opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 27.745199,193.33481 c 0,0 -1.681865,1.10395 -2.416856,2.12291 -0.734991,1.01897 -3.240643,8.4524 -4.510173,19.00955 -1.269531,10.55714 -0.985557,10.80771 -1.085783,14.51607 -0.100226,3.70837 0.06098,11.98844 0.627949,15.41385 0.566964,3.42541 2.69308,11.19754 4.086867,13.98512 1.393787,2.78757 2.944127,5.32102 3.061057,5.37113 0.116931,0.0501 0.175396,0.10858 0.400904,-0.0334 0.225509,-0.14198 1.03567,-0.92709 1.127544,-1.30294 0.09187,-0.37584 0.200452,-0.77675 0.04176,-1.17765 -0.158692,-0.40091 -2.029578,-3.25735 -2.38037,-4.14268 -0.350791,-0.88533 -2.15486,-4.86097 -2.873147,-8.4357 -0.718287,-3.57473 -1.503391,-7.51695 -1.753956,-9.83885 -0.250566,-2.32191 -0.183748,-4.09257 -0.183748,-5.04472 0,-0.95214 0.09187,-2.02958 0.09187,-2.02958 0.279608,-13.8572 2.014074,-26.7818 5.766082,-38.41311 z"
+       id="path5223"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssccccccsssscc" />
+    <g
+       id="g1137"
+       transform="translate(-3.6416254,5.291675)">
+      <rect
+         y="193.85353"
+         x="48.915695"
+         height="14.312759"
+         width="1.8040693"
+         id="rect1131"
+         style="opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:none;stroke-width:0.26502112px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         style="opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:none;stroke-width:0.26502112px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         id="rect1133"
+         width="1.8040693"
+         height="14.312759"
+         x="52.090698"
+         y="193.85353" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     transform="translate(0,-179.26022)">
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,2.1166624,183.016)"
+       style="display:inline"
+       id="button1-path"
+       inkscape:label="#g131">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 242.94764,50.505764 H 477"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="237"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="50.005764" />
+    </g>
+    <g
+       inkscape:label="#g131"
+       id="button6-path"
+       style="display:inline"
+       transform="matrix(0.26458333,0,0,0.26458333,2.1166624,213.83995)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5469"
+         d="M 173.32645,40.025431 193.47816,54.00578 H 477.59978"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         y="36.559353"
+         x="169.85715"
+         height="6.999999"
+         width="6.999999"
+         id="rect5471"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="53.505779"
+         x="477"
+         height="1"
+         width="1"
+         id="button6-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,2.1166624,204.05037)"
+       style="display:inline"
+       id="button0-path"
+       inkscape:label="#g131">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 132.23335,50.505764 H 477"
+         id="path5477"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5479"
+         width="6.999999"
+         height="6.999999"
+         x="128.42857"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button0-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="50.005764" />
+    </g>
+    <g
+       inkscape:label="#g131"
+       id="button2-path"
+       style="display:inline"
+       transform="matrix(0.26458333,0,0,0.26458333,2.1166624,193.59933)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5485"
+         d="M 168.43093,50.505764 H 477"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.94604886;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="167.35715"
+         height="6.999999"
+         width="6.999999"
+         id="rect5487"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="477"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,2.1166624,225.21704)"
+       style="display:inline"
+       id="button5-path"
+       inkscape:label="#g131">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1.17770362;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 55.283671,50.505764 H 477"
+         id="path5493"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5495"
+         width="6.999999"
+         height="6.999999"
+         x="48.428574"
+         y="47.005764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button5-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="50.005764" />
+    </g>
+    <g
+       inkscape:label="#g131"
+       id="button4-path"
+       style="display:inline"
+       transform="matrix(0.26458333,0,0,0.26458333,2.1166624,235.80037)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path5503"
+         d="M 69.460332,50.505764 H 477"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1.13811326;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="47.005764"
+         x="67.665703"
+         height="6.999999"
+         width="6.999999"
+         id="rect5505"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="477"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,2.1166624,246.3837)"
+       style="display:inline"
+       id="button3-path"
+       inkscape:label="#g131">
+      <path
+         sodipodi:nodetypes="ccc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1.12054801;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 78.817927,36.487907 105.14285,50.505764 H 477"
+         id="path5513"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5515"
+         width="6.999999"
+         height="6.999999"
+         x="75.454132"
+         y="33.075569" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button3-leader"
+         width="1"
+         height="1"
+         x="477"
+         y="50.005764" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     transform="translate(0,-14.552099)" />
+</svg>

--- a/data/svgs/logitech-mx-master.svg
+++ b/data/svgs/logitech-mx-master.svg
@@ -1,0 +1,1 @@
+logitech-mx-master-2s.svg

--- a/data/svgs/roccat-kone-xtd.svg
+++ b/data/svgs/roccat-kone-xtd.svg
@@ -1,0 +1,578 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="482.65375"
+   height="409.75723"
+   viewBox="0 0 482.65374 409.75722"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="roccat-kone-xtd.svg"
+   inkscape:export-filename="/home/jimmac/logitech-g403.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96">
+  <defs
+     id="defs2">
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4426"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4416"
+       is_visible="true" />
+    <inkscape:path-effect
+       is_visible="true"
+       id="path-effect4412"
+       effect="spiro" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4397"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4384"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4380"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4368"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4360"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4193"
+       is_visible="true" />
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect4185"
+       is_visible="true" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="0.70710678"
+     inkscape:cx="-64.59026"
+     inkscape:cy="199.95686"
+     inkscape:document-units="px"
+     inkscape:current-layer="Buttons"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="false"
+     showguides="true"
+     inkscape:window-width="1920"
+     inkscape:window-height="1101"
+     inkscape:window-x="1920"
+     inkscape:window-y="28"
+     inkscape:window-maximized="1"
+     fit-margin-top="20"
+     fit-margin-left="0"
+     fit-margin-bottom="20"
+     fit-margin-right="0"
+     inkscape:guide-bbox="true"
+     guidetolerance="10"
+     objecttolerance="10"
+     gridtolerance="10">
+    <inkscape:grid
+       type="xygrid"
+       id="grid956"
+       originx="36.653759"
+       originy="3.4686305" />
+    <sodipodi:guide
+       position="125.24434,292.81279"
+       orientation="1,0"
+       id="guide4350"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="232.01745,389.68642"
+       orientation="0,1"
+       id="guide4352"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="339.49769,179.67571"
+       orientation="1,0"
+       id="guide4354"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="262.42305,21.283798"
+       orientation="0,1"
+       id="guide4356"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="61.51829,157.33126"
+       orientation="1,0"
+       id="guide5867"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     transform="translate(36.653757,-393.71139)"
+     style="display:inline">
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 122.82453,740.37034 c -19.02281,-23.41625 -31.616134,-52.28805 -34.233943,-82.34359 -2.096443,-24.06963 2.128869,-48.32241 8.95101,-71.5 2.158331,-7.33273 4.577033,-14.58882 7.250003,-21.75 -1.3982,-18.81093 -1.06298,-37.75033 1,-56.5 2.52814,-22.97724 7.65448,-45.66761 15.25,-67.5 l 13.25,-11.25 141.5,-5.25 c 12.02953,26.7963 18.37607,56.12763 18.5,85.5 0.12121,28.72967 -5.62197,57.27681 -5,86 0.24638,11.37797 1.49774,22.75148 4.0739,33.8367 3.20755,13.80209 8.47842,27.26326 9.22845,41.4133 0.66161,12.48182 -2.27756,24.99565 -7.36927,36.41091 -5.0917,11.41525 -12.28663,21.79231 -20.30154,31.38369 -9.49466,11.36219 -20.28557,21.78699 -32.84623,29.62777 -12.56066,7.84078 -26.98545,13.02513 -41.78531,13.48575 -15.18013,0.47246 -30.29151,-4.05272 -43.44909,-11.63807 -13.15758,-7.58536 -24.44174,-18.13853 -34.01798,-29.92646 z"
+       id="path4382"
+       inkscape:path-effect="#path-effect4384"
+       inkscape:original-d="m 122.82453,740.37034 c 0,0 -34.233943,-46.59359 -34.233943,-82.34359 0,-35.75 5.95101,-62.75 8.95101,-71.5 3.000003,-8.75 7.250003,-21.75 7.250003,-21.75 25.62768,0 -0.25,-44 1,-56.5 1.25,-12.5 15.25,-67.5 15.25,-67.5 l 13.25,-11.25 141.5,-5.25 c 0,0 18.25,53.25 18.5,85.5 0.25,32.25 -5.25,74.75 -5,86 0.125,5.625 0.81574,20.14113 4.0739,33.8367 3.25816,13.69557 6.83375,29.07057 9.22845,41.4133 0.84882,4.375 -22.22676,62.14156 -27.67081,67.7946 -24.05895,24.98254 -60.00654,43.19257 -74.63154,43.11352 -48.05458,-0.25976 -77.46707,-41.56453 -77.46707,-41.56453 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csscscccssssssc" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 134.2916,429.52675 -12.75,12.5 c -12.31411,36.57641 -16.0253,76.01857 -10.75,114.25 6.1427,44.5177 24.24594,87.57778 23,132.5 -0.49267,17.76334 -4.06145,35.43727 -10.5,52 8.39201,13.20649 20.3144,24.14654 34.19206,31.37481 13.87766,7.22828 29.67603,10.72678 45.30794,10.03331 29.20955,-1.29581 57.30887,-17.926 72.5,-42.90812 -6.99047,-28.36406 -8.86284,-57.98142 -5.5,-87 5.139,-44.34544 22.31262,-86.91141 24.5,-131.5 1.63092,-33.24546 -5.32115,-66.87607 -20,-96.75 l -14,-9.49452 c -20.53616,-0.82089 -41.13517,-0.0647 -61.55586,2.25985 -21.78053,2.4793 -43.35766,6.74311 -64.44414,12.73467 z"
+       id="path4378"
+       inkscape:original-d="m 134.2916,429.52675 -12.75,12.5 c 0,0 -18.75,71.75 -10.75,114.25 8,42.5 23.42774,101.24777 23,132.5 -0.42774,31.25223 -10.5,52 -10.5,52 0,0 43.5,41.40812 79.5,41.40812 36,0 72.5,-42.90812 72.5,-42.90812 0,0 -20,-25.5 -5.5,-87 14.5,-61.5 23,-104.5 24.5,-131.5 1.5,-27 -20,-96.75 -20,-96.75 l -14,-9.49452 c -22.40781,-0.31655 -36.15781,-0.75 -61.55586,2.25985 -25.99748,3.08089 -64.44414,12.73467 -64.44414,12.73467 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccszcscssccsc"
+       inkscape:path-effect="#path-effect4380" />
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#babdb6;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 102.95061,567.96501 c 0.70002,22.44793 2.65772,43.37669 3.30638,62.88708 0.52948,15.92576 7.34749,40.38934 -4.69813,38.78754 -4.929835,-0.65556 -12.883112,-9.26574 -13.017313,-24.73788"
+       id="path4401"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssc" />
+    <path
+       inkscape:label="#path924"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 104.14503,591.78576 c 2.70152,2.04148 8.34731,2.78189 8.46463,3.52635 l 7.53906,47.84087 c 0.37596,2.38573 -1.6214,1.86287 -1.6214,1.86287 -2.38894,0.35504 -11.76758,-6.66231 -11.90814,-9.07339 l -1.90715,-32.71 c -0.14062,-2.41107 -0.567,-11.4467 -0.567,-11.4467 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csscssc" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 105.59036,538.91245 c 0.52253,-0.12564 0.84775,3.74005 1.08254,6.14378 l 4.20424,41.21202 -6.91297,-2.23542 -3.04198,-39.25359 c -0.1866,-2.40794 2.31991,-5.30229 4.66817,-5.86679 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ssccss"
+       inkscape:label="#rect921" />
+    <path
+       style="color:#000000;overflow:visible;opacity:1;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 216.66981,463.35766 c 7.7882,31.51628 -3.10225,161.1236 -3.10225,161.1236 -0.13535,7.02963 -6.07063,10.44123 -13.61129,10.44123 -7.54065,0 -13.50233,-3.41113 -13.61128,-10.44123 0,0 -10.54298,-129.82998 -2.5,-161.31424 8.04298,-31.48426 11.005,-29.3064 16.58919,-29.26346 5.58419,0.0429 8.44743,-2.06218 16.23563,29.4541 z"
+       id="rect913"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="zssszzz" />
+    <rect
+       style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       id="button2"
+       width="23.15593"
+       height="57.717773"
+       x="188.55382"
+       y="461.01868"
+       rx="11.577965"
+       ry="11.577967"
+       inkscape:label="#rect932" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="button7"
+       d="m 209.20722,524.3296 -0.65676,27.92859 -17.18836,0 -0.65677,-27.92859 z"
+       style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:label="#path942" />
+    <path
+       inkscape:label="#path942"
+       style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 208.41172,565.23341 -1.86126,32.17123 c -0.25984,4.4912 -1.83301,4.12045 -6.59419,4.12045 -4.76117,0 -6.33658,0.37088 -6.59417,-4.12045 l -1.94966,-31.99445 z"
+       id="button8"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscc" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 199.58066,416.69667 c -0.28142,0.0314 -0.56434,0.0637 -0.8457,0.0957 -21.78053,2.47931 -43.35688,6.74282 -64.44336,12.73438 l -5.24219,5.13867 c -4.63188,14.23762 -6.48452,22.56972 -10.85742,51.73047 -2.31322,15.42571 0.0333,42.97083 4.37695,70.53516 20.18393,0.10496 59.33211,-0.93056 59.53906,0.375 l 0.0371,-0.30274 c -1.67671,-36.75209 -2.37374,-77.8923 1.69922,-93.83594 6.49241,-25.41455 9.67504,-28.8908 13.59766,-29.26562 l 2.25586,-0.10352 z"
+       id="button0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccscccsccc" />
+    <path
+       inkscape:label="#path942"
+       style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 208.55097,552.1948 -5e-4,13.20984 -17.18836,0 -5.2e-4,-13.17859 z"
+       id="path4391"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="button9"
+       d="m 206.55097,441.9448 1.9995,15.20984 -17.18836,0 1.99948,-15.17859 z"
+       style="color:#000000;overflow:visible;opacity:1;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       inkscape:label="#path942" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:nonzero;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 245.09433,414.2123 c -15.20199,-0.0324 -30.40556,0.79698 -45.51367,2.48437 l 0.33399,17.16016 1.96093,0.0351 c 4.68444,-0.0473 7.71457,0.81299 14.79493,29.46485 3.87599,15.68486 3.12444,55.66092 1.39257,91.86914 l 0.23829,1.79297 60.07421,0.69336 c 8.82289,-52.62093 4.27435,-90.98774 -13.62695,-139.62696 l -0.13281,-0.62109 -4.32422,-2.93164 c -5.0633,-0.2024 -10.12994,-0.30953 -15.19727,-0.32031 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccscccccccc" />
+    <path
+       id="led0"
+       style="fill:#babdb6;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 290.24244,554.46605 c -5.26976,49.56099 -36.23031,99.47705 -15.28225,184.71113 -3.16837,4.44852 -3.173,4.56365 -8.05566,10.86971 -17.84401,-50.57656 -7.8566,-125.64401 4.04428,-156.62518 17.6011,-72.50699 15.50543,-116.35777 -6.20089,-175.33551 l 9.29158,5.5835 c 10.82003,25.11299 27.5667,64.49596 16.20294,130.79635 z m -180.19239,-2.47487 c 7.61079,68.82965 34.53563,125.64 13.2841,188.42344 3.24708,3.97977 8.53092,12.44446 12.34811,15.28913 18.99515,-41.57656 13.57812,-98.28741 2.86138,-129.26858 -11.32886,-31.75516 -24.92286,-109.55879 -20.35212,-140.03876 4.57073,-30.47997 6.3548,-38.13399 11.4734,-53.63774 l -10.11812,10.8868 c -9.96888,31.30753 -13.36232,66.4405 -9.49675,108.34571 z"
+       inkscape:label="#path5753"
+       inkscape:connector-curvature="0" />
+    <path
+       inkscape:label="#path1146"
+       inkscape:connector-curvature="0"
+       id="button6"
+       d="m 221.59975,489.94486 0,7.97552 3.83318,-3.83321 z"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    <path
+       inkscape:label="#path1148"
+       style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+       d="m 178.14034,489.94486 0,7.97552 -3.83318,-3.83321 z"
+       id="button5"
+       inkscape:connector-curvature="0" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(36.653757,6.2887068)">
+    <g
+       id="button1-path"
+       inkscape:label="#g131"
+       transform="translate(8,111.99976)">
+      <path
+         sodipodi:nodetypes="ccc"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 221.19764,23.005764 248.71312,50.628685 437,50.505764"
+         id="path958"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="217.125"
+         y="19.255764" />
+      <rect
+         inkscape:label="#rect867"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="50.005764" />
+    </g>
+    <g
+       id="button9-path"
+       inkscape:label="#g141"
+       transform="translate(8,-88)">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path960"
+         d="m 437,130.50576 -237.65602,0 -3.89602,3.89602"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path960" />
+      <rect
+         y="133.00577"
+         x="189"
+         height="6.999999"
+         width="6.999999"
+         id="rect970"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#rect970" />
+      <rect
+         inkscape:label="#rect871"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button9-leader"
+         width="1"
+         height="1"
+         x="437"
+         y="130.00577" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="#g136"
+       transform="translate(8,-8)">
+      <rect
+         inkscape:label="#rect869"
+         y="90.00576"
+         x="437"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+      <path
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 195.97852,94.49147 3.9857,-3.98571 237.03578,0"
+         id="path908"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect910"
+         width="6.999999"
+         height="6.999999"
+         x="190"
+         y="92" />
+    </g>
+    <g
+       id="button8-path"
+       inkscape:label="#g146"
+       transform="matrix(1,0,0,-1,8,371.99953)">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 436.55132,170.50615 H 213.34398 l -18.11371,18.15319"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="189"
+         y="187" />
+      <rect
+         y="170"
+         x="437"
+         height="1"
+         width="1"
+         id="button8-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="translate(-72.0872,-77.953227)"
+       style="display:inline"
+       id="button7-path"
+       inkscape:label="#g191">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 37.16895,300.50027 59.327469,0 79.344411,-79.98695 96.85261,0"
+         id="path1502"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         transform="scale(-1,-1)"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect1504"
+         width="6.999999"
+         height="6.999999"
+         x="-276.00287"
+         y="-223.98463" />
+      <rect
+         transform="scale(-1,-1)"
+         style="color:#000000;text-align:end;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button7-leader"
+         width="1"
+         height="1"
+         x="-37.168953"
+         y="-301.00027"
+         inkscape:label="#rect873" />
+    </g>
+    <g
+       transform="translate(-72.82271,-38.03545)"
+       style="display:inline"
+       id="button4-path"
+       inkscape:label="#g196">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path1506"
+         d="m 37.16895,340.50027 60.200651,0 87.698379,-87.55322"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="-257.98224"
+         x="-187.04956"
+         height="6.999999"
+         width="6.999999"
+         id="rect1508"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1,-1)" />
+      <rect
+         inkscape:label="#rect873"
+         y="-341.00027"
+         x="-37.168953"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="color:#000000;text-align:end;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1,-1)" />
+    </g>
+    <g
+       inkscape:label="#g196"
+       id="button3-path"
+       style="display:inline"
+       transform="translate(-72.82271,-78.03545)">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 37.16895,340.50027 60.200651,0 83.698379,-83.55322"
+         id="path5817"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         transform="scale(-1,-1)"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect5819"
+         width="6.999999"
+         height="6.999999"
+         x="-183.04956"
+         y="-261.98224" />
+      <rect
+         transform="scale(-1,-1)"
+         style="color:#000000;text-align:end;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button3-leader"
+         width="1"
+         height="1"
+         x="-37.168953"
+         y="-341.00027"
+         inkscape:label="#rect873" />
+    </g>
+    <g
+       inkscape:label="#g191"
+       id="button0-path"
+       style="display:inline"
+       transform="translate(-72.0872,-177.95275)">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="button0-line"
+         d="m 37.16895,320.50027 h 59.327469 l 99.344411,-99.98695 h 26.85261"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="#path5841" />
+      <rect
+         y="-223.98463"
+         x="-226.00287"
+         height="6.999999"
+         width="6.999999"
+         id="button0-rect"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)"
+         inkscape:label="#rect5843" />
+      <rect
+         inkscape:label="#rect873"
+         y="-321.00027"
+         x="-37.168953"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:end;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+    <g
+       transform="translate(-72.0872,-137.95275)"
+       style="display:inline"
+       id="button5-path"
+       inkscape:label="#g191">
+      <path
+         inkscape:label="#path5841"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 37.16895,320.50027 h 59.327469 l 88.152021,-88.86195 h 55.67"
+         id="path85"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         inkscape:label="#rect5843"
+         transform="scale(-1)"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect87"
+         width="6.999999"
+         height="6.999999"
+         x="-244.00287"
+         y="-235.48463" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:end;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button5-leader"
+         width="1"
+         height="1"
+         x="-37.168953"
+         y="-321.00027"
+         inkscape:label="#rect873" />
+    </g>
+    <g
+       transform="translate(10.625,71.49976)"
+       inkscape:label="#g131"
+       id="button6-path">
+      <path
+         inkscape:connector-curvature="0"
+         id="path93"
+         d="m 221.19764,23.005764 27.51548,27.622921 185.72362,-0.122921"
+         style="color:#000000;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         y="19.255764"
+         x="217.125"
+         height="6.999999"
+         width="6.999999"
+         id="rect95"
+         style="color:#000000;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         y="50.005764"
+         x="434.37524"
+         height="1"
+         width="1"
+         id="button6-leader"
+         style="color:#000000;text-align:start;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect867" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     style="display:inline"
+     transform="translate(36.653757,6.2887068)">
+    <g
+       id="led0-path"
+       inkscape:label="#g161"
+       transform="translate(8,56)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path877"
+         d="m 437,290.50577 -158.35562,0 -18.97696,-18.97696"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         y="269.96875"
+         x="256.28125"
+         height="6.999999"
+         width="6.999999"
+         id="rect879"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect881"
+         y="290.00577"
+         x="437"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/steelseries-kinzu-v2.svg
+++ b/data/svgs/steelseries-kinzu-v2.svg
@@ -1,0 +1,285 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="490"
+   height="490"
+   viewBox="0 0 129.64583 129.64583"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="steelseries-kinzu-v2.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="128"
+     inkscape:cx="1.394717"
+     inkscape:cy="334.40624"
+     inkscape:document-units="px"
+     inkscape:current-layer="Buttons"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     showguides="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1163"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showborder="true"
+     inkscape:guide-bbox="true"
+     units="px"
+     inkscape:snap-global="false"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid78" />
+    <sodipodi:guide
+       position="58.722772,112.40709"
+       orientation="0,1"
+       id="guide79"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="39.611923,100.54373"
+       orientation="0,1"
+       id="guide81"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="51.756014,88.614617"
+       orientation="0,1"
+       id="guide83"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="57.778386,76.729167"
+       orientation="0,1"
+       id="guide85"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="45.047078,64.795712"
+       orientation="0,1"
+       inkscape:locked="false"
+       id="guide87" />
+    <sodipodi:guide
+       position="57.646696,52.899321"
+       orientation="0,1"
+       id="guide89"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="64.732676,142.09384"
+       orientation="1,0"
+       id="guide913"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="-45.462545,31.805073"
+       orientation="0,1"
+       inkscape:locked="false"
+       id="guide944" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline;opacity:1"
+     transform="translate(0,-167.35416)">
+    <path
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 61.052601,173.57187 c -6.81302,0.0662 -11.972394,1.52136 -16.073435,3.37344 -2.88728,1.31189 -4.888218,3.54982 -6.680729,5.62239 -2.215885,3.43407 -2.38125,5.63618 -2.976562,8.86355 -0.919394,7.49385 -0.763027,14.47321 -0.79375,22.62187 -0.0441,2.92144 -0.104731,3.9908 -0.33073,6.28385 -0.132292,4.05143 -0.413412,7.82174 -0.79375,11.90625 l -0.859895,11.9724 -1.190625,16.27187 c -0.0248,0.94258 -10e-7,1.65364 0.198437,2.57969 0.171855,0.8399 0.352238,1.03153 0.463021,1.52135 0.595312,2.4033 0.529166,3.99631 1.785937,7.2099 2.116666,4.23333 3.604948,6.84609 6.746875,10.71562 3.858506,4.06797 6.928936,5.67685 11.575518,7.34219 4.293136,1.39044 7.919768,1.65835 12.633854,1.78594 0,0 8.340581,-0.39932 12.633718,-1.78976 4.646582,-1.66534 7.717012,-3.27422 11.575518,-7.34219 3.141927,-3.86953 4.630209,-6.48229 6.746875,-10.71562 1.256771,-3.21359 1.190625,-4.8066 1.785937,-7.2099 0.110783,-0.48982 0.291166,-0.68145 0.463021,-1.52135 0.198438,-0.92605 0.223237,-1.63711 0.198437,-2.57969 L 96.969648,244.2118 96.109753,232.2394 c -0.380338,-4.08451 -0.661458,-7.85482 -0.79375,-11.90625 -0.225999,-2.29305 -0.28663,-3.36241 -0.33073,-6.28385 -0.03072,-8.14866 0.125644,-15.12802 -0.79375,-22.62187 -0.595312,-3.22737 -0.760677,-5.42948 -2.976562,-8.86355 -1.792511,-2.07257 -3.793449,-4.3105 -6.680729,-5.62239 -4.101041,-1.85208 -9.260416,-3.30724 -16.073436,-3.37344"
+       id="path926"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccccccccc" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.56091666;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 67.539008,213.39476 c 0.596076,-0.40461 0.976498,-1.09288 1.262849,-1.75395 0.59297,-1.36894 1.002146,-2.81668 1.345797,-4.2684 0.360294,-1.52203 0.585878,-3.07592 0.760677,-4.63021 0.233495,-2.07621 0.429791,-4.16174 0.463021,-6.25078 0.04814,-3.0267 0.02798,-6.06163 -0.219194,-9.0786 -0.12373,-1.51024 -0.256628,-3.03361 -0.631425,-4.50182 -0.572228,-2.24162 -1.647818,-4.33612 -2.198291,-6.58318 -0.216184,-0.88248 0.0049,-1.99996 -0.01156,-2.94772 -1.271665,3e-5 -4.766155,-0.0195 -7.137319,0.009 -0.0538,0.84704 0.04496,2.27487 -0.171222,3.15735 -0.550473,2.24706 -1.626063,4.34156 -2.198291,6.58318 -0.374797,1.46821 -0.507695,2.99158 -0.631425,4.50182 -0.247174,3.01697 -0.267336,6.0519 -0.219194,9.0786 0.03323,2.08904 0.229526,4.17457 0.463021,6.25078 0.174799,1.55428 0.400383,3.10818 0.760677,4.63021 0.343651,1.45172 0.752827,2.89946 1.345797,4.2684 0.286351,0.66107 0.666773,1.34934 1.262849,1.75395 0.754658,0.51225 1.678069,0.76673 2.876621,0.7559 1.213084,-0.011 2.121964,-0.46243 2.876622,-0.97468 z"
+       id="path67"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssssassccssasssssssc" />
+    <rect
+       style="display:inline;opacity:1;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.56091666;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="button2"
+       width="7.9137998"
+       height="13.453473"
+       x="60.725685"
+       y="182.47507"
+       ry="3.5612154"
+       inkscape:label="#rect4615" />
+    <path
+       style="fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.52916664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 63.166987,210.17431 c 0.413327,0.85333 0.912893,2.12412 1.659236,2.12129 0.787332,-0.0468 1.235565,-1.13423 1.730571,-2.10475 0.963186,-2.27407 1.866349,-4.95232 2.011204,-7.01582 -0.04511,-0.75357 -0.133324,-0.96262 -0.841899,-1.16931 H 62.16021 c -0.833415,0.11951 -1.319565,0.66897 -1.309621,1.44994 0.120828,1.81242 1.213354,4.50867 2.316398,6.71865 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:label="#path914" />
+    <path
+       style="fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.56091666;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 95.299608,220.25429 c 0,0 -2.993099,22.36809 -2.993099,33.61862 0,1.85752 0.06615,2.789 0.06615,4.72943 0,2.7249 -0.02687,3.50461 0.644922,5.02708 0.260631,0.59067 1.072687,1.52327 2.133203,1.88516 1.196295,0.23151 2.146396,-0.87485 2.844271,-2.0836 0.05512,-1.02526 0.110243,-2.05052 0.165364,-3.07578 z"
+       id="path927"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscccc" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 74.015046,179.00533 c -0.3698,5.3513 -0.7396,10.70261 -1.1094,16.05391 5.64679,2.60869 11.29357,5.21739 16.94036,7.82608 0.15918,-3.6955 0.31835,-7.391 0.47753,-11.0865 -1.11745,-3.10672 -2.2349,-6.21344 -3.35235,-9.32016 -4.31871,-1.15778 -8.63743,-2.31555 -12.95614,-3.47333 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       inkscape:label="#path4486"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:none;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 43.711955,183.42729 c -1.214,2.83542 -2.428,5.67083 -3.642,8.50625 0.367,3.65063 0.734,7.30126 1.101,10.95189 5.40711,-2.5672 10.81422,-5.13439 16.22133,-7.70159 -0.30702,-5.36162 -0.61405,-10.72324 -0.92107,-16.08486 -4.25309,1.44277 -8.50617,2.88554 -12.75926,4.32831 z"
+       id="button0"
+       inkscape:connector-curvature="0"
+       inkscape:label="#path3664"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="display:inline;opacity:1;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:0.56091666;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 34.320498,219.97553 c 0,0 2.9931,22.36809 2.9931,33.61862 0,1.85752 -0.0661,2.789 -0.0661,4.72943 0,2.7249 0.0269,3.50461 -0.64492,5.02708 -0.26064,0.59067 -1.07269,1.52327 -2.13321,1.88516 -1.19629,0.23151 -2.146392,-0.87485 -2.844272,-2.0836 -0.0551,-1.02526 -0.11024,-2.05052 -0.16536,-3.07578 z"
+       id="path927-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cssscccc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.19679,-40.717196)"
+       style="display:inline"
+       id="button0-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 81.663449,250.50576 157.960771,0.0352"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="79.083046"
+         y="247.00577" />
+      <rect
+         y="250.00575"
+         x="238.62422"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,40.502648,-19.549003)"
+       style="display:inline"
+       id="button1-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 336.91912,170.14213 -183.57514,0.36405"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="149"
+         y="167" />
+      <rect
+         y="169.75269"
+         x="336.91913"
+         height="1"
+         width="1"
+         id="button1-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(-0.2847136,0,0,0.26458333,87.493539,-7.2646706)"
+       style="display:inline;opacity:1"
+       id="button2-path"
+       inkscape:label="#g151">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path964-6"
+         d="m 79.210952,122.6933 62.691188,68.76371 165.40155,1e-5"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#rect875"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button2-leader"
+         width="1"
+         height="1"
+         x="306.40533"
+         y="190.93378" />
+      <rect
+         y="117.94263"
+         x="76.303352"
+         height="6.999999"
+         width="6.999999"
+         id="rect974-5"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,13.746167,-3.2430852)"
+       style="display:inline"
+       id="button3-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 438.04598,178.25732 H 203.75439 l -10.41041,-7.75114"
+         id="path51-1-9-6-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-2-3-2-2"
+         width="6.999999"
+         height="6.999999"
+         x="189"
+         y="167" />
+      <rect
+         y="177.79317"
+         x="438.04599"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     transform="translate(0,-2.6458338)"
+     style="display:none" />
+</svg>

--- a/data/svgs/steelseries-rival.svg
+++ b/data/svgs/steelseries-rival.svg
@@ -1,0 +1,443 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="490"
+   height="490"
+   viewBox="0 0 129.64583 129.64583"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="steelseries-rival.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="78.639558"
+     inkscape:cy="261.77819"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     showguides="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     showborder="true"
+     inkscape:guide-bbox="true"
+     units="px"
+     inkscape:snap-global="false"
+     inkscape:measure-start="241.5,424.5"
+     inkscape:measure-end="193,423">
+    <inkscape:grid
+       type="xygrid"
+       id="grid78" />
+    <sodipodi:guide
+       position="58.722772,112.40709"
+       orientation="0,1"
+       id="guide79"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="39.611923,100.54373"
+       orientation="0,1"
+       id="guide81"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="51.756014,88.614617"
+       orientation="0,1"
+       id="guide83"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="57.778386,76.729167"
+       orientation="0,1"
+       id="guide85"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="45.047078,64.795712"
+       orientation="0,1"
+       inkscape:locked="false"
+       id="guide87" />
+    <sodipodi:guide
+       position="57.646696,52.899321"
+       orientation="0,1"
+       id="guide89"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="64.031094,118.70775"
+       orientation="1,0"
+       id="guide996"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="76.729165,115.65599"
+       orientation="1,0"
+       id="guide4799"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline;opacity:1"
+     transform="translate(0,-167.35416)">
+    <path
+       style="opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 40.966398,178.40384 c 10.128269,-6.06958 13.843202,-5.15315 22.125375,-5.36057 0.815799,-0.022 1.397736,-0.0441 2.213535,-0.0661 7.544908,0.008 16.804302,3.17239 21.130756,6.44865 1.422136,0.452 2.190922,3.57156 3.150036,8.42225 0.859896,4.92786 2.377355,23.3214 3.378944,30.28552 4.289427,17.445 6.148079,21.13233 5.839397,36.23562 0.08155,9.96062 -3.435205,16.37945 -6.88054,22.71347 -4.707536,5.80429 -6.249571,6.86442 -15.801399,10.09956 -7.805208,1.74184 -11.135198,2.13807 -18.278948,0.8372 -6.32795,-1.67569 -10.758421,-3.68269 -14.782617,-8.15118 -2.665941,-4.21879 -4.043454,-12.34041 -3.573015,-23.27668 0.83923,-20.53867 -3.23693,-47.28029 -3.417692,-53.41373 l 0.529166,-14.69573 c 0.23151,-6.33201 2.28507,-9.07943 4.367002,-10.07828 z"
+       id="path882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccc" />
+    <path
+       sodipodi:type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:0.39215686;stroke:#babdb6;stroke-width:3.62082291;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="led0"
+       sodipodi:cx="64.507607"
+       sodipodi:cy="278.93338"
+       sodipodi:rx="6.5174346"
+       sodipodi:ry="6.5174408"
+       d="m 69.116129,274.32485 a 6.5174346,6.5174408 0 0 1 0,9.21706 6.5174346,6.5174408 0 0 1 -9.217044,0 6.5174346,6.5174408 0 0 1 -10e-7,-9.21706"
+       sodipodi:start="5.4977871"
+       sodipodi:end="3.9269907"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       inkscape:label="#led1" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#babdb6;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 63.998032,175.33704 c -0.0617,17.18181 0,37.8177 0,37.8177 v 0"
+       id="path4530-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       style="display:inline;opacity:1;fill:#eeeeec;fill-opacity:1;stroke:#bfc2bb;stroke-width:0.65934163;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="button2"
+       width="8.6572962"
+       height="16.992365"
+       x="59.667027"
+       y="183.8551"
+       ry="1.5045637"
+       inkscape:label="#rect4615"
+       rx="2.8998742" />
+    <rect
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:0.50999999;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="button5"
+       width="4.0773749"
+       height="11.664907"
+       x="61.934288"
+       y="213.306"
+       ry="0.74915975"
+       inkscape:label="#rect4615"
+       rx="0.63142258" />
+    <path
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.65934163;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 91.112176,226.98205 c -0.763945,13.64188 -1.430609,13.74737 0,20.39268 0.486529,2.25997 1.696179,5.2841 2.85379,6.32088 1.157611,1.03679 1.081149,0.34438 4.589061,0.89006 0.940243,-6.53749 -0.570931,-13.96226 -1.479399,-18.97414 -1.652616,-7.76419 -2.041209,-9.76648 -4.816357,-19.91603 -0.935218,-0.0567 -1.141827,10.22026 -1.147095,11.28655 z"
+       id="path959"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cascccc" />
+    <path
+       style="opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38.306404,179.27446 c 6.240372,-5.59743 15.089504,-6.58952 25.788485,-6.52355 0.06236,2.93106 -0.208006,8.1177 -0.145616,11.04875 -0.966626,0.0156 -1.617539,-0.0389 -2.677709,0.15206 -0.576857,0.12082 -1.668207,0.59244 -1.683798,1.44993 0.03118,4.73958 0.06237,9.47916 0.09355,14.21874 0.428974,0.80223 0.791803,1.0753 1.683798,1.21608 h 2.666014 c 0.09354,3.89768 -0.04677,7.79536 0.04677,11.69304 -1.777343,0.0624 -3.554686,0.12473 -5.332029,0.18709 -4.677216,3.30523 -9.354432,6.6104 -14.031648,9.91563 -1.948383,1.15278 -2.949891,1.59818 -7.302533,1.7394 -0.830377,-6.12609 -3.925564,-39.29473 0.894716,-45.09717 z"
+       id="button0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccc"
+       inkscape:label="#path971" />
+    <path
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 87.229344,179.65609 c -8.975635,-7.54404 -14.108253,-6.88035 -22.922173,-6.91425 -0.06236,2.93106 0.0077,8.08746 -0.05466,11.01851 0.966626,0.0156 1.617539,-0.0389 2.677709,0.15206 0.576857,0.12082 1.668207,0.59244 1.683798,1.44993 -0.03118,4.73958 -0.06237,9.47916 -0.09355,14.21874 -0.428974,0.80223 -0.791803,1.0753 -1.683798,1.21608 h -2.80633 c -0.09354,3.89768 0.187088,7.79536 0.09354,11.69304 1.777343,0.0624 3.554686,0.12473 5.332029,0.18709 4.677216,3.30523 9.050413,6.64971 13.72763,9.95494 2.182243,-0.0165 4.486808,-0.13974 7.992488,-0.15492 2.289604,-8.17688 -1.912326,-39.03947 -3.946687,-42.82126 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccc"
+       inkscape:label="#path971-5" />
+    <path
+       style="opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 39.533701,248.31208 c 0.08789,-9.75637 -0.210156,-12.40005 -1.249267,-23.97153 -0.755908,0.011 0.02246,0.0448 -1.253567,0.0612 l 1.730229,23.94557 c 0.618261,-0.0306 -0.0064,-0.0352 0.772605,-0.0352 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       inkscape:label="#path998" />
+    <path
+       style="opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 38.039569,223.41713 -1.173721,-0.46275 -1.223702,-11.3646 0.83829,-1.79053 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#path1000" />
+    <g
+       id="g27"
+       inkscape:label="#g84"
+       style="opacity:1">
+      <path
+         inkscape:label="#path42"
+         inkscape:connector-curvature="0"
+         id="led1"
+         d="m 60.202463,185.20746 c 0,14.31228 0,14.31228 0,14.31228"
+         style="fill:#c8c8c8;fill-opacity:1;stroke:#babdb6;stroke-width:0.23228861px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:label="#path42"
+         inkscape:connector-curvature="0"
+         id="led0-3"
+         d="m 67.749483,185.21452 c 0,14.31228 0,14.31228 0,14.31228"
+         style="display:inline;opacity:1;fill:#c8c8c8;fill-opacity:1;stroke:#babdb6;stroke-width:0.23228861px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <path
+       style="fill:none;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.50999999;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1;stroke-miterlimit:4;stroke-dasharray:none"
+       d="m 63.937548,224.94747 v 9.40121"
+       id="path951"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.19679,-46.28282)"
+       style="display:inline"
+       id="button0-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 69.018882,250.50576 170.100828,0.008"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="65.211685"
+         y="247.25577" />
+      <rect
+         y="250.01747"
+         x="238.66302"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,40.502648,-25.152234)"
+       style="display:inline"
+       id="button1-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 336.41912,170.11088 -197.26264,0.0828"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="137"
+         y="166.75" />
+      <rect
+         y="169.61206"
+         x="335.92694"
+         height="1"
+         width="1"
+         id="button1-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,39.927878,-13.516602)"
+       style="display:inline"
+       id="button2-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 338.62224,171.07963 91.069203,171.06803"
+         id="path51-2"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-3"
+         width="6.999999"
+         height="6.999999"
+         x="87.596474"
+         y="167.57452" />
+      <rect
+         y="170.56519"
+         x="338.10663"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,39.855422,10.357346)"
+       style="display:inline"
+       id="button5-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 338.91912,170.14213 91.343981,170.50618"
+         id="path51-2-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-3-4"
+         width="6.999999"
+         height="6.999999"
+         x="88"
+         y="167.375" />
+      <rect
+         y="169.65894"
+         x="338.32538"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.354375,-10.600792)"
+       style="display:inline"
+       id="button4-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 113.69984,250.59415 125.92438,-0.0532"
+         id="path966-1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-3"
+         width="6.999999"
+         height="6.999999"
+         x="110.07652"
+         y="247.06827" />
+      <rect
+         y="250.06044"
+         x="239.16049"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.260832,1.1857932)"
+       style="display:inline"
+       id="button3-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 109.05947,250.54995 130.56475,-0.009"
+         id="path966-2"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-8"
+         width="6.999999"
+         height="6.999999"
+         x="105.5442"
+         y="247.06068" />
+      <rect
+         y="250.00575"
+         x="238.62422"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,69.912779,-34.520744)"
+       style="display:inline"
+       id="led1-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 33.260958,250.40632 204.900782,0.0964"
+         id="path966-0"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-2"
+         width="6.999999"
+         height="6.999999"
+         x="29.527279"
+         y="246.99062" />
+      <rect
+         y="249.97328"
+         x="237.64519"
+         height="1"
+         width="1"
+         id="led1-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,69.953208,49.201431)"
+       style="display:inline"
+       id="led0-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 19.28901,250.49471 219.01243,0.008"
+         id="path966-0-2"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-2-1"
+         width="6.999999"
+         height="6.999999"
+         x="16.834169"
+         y="246.63705" />
+      <rect
+         y="249.97328"
+         x="237.7849"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/steelseries-rival310.svg
+++ b/data/svgs/steelseries-rival310.svg
@@ -1,0 +1,443 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="490"
+   height="490"
+   viewBox="0 0 129.64583 129.64583"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="steelseries-rival310.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="158.34512"
+     inkscape:cy="283.9471"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     showguides="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1163"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showborder="true"
+     inkscape:guide-bbox="true"
+     units="px"
+     inkscape:snap-global="false"
+     inkscape:measure-start="241.5,424.5"
+     inkscape:measure-end="193,423">
+    <inkscape:grid
+       type="xygrid"
+       id="grid78" />
+    <sodipodi:guide
+       position="58.722772,112.40709"
+       orientation="0,1"
+       id="guide79"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="39.611923,100.54373"
+       orientation="0,1"
+       id="guide81"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="51.756014,88.614617"
+       orientation="0,1"
+       id="guide83"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="57.778386,76.729167"
+       orientation="0,1"
+       id="guide85"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="45.047078,64.795712"
+       orientation="0,1"
+       inkscape:locked="false"
+       id="guide87" />
+    <sodipodi:guide
+       position="57.646696,52.899321"
+       orientation="0,1"
+       id="guide89"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="64.031094,118.70775"
+       orientation="1,0"
+       id="guide996"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="76.729165,115.65599"
+       orientation="1,0"
+       id="guide4799"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline;opacity:1"
+     transform="translate(0,-167.35416)">
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;opacity:1"
+       d="m 39.422916,178.73125 c 8.753298,-5.1263 8.742273,-5.15937 19.909893,-6.35 0.86322,1.81872 1.399035,2.16412 3.571875,2.57968 0.815799,-0.022 1.631597,-0.0441 2.447396,-0.0661 1.808025,-0.44162 2.142728,-0.67277 3.108854,-2.4474 11.230355,1.36029 11.188618,1.38757 18.25625,6.74688 2.745052,3.1309 3.671094,5.00504 4.365625,8.59896 0.264583,5.1263 1.254823,10.18645 1.320969,15.27968 4.850693,20.06424 6.726771,34.70452 8.270172,54.63646 -0.57326,10.05417 -1.411108,14.15521 -6.879162,21.43125 -5.55625,5.60034 -10.31875,7.8934 -17.859375,10.84791 -7.805208,1.74184 -11.509375,1.76389 -18.653125,0.46302 -6.32795,-1.67569 -10.384244,-5.1794 -14.221351,-10.58333 -4.882794,-8.38114 -5.236545,-14.94896 -7.408333,-22.62187 -0.782726,-9.55807 -1.367014,-19.31459 -2.050521,-28.97188 l 2.38125,-0.39687 c -0.0441,-0.50712 -0.08819,-1.01423 -0.132292,-1.52135 l -2.38125,-0.99219 v -17.19792 c 0.617361,-1.6316 1.234723,-3.26319 1.852084,-4.89479 l 0.926041,-18.1901 c 0.496094,-3.10887 1.256771,-4.69638 3.175,-6.35004 z"
+       id="path882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccccccccccccccccc" />
+    <path
+       sodipodi:type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:0.39215686;stroke:#babdb6;stroke-width:3.62082291;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="led0"
+       sodipodi:cx="64.507607"
+       sodipodi:cy="278.93338"
+       sodipodi:rx="6.5174346"
+       sodipodi:ry="6.5174408"
+       d="m 69.116129,274.32485 a 6.5174346,6.5174408 0 0 1 0,9.21706 6.5174346,6.5174408 0 0 1 -9.217044,0 6.5174346,6.5174408 0 0 1 -10e-7,-9.21706"
+       sodipodi:start="5.4977871"
+       sodipodi:end="3.9269907"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       inkscape:label="#led1" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#babdb6;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 63.998032,175.33704 c -0.0617,17.18181 0,37.8177 0,37.8177 v 0"
+       id="path4530-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       style="display:inline;opacity:1;fill:#eeeeec;fill-opacity:1;stroke:#bfc2bb;stroke-width:0.65934163;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="button2"
+       width="8.6572962"
+       height="16.992365"
+       x="59.667027"
+       y="183.8551"
+       ry="1.5045637"
+       inkscape:label="#rect4615"
+       rx="2.8998742" />
+    <rect
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:0.51011665;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="button5"
+       width="4.0773749"
+       height="11.664907"
+       x="61.934288"
+       y="213.306"
+       ry="0.74915975"
+       inkscape:label="#rect4615"
+       rx="0.63142258" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.65934163;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;opacity:1"
+       d="m 92.234711,203.24519 c 0.280629,9.51034 -0.467724,16.09741 -0.467724,24.43845 -0.763945,13.64188 -1.153714,9.79098 -1.590254,28.48425 -0.04677,3.7028 1.344699,5.74518 2.50231,6.78196 1.157611,1.03679 4.41997,3.85091 6.618261,5.14494 0.941986,-4.54444 1.338226,-4.86758 1.335156,-10.49869 -0.4989,-10.35224 -1.350744,-19.81747 -3.369743,-31.52609 -1.652616,-7.76419 -1.878682,-12.53495 -5.028008,-22.82482 z"
+       id="path959"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccsccccc" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.65934163;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;opacity:1"
+       d="m 37.603906,265.61379 c 1.378038,-1.69774 1.896181,-2.56866 2.447396,-4.49791 0.275607,-1.59853 0.319704,-2.27101 0.132291,-3.70417 -0.176389,-0.97014 -0.352777,-1.94028 -0.529166,-2.91042 -0.352778,0.022 -0.705556,0.0441 -1.058334,0.0661 -1.113455,-0.31971 -1.631597,-0.93707 -2.248958,-1.65365 -0.429948,-0.89297 -0.859896,-1.78593 -1.289844,-2.6789 0.176389,2.30408 0.352778,4.60816 0.529167,6.91224 0.672483,2.82224 1.344965,5.64447 2.017448,8.46671 z"
+       id="path961"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011665;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;opacity:1"
+       d="m 39.662795,224.50314 c -1.418755,-15.53616 -1.294028,-30.04332 -0.748352,-45.27546 7.464057,-5.23848 10.578303,-5.75298 20.392662,-7.01583 0.604141,2.15932 2.552981,2.88039 4.583673,2.89988 0.06236,2.93106 -0.0039,5.75688 0.05847,8.68793 -0.966626,0.0156 -1.617539,-0.0389 -2.677709,0.15206 -0.576857,0.12082 -1.668207,0.59244 -1.683798,1.44993 0.03118,4.73958 0.06237,9.47916 0.09355,14.21874 0.428974,0.80223 0.791803,1.0753 1.683798,1.21608 h 2.666014 c 0.09354,3.89768 -0.04677,7.79536 0.04677,11.69304 -1.777343,0.0624 -3.554686,0.12473 -5.332029,0.18709 -4.677216,3.30523 -9.354432,6.61047 -14.031648,9.9157 -1.948383,1.15278 -3.036871,1.77639 -5.051401,1.87084 z"
+       id="button0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccc"
+       inkscape:label="#path971" />
+    <path
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 88.538966,224.46383 c 1.418756,-15.53616 -0.763946,-29.5756 -1.309622,-44.80774 -6.341526,-5.61266 -8.520329,-6.2207 -18.334688,-7.48355 -0.604141,2.15932 -2.833614,2.83362 -4.864306,2.85311 -0.06236,2.93106 0.284533,5.80365 0.222163,8.7347 0.966626,0.0156 1.617539,-0.0389 2.677709,0.15206 0.576857,0.12082 1.668207,0.59244 1.683798,1.44993 -0.03118,4.73958 -0.06237,9.47916 -0.09355,14.21874 -0.428974,0.80223 -0.791803,1.0753 -1.683798,1.21608 h -2.80633 c -0.09354,3.89768 0.187088,7.79536 0.09354,11.69304 1.777343,0.0624 3.554686,0.12473 5.332029,0.18709 4.677216,3.30523 9.354432,6.61047 14.031649,9.9157 1.948382,1.15278 3.036871,1.77639 5.0514,1.87084 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccc"
+       inkscape:label="#path971-5" />
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;opacity:1"
+       d="m 39.721262,254.48409 c -2.127995,-12.76601 -2.492187,-15.11204 -3.531298,-26.68352 -0.880877,0.16371 -1.761753,0.32741 -2.64263,0.49111 0.510597,7.26528 1.021194,14.53055 1.531791,21.79583 0.415673,1.21059 0.673654,1.8504 1.39147,2.98173 0.557369,0.65481 1.067966,1.08745 1.882582,1.5084 0.738934,0.12313 0.851361,0.031 1.368085,-0.0935 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc"
+       inkscape:label="#path998" />
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;opacity:1"
+       d="m 36.061341,226.30387 -2.595857,-0.95884 v -17.51617 l 2.128134,-4.89938 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#path1000" />
+    <g
+       id="g27"
+       inkscape:label="#g84"
+       style="opacity:1">
+      <path
+         inkscape:label="#path42"
+         inkscape:connector-curvature="0"
+         id="led1"
+         d="m 60.202463,185.20746 c 0,14.31228 0,14.31228 0,14.31228"
+         style="fill:#c8c8c8;fill-opacity:1;stroke:#babdb6;stroke-width:0.23228861px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:label="#path42"
+         inkscape:connector-curvature="0"
+         id="led0-3"
+         d="m 67.749483,185.21452 c 0,14.31228 0,14.31228 0,14.31228"
+         style="display:inline;opacity:1;fill:#c8c8c8;fill-opacity:1;stroke:#babdb6;stroke-width:0.23228861px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.19679,-46.28282)"
+       style="display:inline"
+       id="button0-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 69.018882,250.50576 170.100828,0.008"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="65.211685"
+         y="247.25577" />
+      <rect
+         y="250.01747"
+         x="238.66302"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,40.502648,-25.152234)"
+       style="display:inline"
+       id="button1-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 336.41912,170.11088 -197.26264,0.0828"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="137"
+         y="166.75" />
+      <rect
+         y="169.61206"
+         x="335.92694"
+         height="1"
+         width="1"
+         id="button1-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,39.927878,-13.516602)"
+       style="display:inline"
+       id="button2-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 338.62224,171.07963 91.069203,171.06803"
+         id="path51-2"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-3"
+         width="6.999999"
+         height="6.999999"
+         x="87.596474"
+         y="167.57452" />
+      <rect
+         y="170.56519"
+         x="338.10663"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,39.855422,10.357346)"
+       style="display:inline"
+       id="button5-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 338.91912,170.14213 91.343981,170.50618"
+         id="path51-2-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-3-4"
+         width="6.999999"
+         height="6.999999"
+         x="88"
+         y="167.375" />
+      <rect
+         y="169.65894"
+         x="338.32538"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.354375,-10.600792)"
+       style="display:inline"
+       id="button4-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 121.40352,250.50576 118.2207,0.0352"
+         id="path966-1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-3"
+         width="6.999999"
+         height="6.999999"
+         x="118.01969"
+         y="247.06827" />
+      <rect
+         y="250.06044"
+         x="239.16049"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.260832,1.1857932)"
+       style="display:inline"
+       id="button3-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 119.59715,250.50576 120.02707,0.0352"
+         id="path966-2"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-8"
+         width="6.999999"
+         height="6.999999"
+         x="116.24155"
+         y="247.19327" />
+      <rect
+         y="250.00575"
+         x="238.62422"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,69.912779,-34.520744)"
+       style="display:inline"
+       id="led1-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 33.260958,250.40632 204.900782,0.0964"
+         id="path966-0"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-2"
+         width="6.999999"
+         height="6.999999"
+         x="29.527279"
+         y="246.99062" />
+      <rect
+         y="249.97328"
+         x="237.64519"
+         height="1"
+         width="1"
+         id="led1-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,69.953208,49.201431)"
+       style="display:inline"
+       id="led0-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 19.28901,250.49471 219.01243,0.008"
+         id="path966-0-2"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-2-1"
+         width="6.999999"
+         height="6.999999"
+         x="16.834169"
+         y="246.63705" />
+      <rect
+         y="249.97328"
+         x="237.7849"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/steelseries-rival600.svg
+++ b/data/svgs/steelseries-rival600.svg
@@ -1,0 +1,637 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="499"
+   height="499"
+   viewBox="0 0 132.02708 132.02709"
+   version="1.1"
+   id="svg8"
+   inkscape:version="0.92.2 2405546, 2018-03-11"
+   sodipodi:docname="steelseries-rival600.svg">
+  <defs
+     id="defs2">
+    <clipPath
+       clipPathUnits="userSpaceOnUse"
+       id="clipPath4634">
+      <rect
+         style="fill:#3d1400;fill-opacity:0.54140128;stroke:#000000;stroke-width:0.2117648;stroke-opacity:1"
+         id="rect4636"
+         width="107.04193"
+         height="199.41115"
+         x="30.877195"
+         y="155.32713" />
+    </clipPath>
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="4.0000002"
+     inkscape:cx="257.92153"
+     inkscape:cy="362.68056"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     showgrid="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1012"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     units="px"
+     showguides="false"
+     inkscape:guide-bbox="true"
+     inkscape:snap-global="true"
+     inkscape:measure-start="305.625,430.5"
+     inkscape:measure-end="269.5,430.75">
+    <sodipodi:guide
+       position="66.14583,85.422621"
+       orientation="1,0"
+       id="guide4638"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="115.99497,127"
+       orientation="0,1"
+       id="guide4640"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="9.354433,5.2916666"
+       orientation="0,1"
+       id="guide4642"
+       inkscape:locked="false"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline"
+     transform="translate(0,-0.26458333)">
+    <path
+       sodipodi:nodetypes="csccccccccsscccccccssssssscccccccccccscsssc"
+       inkscape:connector-curvature="0"
+       id="path4673"
+       d="m 40.02385,14.984554 c 1.580795,-2.51549 5.975285,-3.539984 9.385335,-4.965329 3.128814,-1.3077924 9.164225,-4.4175966 9.164225,-4.4175966 l 3.236676,-0.3099634 -0.0053,8.952208 1.214482,-5.705833 6.015962,-0.014436 1.88187,5.552463 -0.06133,-8.784402 2.895343,0.3674956 c 0,0 5.054486,2.5992473 7.544173,3.9686799 5.3036,2.9172035 11.440444,3.4069705 11.658567,6.9089765 l 2.434325,39.08341 2.530042,28.965015 c 0,0 0.286756,7.495044 -0.371079,10.115766 l -3.292458,-3.010664 -0.559771,0.835476 1.951257,2.541965 c 0.442734,0.62875 1.161707,2.907068 1.161707,2.907068 0,0 -0.1,2.252347 -0.334606,3.189677 -1.586764,6.33968 -6.10449,11.6792 -9.236308,15.53526 -2.544851,3.13335 -5.161521,5.64996 -8.518934,7.38326 -3.502718,1.80832 -7.474043,2.75126 -11.412536,2.91659 -4.30071,0.18053 -6.918836,0.23282 -12.770724,-1.91491 -4.175515,-1.53248 -7.367165,-5.08869 -9.121485,-7.10927 -9.051815,-10.4256 -9.37199,-18.857963 -8.769367,-19.894766 L 39.845444,91.905117 39.425142,90.803985 37.552215,94.320171 37.160224,93.903502 37.128144,92.93534 38.295133,81.010098 37.99214,64.407639 38.450135,63.977055 37.8061,63.559233 36.932233,47.808124 36.554461,47.459545 c 0,0 0.05032,-2.921717 0.06444,-3.330011 0.09797,-2.831675 0.826526,-3.731517 0.826526,-3.731517 0,0 0.08006,-10.762552 0.583863,-15.991305 0.174175,-1.807686 0.853434,-1.118453 0.93179,-1.886883 0.337789,-3.312656 -0.515822,-5.023298 1.062766,-7.535275 z"
+       style="display:inline;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:1.32291663;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:none;stroke-width:1.57558382;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 232.34375,93.232422 v 60.628908 c 0.50061,1.14157 1.4678,2.62577 3.32617,4.04492 h 0.60742 V 93.232422 Z m 31.91406,0 v 64.673828 h 1.83985 c 0.83119,-0.78541 1.40627,-1.64516 1.81054,-2.55664 V 93.232422 Z"
+       transform="matrix(0.26458334,0,0,0.26458334,0,0.26458333)"
+       id="led0"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:1.99999988;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       d="m 243.77734,85.634766 c -4.155,0 -7.5,3.345 -7.5,7.5 v 65.191404 c 2.23306,1.53273 5.55795,2.93721 10.59375,3.66211 l -0.0527,4.12695 h 6.42578 v -4.08593 c 5.24654,-0.45952 8.69408,-1.43412 10.98047,-2.7461 0.0194,-0.22077 0.0332,-0.44199 0.0332,-0.66797 V 93.134766 c 0,-4.155 -3.345,-7.5 -7.5,-7.5 z"
+       transform="matrix(0.26458334,0,0,0.26458334,0,0.26458333)"
+       id="button2"
+       inkscape:connector-curvature="0"
+       inkscape:label="#button2" />
+    <rect
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:0.52916664;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       id="button6"
+       width="5.0028081"
+       height="14.072443"
+       x="63.525414"
+       y="49.707458"
+       ry="0.89731663"
+       inkscape:label="#button6" />
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       d="m 231.80196,19.999994 -10.42305,1.171881 c 0,0 -22.80933,11.752475 -34.63477,16.695313 -12.88838,5.38713 -29.498,9.260214 -35.47266,18.767578 -5.45964,8.687822 -3.23027,14.853779 -3.78906,25.429687 l 0.89286,110.357427 c 0.75974,6.5985 8.53258,13.62191 67.64583,28.30897 l 20.49636,0.59268 0.20962,-34.60642 c 1.20454,-5.7407 4.81879,-6.03597 9.92297,-6.35918 l 0.22147,-17.37007 c -14.80392,-2.13101 -15.06957,-10.10154 -15.06957,-10.10154 z"
+       transform="scale(0.26458333)"
+       id="button0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccssccccccccc"
+       inkscape:label="#button0" />
+    <path
+       style="fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;paint-order:normal"
+       d="m 268.57227,20.097656 0.34526,131.616644 c -0.47516,5.1884 -1.66448,10.08839 -15.67427,11.31543 l 6.2e-4,17.28677 c 4.75243,0.31401 8.60528,1.4133 9.36291,7.0537 l 0.15706,34.28927 23.61411,-0.28538 c 59.2439,-12.2777 65.79173,-21.56131 66.69622,-30.52428 V 90.634766 l -1.75195,-28.132813 c -0.82441,-13.235928 -24.01935,-15.08763 -44.06446,-26.113281 -9.40984,-5.175808 -28.51367,-15 -28.51367,-15 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccscc"
+       inkscape:label="#button1"
+       transform="scale(0.26458333)" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 141.16016,153.26562 c -0.75439,1.32491 -2.46978,5.19815 -2.75782,13.52344 -0.0534,1.54316 -0.24414,12.58594 -0.24414,12.58594 l 1.42774,1.31641 v 0 l 2.08789,0.006 v -27.43148 z"
+       transform="scale(0.26458333)"
+       id="button5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc"
+       inkscape:label="#button5" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 139.70312,182.80273 3.17774,57.26563 h 4.10547 l -3.40926,-57.51817 z"
+       transform="scale(0.26458333)"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#button4" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 143.60352,244.08398 2.65262,62.72071 4.65625,16.10854 -0.46289,-21.07144 -2.32143,-57.75782 z"
+       transform="scale(0.26458333)"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc"
+       inkscape:label="#button3" />
+    <path
+       sodipodi:type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:0.39215686;stroke:#babdb6;stroke-width:3.62082291;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="led1"
+       sodipodi:cx="66.014069"
+       sodipodi:cy="113.27822"
+       sodipodi:rx="6.5174346"
+       sodipodi:ry="6.5174413"
+       d="m 70.622591,108.66969 a 6.5174346,6.5174413 0 0 1 0,9.21706 6.5174346,6.5174413 0 0 1 -9.217044,0 6.5174346,6.5174413 0 0 1 -10e-7,-9.21706"
+       sodipodi:start="5.4977871"
+       sodipodi:end="3.9269907"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       inkscape:label="#led1" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 53.883876,61.201732 c 0.701684,-1.04199 1.713438,-1.252361 2.700948,-1.273296 -1.062711,6.124293 -2.23957,15.448337 -2.929315,17.714841 l -2.279083,-0.01181 c 0.921085,-4.981084 1.8723,-11.917817 2.50745,-16.429735 z"
+       id="led2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#led2" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 51.098164,78.550869 2.137416,0.0032 c -2.45902,3.08502 -5.645313,5.394855 -8.68164,7.870003 l 0.01274,-1.902901 c 2.26525,-2.119478 4.965592,-3.807868 6.531484,-5.970314 z"
+       id="led4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#led4" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.38111177;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 39.904215,90.216504 c 2.946365,-4.10277 2.992207,-3.879322 3.87751,-4.907952 v 1.643592 c -1.069962,1.220999 -2.14185,2.446029 -3.652074,4.588366 -0.34675,-0.266319 -0.171896,-0.86875 -0.225436,-1.324006 z"
+       id="led6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#led6" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="led3"
+       d="m 77.958921,61.201732 c -0.701684,-1.04199 -1.713438,-1.252361 -2.700948,-1.273296 1.062711,6.124293 2.23957,15.448337 2.929315,17.714841 l 2.279083,-0.01181 c -0.921085,-4.981084 -1.8723,-11.917817 -2.50745,-16.429735 z"
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#led3" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="led5"
+       d="m 80.744633,78.550869 -2.137416,0.0032 c 2.45902,3.08502 5.645313,5.394855 8.68164,7.870003 l -0.01274,-1.902901 c -2.26525,-2.119478 -4.965592,-3.807868 -6.531484,-5.970314 z"
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.39687499;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#led5" />
+    <path
+       sodipodi:nodetypes="ccccc"
+       inkscape:connector-curvature="0"
+       id="led7"
+       d="M 93.828039,91.01326 C 90.782971,87.489788 88.89285,86.252223 88.034855,85.182947 l 0.02219,1.740055 c 1.135212,1.088123 3.299661,3.204904 5.082908,5.26536 0.341405,-0.26364 0.635364,-0.724423 0.688079,-1.175102 z"
+       style="fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.37625623;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:label="#led7" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     transform="translate(0,-0.26458333)">
+    <g
+       id="button0-path"
+       inkscape:label="#button0-path">
+      <path
+         inkscape:connector-curvature="0"
+         id="path966"
+         d="m 50.609489,18.387576 -50.47151772,0.0019"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.26270351;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="17.462502"
+         x="-51.329166"
+         height="1.8520831"
+         width="1.8520833"
+         id="rect976"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50289863;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1,1)" />
+      <rect
+         transform="scale(-1,1)"
+         y="18.25625"
+         x="-0.26458332"
+         height="0.26458332"
+         width="0.26458332"
+         id="button0-leader"
+         style="color:#000000;text-align:end;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26458335;stroke-linecap:round"
+         inkscape:label="#button0-leader" />
+    </g>
+    <g
+       inkscape:label="#button5-path"
+       id="button5-path"
+       transform="matrix(1,0,0,0.99991172,-13.551005,26.460036)">
+      <path
+         sodipodi:nodetypes="ccc"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.26290539;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 50.998437,18.983827 37.196023,5.1572762 H 13.68371"
+         id="path8646"
+         inkscape:connector-curvature="0" />
+      <rect
+         transform="scale(-1,1)"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50289863;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect8648"
+         width="1.8520833"
+         height="1.8520831"
+         x="-51.329166"
+         y="17.462502" />
+      <rect
+         inkscape:label="#button5-leader"
+         style="color:#000000;text-align:end;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26458335;stroke-linecap:round"
+         id="button5-leader"
+         width="0.26458332"
+         height="0.26458332"
+         x="-13.815588"
+         y="5.0258474"
+         transform="scale(-1,1)" />
+    </g>
+    <g
+       transform="matrix(1,0,0,0.99991171,-13.551005,26.460037)"
+       id="button4-path"
+       inkscape:label="#button4-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.27385584;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 51.951929,30.017489 40.205394,18.387452 H 13.749442"
+         id="path8646-1"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="28.52924"
+         x="-52.315731"
+         height="1.8520831"
+         width="1.8520833"
+         id="rect8648-0"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50289863;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1,1)" />
+      <rect
+         transform="scale(-1,1)"
+         y="18.256182"
+         x="-13.815588"
+         height="0.26458332"
+         width="0.26458332"
+         id="button4-leader"
+         style="color:#000000;text-align:end;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26458335;stroke-linecap:round"
+         inkscape:label="#button4-leader" />
+    </g>
+    <g
+       id="button3-path"
+       inkscape:label="#button3-path">
+      <path
+         style="fill:none;stroke:#888a85;stroke-width:0.26771936px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 0.13358648,58.076072 H 27.970024 l 10.933108,10.675053"
+         id="path8774"
+         inkscape:connector-curvature="0" />
+      <rect
+         transform="scale(-1,1)"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50287646;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect8648-0-7"
+         width="1.8520833"
+         height="1.8519195"
+         x="-39.559853"
+         y="67.568466" />
+      <rect
+         inkscape:label="#button3-leader"
+         style="color:#000000;text-align:end;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26457167;stroke-linecap:round"
+         id="button3-leader"
+         width="0.26458332"
+         height="0.26455995"
+         x="-0.26458332"
+         y="57.943771"
+         transform="scale(-1,1)" />
+    </g>
+    <g
+       id="button1-path"
+       inkscape:label="#button1-path">
+      <path
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.26376939px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 131.97389,18.386474 H 80.896353"
+         id="path8957"
+         inkscape:connector-curvature="0" />
+      <rect
+         transform="scale(-1,1)"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50289863;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-6"
+         width="1.8520833"
+         height="1.8520831"
+         x="-81.801758"
+         y="17.4625" />
+      <rect
+         inkscape:label="#button1-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26458335;stroke-linecap:round"
+         id="button1-leader"
+         width="0.26458332"
+         height="0.26458332"
+         x="-132.02708"
+         y="18.25625"
+         transform="scale(-1,1)" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="#button2-path">
+      <path
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.26416048px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 131.95474,31.62391 H 66.14583"
+         id="path8993"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="30.632051"
+         x="-67.080887"
+         height="1.8520831"
+         width="1.8520833"
+         id="rect976-6-9"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50289863;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1,1)" />
+      <rect
+         transform="scale(-1,1)"
+         y="31.485416"
+         x="-132.02708"
+         height="0.26458332"
+         width="0.26458332"
+         id="button2-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26458335;stroke-linecap:round"
+         inkscape:label="#button2-leader" />
+    </g>
+    <g
+       id="button6-path"
+       inkscape:label="#button6-path">
+      <path
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.26408577px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 131.91236,58.082243 H 66.14583"
+         id="path9075"
+         inkscape:connector-curvature="0" />
+      <rect
+         transform="scale(-1,1)"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50289863;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-6-9-2"
+         width="1.8520833"
+         height="1.8520831"
+         x="-67.0345"
+         y="57.148987" />
+      <rect
+         inkscape:label="#button6-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26458335;stroke-linecap:round"
+         id="button6-leader"
+         width="0.26458332"
+         height="0.26458332"
+         x="-132.02708"
+         y="57.943748"
+         transform="scale(-1,1)" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     transform="translate(0,-0.26458333)">
+    <g
+       id="led2-path"
+       inkscape:label="#led2-path">
+      <path
+         style="fill:none;stroke:#888a85;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 0.12402344,71.315542 H 53.647675"
+         id="path8810"
+         inkscape:connector-curvature="0" />
+      <rect
+         y="70.379326"
+         x="-54.539886"
+         height="1.8519195"
+         width="1.8520833"
+         id="rect8648-0-7-5"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50287646;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1,1)" />
+      <rect
+         transform="scale(-1,1)"
+         y="71.172935"
+         x="-0.26458332"
+         height="0.26455995"
+         width="0.26458332"
+         id="led2-leader"
+         style="color:#000000;text-align:end;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26457167;stroke-linecap:round"
+         inkscape:label="#led2-leader" />
+    </g>
+    <g
+       id="led4-path"
+       inkscape:label="#led4-path">
+      <path
+         style="fill:none;stroke:#888a85;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+         d="M 0.12862346,84.537282 H 27.648958 l 2.241759,-2.400562 h 18.612019"
+         id="path8848"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         transform="scale(-1,1)"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50287646;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect8648-0-7-5-7"
+         width="1.8520833"
+         height="1.8519195"
+         x="-49.503178"
+         y="81.204086" />
+      <rect
+         inkscape:label="#led4-leader"
+         style="color:#000000;text-align:end;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26457167;stroke-linecap:round"
+         id="led4-leader"
+         width="0.26458332"
+         height="0.26455995"
+         x="-0.26458332"
+         y="84.402107"
+         transform="scale(-1,1)" />
+    </g>
+    <g
+       id="led6-path"
+       inkscape:label="#led6-path">
+      <path
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.26458332px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="m 0.12277694,97.767959 25.38364906,4e-5 9.304738,-9.437079 7.003154,-4e-5"
+         id="path8884"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         y="87.419861"
+         x="-42.752739"
+         height="1.8519195"
+         width="1.8520833"
+         id="rect8648-0-7-5-7-7"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50287646;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1,1)" />
+      <rect
+         transform="scale(-1,1)"
+         y="97.631271"
+         x="-0.26458332"
+         height="0.26455995"
+         width="0.26458332"
+         id="led6-leader"
+         style="color:#000000;text-align:end;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26457167;stroke-linecap:round"
+         inkscape:label="#led6-leader" />
+    </g>
+    <g
+       id="led1-path"
+       inkscape:label="#led1-path"
+       transform="matrix(-1,0,0,1,132.29166,0)">
+      <path
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.26420629px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 0.31955082,110.99571 H 27.672239 l 2.158822,2.42958 H 66.14583"
+         id="path8920"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         transform="scale(-1,1)"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50287646;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect8648-0-7-5-7-7-6"
+         width="1.8520833"
+         height="1.8519195"
+         x="-67.071869"
+         y="112.48402" />
+      <rect
+         inkscape:label="#led1-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26457167;stroke-linecap:round"
+         id="led1-leader"
+         width="0.26458332"
+         height="0.26455995"
+         x="-0.52915835"
+         y="110.86044"
+         transform="scale(-1,1)" />
+    </g>
+    <g
+       id="led0-path"
+       inkscape:label="#led0-path">
+      <path
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.26413852px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         d="M 131.9564,44.847906 H 106.24218 L 100.20967,38.95381 H 70.511457"
+         id="path9031"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <rect
+         y="38.02457"
+         x="-71.448746"
+         height="1.8519195"
+         width="1.8520833"
+         id="rect8648-0-7-5-7-7-6-4"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50287646;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1,1)" />
+      <rect
+         transform="scale(-1,1)"
+         y="44.714607"
+         x="-132.02708"
+         height="0.26455995"
+         width="0.26458332"
+         id="led0-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26457167;stroke-linecap:round"
+         inkscape:label="#led0-leader" />
+    </g>
+    <g
+       inkscape:label="#led3-path"
+       id="led3-path"
+       transform="matrix(-1,0,0,1,131.90105,0)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path9077"
+         d="M -0.02273763,71.315542 H 53.647675"
+         style="fill:none;stroke:#888a85;stroke-width:0.26494581px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         transform="scale(-1,1)"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50287646;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect9079"
+         width="1.8520833"
+         height="1.8519195"
+         x="-54.539886"
+         y="70.379326" />
+      <rect
+         inkscape:label="#led3-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26457167;stroke-linecap:round"
+         id="led3-leader"
+         width="0.26458332"
+         height="0.26455995"
+         x="-0.13854833"
+         y="71.172935"
+         transform="scale(-1,1)" />
+    </g>
+    <g
+       inkscape:label="#led5-path"
+       id="led5-path"
+       transform="matrix(-1,0,0,1,131.90105,0)">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path9085"
+         d="M -0.08572876,84.537282 H 27.556552 l 2.251693,-2.400562 h 18.694491"
+         style="fill:none;stroke:#888a85;stroke-width:0.26516888px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <rect
+         y="81.204086"
+         x="-49.503178"
+         height="1.8519195"
+         width="1.8520833"
+         id="rect9087"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50287646;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1,1)" />
+      <rect
+         transform="scale(-1,1)"
+         y="84.402107"
+         x="-0.13854833"
+         height="0.26455995"
+         width="0.26458332"
+         id="led5-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26457167;stroke-linecap:round"
+         inkscape:label="#led5-leader" />
+    </g>
+    <g
+       inkscape:label="#led7-path"
+       id="led7-path"
+       transform="matrix(-1,0,0,1,131.90105,0)">
+      <path
+         sodipodi:nodetypes="cccc"
+         inkscape:connector-curvature="0"
+         id="path9093"
+         d="m 0.02270835,97.767959 25.44457565,4e-5 9.327071,-9.437079 7.019963,-4e-5"
+         style="opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.26490065px;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+      <rect
+         transform="scale(-1,1)"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0.50287646;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect9095"
+         width="1.8520833"
+         height="1.8519195"
+         x="-42.752739"
+         y="87.419861" />
+      <rect
+         inkscape:label="#led7-leader"
+         style="color:#000000;text-align:start;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:0.26457167;stroke-linecap:round"
+         id="led7-leader"
+         width="0.26458332"
+         height="0.26455995"
+         x="-0.13854833"
+         y="97.631271"
+         transform="scale(-1,1)" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/steelseries-sensei310.svg
+++ b/data/svgs/steelseries-sensei310.svg
@@ -1,0 +1,513 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="490"
+   height="490"
+   viewBox="0 0 129.64583 129.64583"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="steelseries-sensei310.svg"
+   inkscape:version="0.92.2 (5c3e80d, 2017-08-06)">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1"
+     inkscape:cx="251.39478"
+     inkscape:cy="163.59644"
+     inkscape:document-units="px"
+     inkscape:current-layer="Buttons"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     showguides="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1163"
+     inkscape:window-x="1920"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showborder="true"
+     inkscape:guide-bbox="true"
+     units="px"
+     inkscape:snap-global="false"
+     inkscape:measure-start="-166.877,108.894"
+     inkscape:measure-end="135.057,119.501">
+    <inkscape:grid
+       type="xygrid"
+       id="grid78" />
+    <sodipodi:guide
+       position="58.722772,112.40709"
+       orientation="0,1"
+       id="guide79"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="39.611923,100.54373"
+       orientation="0,1"
+       id="guide81"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="51.756014,88.614617"
+       orientation="0,1"
+       id="guide83"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="57.778386,76.729167"
+       orientation="0,1"
+       id="guide85"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="45.047078,64.795712"
+       orientation="0,1"
+       inkscape:locked="false"
+       id="guide87" />
+    <sodipodi:guide
+       position="57.646696,52.899321"
+       orientation="0,1"
+       id="guide89"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="64.029165,118.70775"
+       orientation="1,0"
+       id="guide996"
+       inkscape:locked="true"
+       inkscape:label=""
+       inkscape:color="rgb(0,0,255)" />
+    <sodipodi:guide
+       position="76.729165,115.65599"
+       orientation="1,0"
+       id="guide4799"
+       inkscape:locked="false" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline;opacity:1"
+     transform="translate(0,-167.35416)">
+    <path
+       style="opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 39.422916,178.73125 c 8.753298,-5.1263 8.742273,-5.15937 19.909893,-6.35 0.86322,1.81872 1.399035,2.16412 3.571875,2.57968 0.815799,-0.022 1.631597,-0.0441 2.447396,-0.0661 1.808025,-0.44162 2.142728,-0.67277 3.108854,-2.4474 11.230355,1.36029 11.188618,1.38757 18.25625,6.74688 2.745052,3.1309 3.671094,5.00504 4.365625,8.59896 0.264583,5.1263 1.254823,10.38485 1.320969,15.47808 l 2.184761,4.89479 v 17.19791 l -2.513542,0.99224 10e-7,1.52135 2.513541,0.39687 c -1.007974,11.0006 -2.00013,19.52446 -2.182812,28.97188 -0.57326,10.05417 -0.800418,19.72432 -6.813021,26.64427 -3.502949,4.03157 -9.595838,4.97222 -14.816666,6.09791 -4.39946,0.94859 -9.075269,1.31864 -13.493752,0.46302 -5.302922,-1.02689 -11.328135,-2.43714 -14.816664,-6.56093 -5.920645,-6.99879 -4.641232,-18.97136 -6.81302,-26.64427 -0.782726,-9.55807 -1.367014,-19.31459 -2.050521,-28.97188 l 2.38125,-0.39687 c -0.0441,-0.50712 -0.08819,-1.01423 -0.132292,-1.52135 l -2.38125,-0.99224 v -17.19791 c 0.617361,-1.6316 1.234723,-3.26319 1.852084,-4.89479 l 0.926041,-18.19006 c 0.496094,-3.10887 1.256771,-4.69638 3.175,-6.35004 z"
+       id="path882"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccaaaaccccccccc" />
+    <path
+       sodipodi:type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:0.39215686;stroke:#babdb6;stroke-width:3.62082291;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="led0"
+       sodipodi:cx="64.507607"
+       sodipodi:cy="278.93338"
+       sodipodi:rx="6.5174346"
+       sodipodi:ry="6.5174408"
+       d="m 69.116129,274.32485 a 6.5174346,6.5174408 0 0 1 0,9.21706 6.5174346,6.5174408 0 0 1 -9.217044,0 6.5174346,6.5174408 0 0 1 -10e-7,-9.21706"
+       sodipodi:start="5.4977871"
+       sodipodi:end="3.9269907"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       inkscape:label="#led1" />
+    <path
+       style="display:inline;opacity:1;fill:none;stroke:#babdb6;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 63.998032,175.33704 c -0.0617,17.18181 0,37.8177 0,37.8177 v 0"
+       id="path4530-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccc" />
+    <rect
+       style="display:inline;opacity:1;fill:#eeeeec;fill-opacity:1;stroke:#bfc2bb;stroke-width:0.65934163;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="button2"
+       width="8.6572962"
+       height="16.992365"
+       x="59.667027"
+       y="183.8551"
+       ry="1.5045637"
+       inkscape:label="#rect4615"
+       rx="2.8998742" />
+    <rect
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:0.51011664;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="button7"
+       width="4.0773749"
+       height="11.664907"
+       x="61.934288"
+       y="213.306"
+       ry="0.74915975"
+       inkscape:label="#rect4615"
+       rx="0.63142258" />
+    <path
+       style="opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.65934163;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 37.140885,265.81223 c 1.378038,-1.69774 2.359202,-2.7671 2.910417,-4.69635 0.275607,-1.59853 0.319704,-2.27101 0.132291,-3.70417 l -0.529166,-2.91042 c -0.352778,0.022 -0.705556,0.0441 -1.058334,0.0661 -1.113455,-0.31971 -1.631597,-0.93707 -2.248958,-1.65365 -0.429948,-0.89297 -0.859896,-1.78593 -1.289844,-2.6789 l 0.529167,6.91224 z"
+       id="path961"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 39.662795,224.50314 c -1.418755,-15.53616 -1.294028,-30.04332 -0.748352,-45.27546 7.464057,-5.23848 10.578303,-5.75298 20.392662,-7.01583 0.604141,2.15932 2.552981,2.88039 4.583673,2.89988 0.06236,2.93106 -0.0039,5.75688 0.05847,8.68793 -0.966626,0.0156 -1.617539,-0.0389 -2.677709,0.15206 -0.576857,0.12082 -1.668207,0.59244 -1.683798,1.44993 0.03118,4.73958 0.06237,9.47916 0.09355,14.21874 0.428974,0.80223 0.791803,1.0753 1.683798,1.21608 h 2.666014 c 0.09354,3.89768 -0.04677,7.79536 0.04677,11.69304 -1.777343,0.0624 -3.554686,0.12473 -5.332029,0.18709 -4.677216,3.30523 -9.354432,6.61047 -14.031648,9.9157 -1.948383,1.15278 -3.036871,1.77639 -5.051401,1.87084 z"
+       id="button0"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccc"
+       inkscape:label="#path971" />
+    <path
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 88.538966,224.46383 c 1.418756,-15.53616 -0.763946,-29.5756 -1.309622,-44.80774 -6.341526,-5.61266 -8.520329,-6.2207 -18.334688,-7.48355 -0.604141,2.15932 -2.833614,2.83362 -4.864306,2.85311 -0.06236,2.93106 0.284533,5.80365 0.222163,8.7347 0.966626,0.0156 1.617539,-0.0389 2.677709,0.15206 0.576857,0.12082 1.668207,0.59244 1.683798,1.44993 -0.03118,4.73958 -0.06237,9.47916 -0.09355,14.21874 -0.428974,0.80223 -0.791803,1.0753 -1.683798,1.21608 h -2.80633 c -0.09354,3.89768 0.187088,7.79536 0.09354,11.69304 1.777343,0.0624 3.554686,0.12473 5.332029,0.18709 4.677216,3.30523 9.354432,6.61047 14.031649,9.9157 1.948382,1.15278 3.036871,1.77639 5.0514,1.87084 z"
+       id="button1"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccc"
+       inkscape:label="#path971-5" />
+    <path
+       style="opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 39.721262,254.48409 c -2.127995,-12.76601 -2.492187,-15.11204 -3.531298,-26.68352 -0.880877,0.16371 -1.761753,0.32741 -2.64263,0.49111 0.510597,7.26528 1.021194,14.53055 1.531791,21.79583 0.415673,1.21059 0.673654,1.8504 1.39147,2.98173 0.557369,0.65481 1.067966,1.08745 1.882582,1.5084 0.738934,0.12313 0.851361,0.031 1.368085,-0.0935 z"
+       id="button3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc"
+       inkscape:label="#path998" />
+    <path
+       style="opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 36.061341,226.30387 -2.595857,-0.95884 v -17.51617 l 2.128134,-4.89938 z"
+       id="button4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#path1000" />
+    <g
+       id="g27"
+       inkscape:label="#g84"
+       style="opacity:1">
+      <path
+         inkscape:label="#path42"
+         inkscape:connector-curvature="0"
+         id="led1"
+         d="m 60.202463,185.20746 c 0,14.31228 0,14.31228 0,14.31228"
+         style="fill:#c8c8c8;fill-opacity:1;stroke:#babdb6;stroke-width:0.23228861px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+      <path
+         inkscape:label="#path42"
+         inkscape:connector-curvature="0"
+         id="led0-3"
+         d="m 67.749483,185.21452 c 0,14.31228 0,14.31228 0,14.31228"
+         style="display:inline;opacity:1;fill:#c8c8c8;fill-opacity:1;stroke:#babdb6;stroke-width:0.23228861px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1" />
+    </g>
+    <path
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 91.839114,226.13585 2.59586,-0.95884 v -17.51617 l -2.12814,-4.89938 z"
+       id="button6"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccc"
+       inkscape:label="#path1000" />
+    <path
+       style="display:inline;opacity:1;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.65934163;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 91.651856,265.50364 c -1.378038,-1.69774 -3.25217,-2.70095 -3.803385,-4.6302 -0.275607,-1.59853 -0.319704,-2.27101 -0.132291,-3.70417 l 0.529166,-2.91042 c 0.352778,0.022 0.705556,0.0441 1.058334,0.0661 1.113455,-0.31971 1.631597,-0.93707 2.248958,-1.65365 0.429948,-0.89297 0.859896,-1.78593 1.289844,-2.6789 l -0.529167,6.91224 z"
+       id="path961-7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccc" />
+    <path
+       style="display:inline;opacity:1;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#bfc2bb;stroke-width:0.51011664;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 88.31891,254.33178 c 2.127995,-12.76601 2.492187,-15.11204 3.531298,-26.68352 0.880877,0.16371 1.761753,0.32741 2.64263,0.49111 -0.510597,7.26528 -1.021194,14.53055 -1.531791,21.79583 -0.415673,1.21059 -0.673654,1.8504 -1.39147,2.98173 -0.557369,0.65481 -1.067966,1.08745 -1.882582,1.5084 -0.738934,0.12313 -0.851361,0.031 -1.368085,-0.0935 z"
+       id="button5"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc"
+       inkscape:label="#path998" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.19679,-46.28282)"
+       style="display:inline"
+       id="button0-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 69.018882,250.50576 170.100828,0.008"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="65.211685"
+         y="247.25577" />
+      <rect
+         y="250.01747"
+         x="238.66302"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,40.502648,-25.152234)"
+       style="display:inline"
+       id="button1-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 336.41912,170.11088 -197.26264,0.0828"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="137"
+         y="166.75" />
+      <rect
+         y="169.61206"
+         x="335.92694"
+         height="1"
+         width="1"
+         id="button1-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,39.927878,-13.516602)"
+       style="display:inline"
+       id="button2-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 338.62224,171.07963 91.069203,171.06803"
+         id="path51-2"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-3"
+         width="6.999999"
+         height="6.999999"
+         x="87.596474"
+         y="167.57452" />
+      <rect
+         y="170.56519"
+         x="338.10663"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,39.855422,10.357346)"
+       style="display:inline"
+       id="button7-path"
+       inkscape:label="#g146">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 339.97978,126.30151 139.89299,126.07359 91.343981,170.50618"
+         id="path51-2-3"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-3-4"
+         width="6.999999"
+         height="6.999999"
+         x="88"
+         y="167.375" />
+      <rect
+         y="125.46475"
+         x="338.41376"
+         height="1"
+         width="1"
+         id="button7-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect871" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.354375,-10.600792)"
+       style="display:inline"
+       id="button4-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 121.40352,250.50576 118.2207,0.0352"
+         id="path966-1"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-3"
+         width="6.999999"
+         height="6.999999"
+         x="118.01969"
+         y="247.06827" />
+      <rect
+         y="250.06044"
+         x="239.16049"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.260832,1.1857932)"
+       style="display:inline"
+       id="button3-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 119.59715,250.50576 120.02707,0.0352"
+         id="path966-2"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-8"
+         width="6.999999"
+         height="6.999999"
+         x="116.24155"
+         y="247.19327" />
+      <rect
+         y="250.00575"
+         x="238.62422"
+         height="1"
+         width="1"
+         id="button3-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(0.29294531,0,0,0.26458333,57.669203,-10.667542)"
+       style="display:inline"
+       id="button6-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 121.40352,250.50576 245.2523,250.36418"
+         id="path966-1-56"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-3-2"
+         width="6.999999"
+         height="6.999999"
+         x="118.01969"
+         y="247.06827" />
+      <rect
+         y="249.93338"
+         x="244.75864"
+         height="1"
+         width="1"
+         id="button6-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(0.29294531,0,0,0.26458333,57.642982,1.1725622)"
+       style="display:inline"
+       id="button5-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 121.40352,250.50576 245.2523,250.36418"
+         id="path966-1-56-2"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-3-2-7"
+         width="6.999999"
+         height="6.999999"
+         x="116.50291"
+         y="247.24504" />
+      <rect
+         y="249.93338"
+         x="244.75864"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,69.912779,-34.520744)"
+       style="display:inline"
+       id="led1-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 33.260958,250.40632 204.900782,0.0964"
+         id="path966-0"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-2"
+         width="6.999999"
+         height="6.999999"
+         x="29.527279"
+         y="246.99062" />
+      <rect
+         y="249.97328"
+         x="237.64519"
+         height="1"
+         width="1"
+         id="led1-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,69.953208,49.201431)"
+       style="display:inline"
+       id="led0-path"
+       inkscape:label="#g156">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 19.28901,250.49471 219.01243,0.008"
+         id="path966-0-2"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-2-1"
+         width="6.999999"
+         height="6.999999"
+         x="16.834169"
+         y="246.63705" />
+      <rect
+         y="249.97328"
+         x="237.7849"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/steelseries-senseiraw.svg
+++ b/data/svgs/steelseries-senseiraw.svg
@@ -1,0 +1,497 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="490"
+   height="490"
+   viewBox="0 0 129.64583 129.64583"
+   version="1.1"
+   id="svg8"
+   sodipodi:docname="steelseries-senseiraw.svg"
+   inkscape:version="0.92.3 (2405546, 2018-03-11)">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4986862"
+     inkscape:cx="234.07051"
+     inkscape:cy="291.38143"
+     inkscape:document-units="px"
+     inkscape:current-layer="Device"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     showguides="false"
+     inkscape:window-width="1920"
+     inkscape:window-height="1149"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     showborder="true"
+     inkscape:guide-bbox="true"
+     units="px"
+     inkscape:snap-global="false"
+     inkscape:measure-start="0,0"
+     inkscape:measure-end="0,0">
+    <inkscape:grid
+       type="xygrid"
+       id="grid78" />
+    <sodipodi:guide
+       position="58.722772,112.40709"
+       orientation="0,1"
+       id="guide79"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="39.611923,100.54373"
+       orientation="0,1"
+       id="guide81"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="51.756014,88.614617"
+       orientation="0,1"
+       id="guide83"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="57.778386,76.729167"
+       orientation="0,1"
+       id="guide85"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="45.047078,64.795712"
+       orientation="0,1"
+       inkscape:locked="false"
+       id="guide87" />
+    <sodipodi:guide
+       position="57.646696,52.899321"
+       orientation="0,1"
+       id="guide89"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="64.732676,142.09384"
+       orientation="1,0"
+       id="guide913"
+       inkscape:locked="false" />
+    <sodipodi:guide
+       position="-45.462545,31.805073"
+       orientation="0,1"
+       inkscape:locked="false"
+       id="guide944" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="layer1"
+     inkscape:label="Image"
+     style="display:none"
+     sodipodi:insensitive="true" />
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     style="display:inline;opacity:1"
+     transform="translate(0,-167.35416)">
+    <path
+       style="display:inline;fill:#d3d3ce;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 61.118815,173.57187 c -6.81302,0.0662 -11.972394,1.52136 -16.073435,3.37344 -2.88728,1.31189 -4.888218,3.54982 -6.680729,5.62239 -2.215885,3.43407 -3.375386,5.63618 -3.970698,8.86355 -0.919394,7.49385 -0.194949,14.47321 -0.225672,22.62187 -0.0441,2.92144 0.321327,3.9908 0.09533,6.28385 -0.132292,4.05143 -0.413412,7.82174 -0.79375,11.90625 l -0.859895,11.9724 -1.190625,16.27187 c -0.0248,0.94258 -1e-6,1.65364 0.198437,2.57969 0.171855,0.8399 0.352238,1.03153 0.463021,1.52135 0.595312,2.4033 0.529166,3.99631 1.785937,7.2099 2.116666,4.23333 3.604948,6.84609 6.746875,10.71562 3.858506,4.06797 6.928936,5.67685 11.575518,7.34219 4.293136,1.39044 7.919768,1.65835 12.633854,1.78594 0,0 8.340581,-0.39932 12.633718,-1.78976 4.646582,-1.66534 7.717012,-3.27422 11.575518,-7.34219 3.141927,-3.86953 4.630209,-6.48229 6.746875,-10.71562 1.256771,-3.21359 1.190625,-4.8066 1.785937,-7.2099 0.110783,-0.48982 0.291166,-0.68145 0.463021,-1.52135 0.198438,-0.92605 0.223237,-1.63711 0.198437,-2.57969 l -1.190625,-16.27187 -0.717876,-8.98999 c -0.380338,-4.08451 -0.803477,-10.83723 -0.935769,-14.88866 -0.225999,-2.29305 -0.28663,-3.36241 -0.33073,-6.28385 -0.03072,-8.14866 0.835741,-15.12802 -0.08365,-22.62187 -0.595312,-3.22737 -1.470774,-5.42948 -3.686659,-8.86355 -1.792511,-2.07257 -3.793449,-4.3105 -6.680729,-5.62239 -4.101041,-1.85208 -9.260416,-3.30724 -16.073436,-3.37344 -3.028432,-0.0919 -5.294794,0.0499 -7.4082,0.004 z"
+       id="path926"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccccccccccccccccc" />
+    <path
+       id="path5205"
+       style="display:inline;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:markers fill stroke"
+       d="m 68.894015,173.48626 c 0.01741,1.97468 0.845255,8.1474 1.684943,11.60161 1.369264,5.63272 0.266853,23.47034 0.266853,23.47034 0,0 -2.042025,17.37272 -6.022897,17.27166 -3.980871,0.16348 -6.022896,-17.20924 -6.022896,-17.20924 0,0 -1.10241,-17.83762 0.266854,-23.47034 0.839687,-3.45421 1.667532,-9.62693 1.684942,-11.60161 z"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cscccscc" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 64.695108,222.94948 c -0.606916,-0.009 -3.440676,-6.06643 -3.513997,-9.56014 -0.02982,-1.42071 0.176696,-1.66675 3.591511,-1.70532 3.503766,-0.0396 3.702586,0.22584 3.694867,1.62781 -0.01799,3.26716 -3.27008,9.64508 -3.772381,9.63765 z"
+       id="button7"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssss"
+       mask="none"
+       clip-path="none" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 95.121771,209.18914 c 0,0 -0.197205,17.71196 -1.241986,33.44373 -0.483924,7.28668 -1.491683,12.97597 -2.130552,18.3934 -0.45519,3.85988 0.58105,6.73694 2.373267,7.24471 1.728139,0.48961 3.747262,-3.87217 3.747262,-3.87217"
+       id="path4742"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="csssc" />
+    <path
+       sodipodi:nodetypes="csssc"
+       inkscape:connector-curvature="0"
+       id="path4744"
+       d="m 34.385075,208.66134 c 0,0 0.197205,17.71196 1.241986,33.44373 0.483924,7.28668 1.491683,12.97597 2.130552,18.3934 0.45519,3.85988 -0.58105,6.73694 -2.373267,7.24471 -1.728139,0.48961 -3.747262,-3.87217 -3.747262,-3.87217"
+       style="display:inline;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 33.794256,226.79927 0.594666,-18.07871"
+       id="path58"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 35.720073,242.99898 c 0,0 -1.305894,-0.86732 -1.520495,-1.08633 -0.214601,-0.21901 -0.406023,-15.1316 -0.406023,-15.1316 l 1.116802,0.0102"
+       id="path56"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czcc" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 95.452345,226.07744 -0.362533,-16.8175"
+       id="path54"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+       d="m 93.827188,242.82115 c 0,0 1.385456,-0.49501 1.574101,-0.65851 0.188645,-0.16351 0.05639,-16.17317 0.05639,-16.17317 l -0.703725,-0.17593"
+       id="path52"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="czcc" />
+    <path
+       sodipodi:type="arc"
+       style="display:inline;opacity:1;fill:none;fill-opacity:0.39215686;stroke:#babdb6;stroke-width:3.62082291;stroke-linecap:square;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       id="led0"
+       sodipodi:cx="64.822914"
+       sodipodi:cy="280.68228"
+       sodipodi:rx="6.5174346"
+       sodipodi:ry="6.5174413"
+       d="m 69.431436,276.07375 a 6.5174346,6.5174413 0 0 1 10e-7,9.21706 6.5174346,6.5174413 0 0 1 -9.217045,0 6.5174346,6.5174413 0 0 1 -10e-7,-9.21705"
+       sodipodi:start="5.4977871"
+       sodipodi:end="3.9269907"
+       sodipodi:open="true"
+       sodipodi:arc-type="arc"
+       inkscape:label="#led1" />
+    <path
+       style="display:inline;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:0.98636663;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;paint-order:normal"
+       d="m 62.181167,187.21067 -0.0053,13.99772 c 0.798868,1.60491 0.79411,1.60258 2.56045,1.60804 1.9255,-0.003 1.931661,-0.005 2.733645,-1.59929 l -0.0049,-14.01641 c -0.79057,-1.56574 -0.793119,-1.57885 -2.72281,-1.60756 -1.766557,0.0242 -1.762015,0.025 -2.561099,1.6175 z"
+       id="button2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <rect
+       id="button0"
+       width="18.360525"
+       height="26.481527"
+       x="37.983463"
+       y="180.65782"
+       style="display:inline;fill:none;stroke-width:0.26458332"
+       inkscape:label="#button0" />
+    <rect
+       id="button1"
+       width="19.0667"
+       height="26.834612"
+       x="72.056366"
+       y="179.95164"
+       style="display:inline;fill:none;stroke-width:0.26458332"
+       inkscape:label="#button1" />
+    <rect
+       id="button4"
+       width="3.8839571"
+       height="16.242002"
+       x="32.334072"
+       y="209.96404"
+       style="display:inline;fill:none;stroke-width:0.26458332"
+       inkscape:label="#button4" />
+    <rect
+       id="button3"
+       width="4.0605006"
+       height="15.006199"
+       x="32.334072"
+       y="227.2653"
+       style="display:inline;fill:none;stroke-width:0.26458332"
+       inkscape:label="#button3" />
+    <rect
+       id="button5"
+       width="3.177783"
+       height="14.653111"
+       x="93.594673"
+       y="210.67021"
+       style="display:inline;fill:none;stroke-width:0.26458332"
+       inkscape:label="#button5" />
+    <rect
+       id="button6"
+       width="3.3543267"
+       height="15.712373"
+       x="93.594673"
+       y="226.91222"
+       style="display:inline;fill:none;stroke-width:0.26458332"
+       inkscape:label="#button6" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.223399,-40.717196)"
+       style="display:inline"
+       id="button0-path"
+       inkscape:label="#button0-path">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 81.663449,250.50576 157.960771,0.0352"
+         id="path966"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976"
+         width="6.999999"
+         height="6.999999"
+         x="79.083046"
+         y="247.00577" />
+      <rect
+         y="250.00575"
+         x="238.62422"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#button0-leader" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,40.529257,-19.549003)"
+       style="display:inline"
+       id="button1-path"
+       inkscape:label="#button1-path">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 336.91912,170.14213 -183.57514,0.36405"
+         id="path51"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53"
+         width="6.999999"
+         height="6.999999"
+         x="149"
+         y="167" />
+      <rect
+         y="169.75269"
+         x="336.91913"
+         height="1"
+         width="1"
+         id="button1-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#button1-leader" />
+    </g>
+    <g
+       transform="matrix(-0.2847136,0,0,0.26458333,87.395313,-3.7692874)"
+       style="display:inline;opacity:1"
+       id="button2-path"
+       inkscape:label="#button2-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path964-6"
+         d="m 79.210952,122.6933 62.691188,68.76371 165.40155,1e-5"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#button2-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button2-leader"
+         width="1"
+         height="1"
+         x="306.40533"
+         y="190.93378" />
+      <rect
+         y="117.94263"
+         x="76.303352"
+         height="6.999999"
+         width="6.999999"
+         id="rect974-5"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+    </g>
+    <g
+       transform="matrix(0.26458333,0,0,0.26458333,13.523106,5.8698781)"
+       style="display:inline"
+       id="button7-path"
+       inkscape:label="#button7-path">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 438.5178,161.34199 H 204.22621 l -10.41041,7.75114"
+         id="path51-1-9-6-0"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect53-2-3-2-2"
+         width="6.999999"
+         height="6.999999"
+         x="189"
+         y="167" />
+      <rect
+         y="160.86166"
+         x="437.87918"
+         height="1"
+         width="1"
+         id="button7-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#button7-leader" />
+    </g>
+    <g
+       inkscape:label="#button3-path"
+       id="button3-path"
+       style="display:inline"
+       transform="matrix(-0.29294531,0,0,0.26458333,58.364063,-10.132593)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path64"
+         d="m 81.659897,250.49954 118.042313,0.0476"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1.00572562;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="247.00577"
+         x="79.083046"
+         height="6.999999"
+         width="6.999999"
+         id="rect66"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#button3-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button3-leader"
+         width="1"
+         height="1"
+         x="199.22597"
+         y="250.00575" />
+    </g>
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,58.488898,4.7227855)"
+       style="display:inline"
+       id="button4-path"
+       inkscape:label="#button4-path">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1.00572562;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 81.659897,250.49954 118.042313,0.0476"
+         id="path72"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect74"
+         width="6.999999"
+         height="6.999999"
+         x="79.083046"
+         y="247.00577" />
+      <rect
+         y="250.00575"
+         x="199.15065"
+         height="1"
+         width="1"
+         id="button4-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#button4-leader" />
+    </g>
+    <g
+       transform="matrix(0.29294531,0,0,0.26458333,71.117413,-9.779506)"
+       style="display:inline"
+       id="button5-path"
+       inkscape:label="#button5-path">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1.00572562;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 81.659897,250.49954 118.042313,0.0476"
+         id="path80"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect82"
+         width="6.999999"
+         height="6.999999"
+         x="79.083046"
+         y="247.00577" />
+      <rect
+         y="250.00575"
+         x="199.22597"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#button5-leader" />
+    </g>
+    <g
+       inkscape:label="#button6-path"
+       id="button6-path"
+       style="display:inline"
+       transform="matrix(0.29294531,0,0,0.26458333,70.992573,5.0758725)">
+      <path
+         inkscape:connector-curvature="0"
+         id="path88"
+         d="m 81.659897,250.49954 118.042313,0.0476"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1.00572562;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cc" />
+      <rect
+         y="247.00577"
+         x="79.083046"
+         height="6.999999"
+         width="6.999999"
+         id="rect90"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <rect
+         inkscape:label="#button6-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button6-leader"
+         width="1"
+         height="1"
+         x="199.15065"
+         y="250.00575" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs"
+     transform="translate(0,-2.6458338)"
+     style="display:inline">
+    <g
+       transform="matrix(-0.29294531,0,0,0.26458333,70.145744,50.590488)"
+       style="display:inline"
+       id="led0-path"
+       inkscape:label="#led0-path">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 19.28901,250.49471 219.01243,0.008"
+         id="path966-0-2"
+         inkscape:connector-curvature="0" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect976-2-1"
+         width="6.999999"
+         height="6.999999"
+         x="16.834169"
+         y="246.63705" />
+      <rect
+         y="249.97328"
+         x="237.7849"
+         height="1"
+         width="1"
+         id="led0-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         inkscape:label="#rect875" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -1,0 +1,139 @@
+[Etekcity Scroll Alpha]
+DeviceMatch=usb:1ea7:4011
+Svg=etekcity.svg
+
+[Logitech Gaming Mouse G102/G103]
+DeviceMatch=usb:046d:c084
+Svg=logitech-g102-g203.svg
+
+[Logitech G300]
+DeviceMatch=usb:046d:c246
+Svg=logitech-g300.svg
+
+[Logitech Gaming Mouse G302]
+DeviceMatch=usb:046d:c07f
+Svg=logitech-g303.svg
+
+[Logitech Gaming Mouse G303]
+DeviceMatch=usb:046d:c080
+Svg=logitech-g303.svg
+
+[Logitech G402 Gaming Mouse]
+DeviceMatch=usb:046d:c07e
+Svg=logitech-g402.svg
+
+[Logitech G403]
+DeviceMatch=usb:046d:c082;usb:046d:c083
+Svg=logitech-g403.svg
+
+[Logitech G500]
+DeviceMatch=usb:046d:c068
+Svg=logitech-g500.svg
+
+[Logitech G500s]
+DeviceMatch=usb:046d:c24e
+Svg=logitech-g500s.svg
+
+[Logitech G502 HERO]
+DeviceMatch=usb:046d:c08b
+Svg=logitech-g502.svg
+
+[Logitech G502 Proteus Core]
+DeviceMatch=usb:046d:c07d
+Svg=logitech-g502.svg
+
+[Logitech G502 Proteus Spectrum]
+DeviceMatch=usb:046d:c332
+Svg=logitech-g502.svg
+
+[Logitech G600]
+DeviceMatch=usb:046d:c24a
+Svg=logitech-g600.svg
+
+[Logitech G603]
+DeviceMatch=bluetooth:046d:b01c
+Svg=logitech-g603.svg
+
+[Logitech G700]
+DeviceMatch=usb:046d:c06b;usb:046d:c07c
+Svg=logitech-g700.svg
+
+[Logitech G700s]
+DeviceMatch=usb:046d:c531
+Svg=logitech-g700.svg
+
+[Logitech G703]
+DeviceMatch=usb:046d:c087
+Svg=logitech-g703.svg
+
+[Logitech G900]
+DeviceMatch=usb:046d:c081
+Svg=logitech-g900.svg
+
+[Logitech G900, G903, G603, G403]
+DeviceMatch=usb:046d:c539
+Svg=logitech-g900.svg
+
+[Logitech G903]
+DeviceMatch=usb:046d:c086
+Svg=logitech-g900.svg
+
+[Logitech G9]
+DeviceMatch=usb:046d:c048
+Svg=logitech-g9.svg
+
+[Logitech G PowerPlay mouse pad.]
+DeviceMatch=usb:046d:c53a
+Svg=logitech-g900.svg
+
+[Logitech Gaming Mouse G Pro]
+DeviceMatch=usb:046d:c085
+Svg=logitech-g-pro.svg
+
+[Logitech G Pro Wireless]
+DeviceMatch=usb:046d:c539;usb:046d:c088
+Svg=logitech-g-pro-wireless.svg
+
+[Logitech MX Anywhere 2]
+DeviceMatch=usb:046d:404a;bluetooth:046d:b013
+Svg=logitech-mx-anywhere2.svg
+
+[Logitech MX Anywhere 2S]
+DeviceMatch=usb:046d:406a
+Svg=logitech-mx-anywhere2.svg
+
+[Logitech MX Master 2S]
+DeviceMatch=bluetooth:046d:b019;usb:046d:4069
+Svg=logitech-mx-master-2s.svg
+
+[Logitech MX Master]
+DeviceMatch=usb:046d:4041;bluetooth:046d:b012;usb:046d:4060
+Svg=logitech-mx-master.svg
+
+[Roccat Kone XTD]
+DeviceMatch=usb:1e7d:2e22
+Svg=roccat-kone-xtd.svg
+
+[SteelSeries Kinzu V2]
+DeviceMatch=usb:1038:1378
+Svg=steelseries-kinzu-v2.svg
+
+[SteelSeries Rival 310]
+DeviceMatch=usb:1038:1720
+Svg=steelseries-rival310.svg
+
+[SteelSeries Rival 600]
+DeviceMatch=usb:1038:1724
+Svg=steelseries-rival600.svg
+
+[SteelSeries Rival]
+DeviceMatch=usb:1038:1384
+Svg=steelseries-rival.svg
+
+[SteelSeries Sensei 310]
+DeviceMatch=usb:1038:1722
+Svg=steelseries-sensei310.svg
+
+[SteelSeries Sensei Raw]
+DeviceMatch=usb:1038:1369
+Svg=steelseries-senseiraw.svg

--- a/piper/devicerow.py
+++ b/piper/devicerow.py
@@ -20,7 +20,9 @@ from .gi_composites import GtkTemplate
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import GdkPixbuf, GObject, Gtk, Rsvg, Gio
+from gi.repository import GdkPixbuf, GObject, Gtk, Rsvg
+
+from piper.svg import get_svg
 
 
 @GtkTemplate(ui="/org/freedesktop/Piper/ui/DeviceRow.ui")
@@ -40,11 +42,8 @@ class DeviceRow(Gtk.ListBoxRow):
         self.title.set_text(device.name)
 
         try:
-            fd = device.get_svg_fd("gnome")
-            uis = Gio.UnixInputStream.new(fd.fileno(), False)
-            handle = Rsvg.Handle.new_from_stream_sync(uis, None,
-                                                      Rsvg.HandleFlags.FLAGS_NONE,
-                                                      None)
+            svg_bytes = get_svg(device.model)
+            handle = Rsvg.Handle.new_from_data(svg_bytes)
             svg = handle.get_pixbuf_sub("#Device")
             handle.close()
             if svg is None:

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -216,35 +216,6 @@ class _RatbagdDBus(GObject.GObject):
                 print(e.message, file=sys.stderr)
                 raise
 
-    def _dbus_call_return_one_fd(self, method, type, *value):
-        # Calls a method synchronously on the bus, using the given method name,
-        # type signature and values.
-        #
-        # It the result is valid, it is returned. Invalid results raise the
-        # appropriate RatbagError* or RatbagdDBus* exception, or GLib.Error if
-        # it is an unexpected exception that probably shouldn't be passed up to
-        # the UI.
-        val = GLib.Variant("({})".format(type), value)
-        try:
-            res = self._proxy.call_with_unix_fd_list_sync(method, val,
-                                                          Gio.DBusCallFlags.NO_AUTO_START,
-                                                          2000, None, None)
-            if res in EXCEPTION_TABLE:
-                raise EXCEPTION_TABLE[res]
-            # Result is a tuple of (GLib.Variant('(h)', (0,)), fd_list),
-            # we return the first file descriptor in that list
-            return res[1].get(0)
-        except GLib.Error as e:
-            if e.code == Gio.DBusError.FILE_NOT_FOUND:
-                raise FileNotFoundError('Failed to open SVG file')
-            elif e.code == Gio.IOErrorEnum.TIMED_OUT:
-                raise RatbagdDBusTimeout(e.message)
-            else:
-                # Unrecognized error code; print the message to stderr and raise
-                # the GLib.Error.
-                print(e.message, file=sys.stderr)
-                raise
-
     def __eq__(self, other):
         return other and self._object_path == other._object_path
 
@@ -301,12 +272,6 @@ class Ratbagd(_RatbagdDBus):
                 return d
         return None
 
-    @GObject.Property
-    def themes(self):
-        """A list of theme names. The theme 'default' is guaranteed to be
-        available."""
-        return self._get_dbus_property("Themes") or []
-
     def __enter__(self):
         return self
 
@@ -361,6 +326,11 @@ class RatbagdDevice(_RatbagdDBus):
         return self._get_dbus_property("Id")
 
     @GObject.Property
+    def model(self):
+        """The unique identifier for this device model."""
+        return self._get_dbus_property("Model")
+
+    @GObject.Property
     def capabilities(self):
         """The capabilities of this device as an array. Capabilities not
         present on the device are not in the list. Thus use e.g.
@@ -391,19 +361,6 @@ class RatbagdDevice(_RatbagdDBus):
                 return profile
         print("No active profile. Please report this bug to the libratbag developers", file=sys.stderr)
         return self._profiles[0]
-
-    def get_svg_fd(self, theme):
-        """Returns a File-like object to the SVG for the given theme, or
-        raises FileNotFoundError if the file is not available.
-
-        The theme must be one of org.freedesktop.ratbag1.Manager.Themes. The
-        theme 'default' is guaranteed to be available (but the file itself
-        may not be).
-
-        @param theme The theme from which to retrieve the SVG, as str
-        """
-        fd = self._dbus_call_return_one_fd("GetSvgFd", "s", theme)
-        return os.fdopen(fd)
 
     def commit(self):
         """Commits all changes made to the device.

--- a/piper/svg.py
+++ b/piper/svg.py
@@ -1,0 +1,50 @@
+# Copyright (C) 2019 Red Hat, Inc
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License along
+# with this program; if not, write to the Free Software Foundation, Inc.,
+# 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+from gi.repository import Gio
+
+import configparser
+
+
+def get_svg(model):
+    resource = Gio.resources_lookup_data('/org/freedesktop/Piper/svgs/svg-lookup.ini', Gio.ResourceLookupFlags.NONE)
+
+    data = resource.get_data()
+    config = configparser.ConfigParser()
+    config.read_string(data.decode('utf-8'), source='svg-lookup.ini')
+    assert config.sections()
+
+    filename = 'fallback.svg'
+
+    if model.startswith('usb:') or model.startswith('bluetooth:'):
+        bus, vid, pid, version = model.split(':')
+        # Where the version is 0 (virtually all devices) we drop it. This
+        # way the DeviceMatch lines are less confusing.
+        if int(version) == 0:
+            usbid=':'.join([bus, vid, pid])
+        else:
+            usbid = model
+
+        for s in config.sections():
+            matches = config[s]['DeviceMatch'].split(';')
+            if usbid in matches:
+                filename = config[s]['Svg']
+                break
+
+    resource = Gio.resources_lookup_data('/org/freedesktop/Piper/svgs/{}'.format(filename),
+                                         Gio.ResourceLookupFlags.NONE)
+
+    return resource.get_data()


### PR DESCRIPTION
This is the other half to the libratbag commit: https://github.com/libratbag/libratbag/pull/638

It adds the SVGs from libratbag and in the second commit hooks up the SVG loading through gresources.