### PR TITLE
Add PID for MX Anywhere 2

### DIFF
--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -95,7 +95,7 @@ DeviceMatch=usb:046d:c539;usb:046d:c088
 Svg=logitech-g-pro-wireless.svg
 
 [Logitech MX Anywhere 2]
-DeviceMatch=usb:046d:404a;bluetooth:046d:b013
+DeviceMatch=usb:046d:404a;bluetooth:046d:b013;bluetooth:406d:b018
 Svg=logitech-mx-anywhere2.svg
 
 [Logitech MX Anywhere 2S]


### PR DESCRIPTION
Adds an additional PID match for the MX Anywhere 2 since these mice appear to use one of several differen Bluetooth PIDs.

See libratbag/libratbag#721 and libratbag/libratbag#722