### PR TITLE
Fake a profile name where none exists

### DIFF
--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -94,7 +94,10 @@ class MousePerspective(Gtk.Overlay):
             self.stack.add_titled(LedsPage(device), "leds", _("LEDs"))
 
         self.button_profile.set_visible(len(device.profiles) > 1)
-        self.label_profile.set_label(active_profile.name)
+        name = active_profile.name
+        if not name:
+            name = 'Profile {}'.format(active_profile.index)
+        self.label_profile.set_label(name)
         self._on_profile_notify_dirty(active_profile, None)
 
         # Find the first profile that is enabled. If there is none, disable the

--- a/piper/profilerow.py
+++ b/piper/profilerow.py
@@ -36,7 +36,11 @@ class ProfileRow(Gtk.ListBoxRow):
         self._profile = profile
         self._profile.connect("notify::enabled", self._on_profile_notify_enabled)
 
-        self.title.set_text(profile.name)
+        name = profile.name
+        if not name:
+            name = 'Profile {}'.format(profile.index)
+
+        self.title.set_text(name)
         self.show_all()
         self.set_visible(profile.enabled)
 


### PR DESCRIPTION
Where the profile name is none (the empty string), fake a profile name based
on the index. This used to be done in ratbagd but was removed there with the
most recent snapshot.

Fixes #323 