### PR TITLE
Prepare for linux 5.2

### DIFF
--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -23,7 +23,7 @@ DeviceMatch=usb:046d:c07e
 Svg=logitech-g402.svg
 
 [Logitech G403]
-DeviceMatch=usb:046d:c082;usb:046d:c083
+DeviceMatch=usb:046d:c082;usb:046d:c083;usb:046d:405d
 Svg=logitech-g403.svg
 
 [Logitech G500]

--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -91,7 +91,7 @@ DeviceMatch=usb:046d:c085;usb:046d:c08c
 Svg=logitech-g-pro.svg
 
 [Logitech G Pro Wireless]
-DeviceMatch=usb:046d:c539;usb:046d:c088
+DeviceMatch=usb:046d:4079;usb:046d:c088
 Svg=logitech-g-pro-wireless.svg
 
 [Logitech MX Anywhere 2]

--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -70,10 +70,6 @@ Svg=logitech-g703.svg
 DeviceMatch=usb:046d:c081;usb:046d:4053
 Svg=logitech-g900.svg
 
-[Logitech G900, G903, G603, G403]
-DeviceMatch=usb:046d:c539
-Svg=logitech-g900.svg
-
 [Logitech G903]
 DeviceMatch=usb:046d:c086
 Svg=logitech-g900.svg

--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -67,7 +67,7 @@ DeviceMatch=usb:046d:c087
 Svg=logitech-g703.svg
 
 [Logitech G900]
-DeviceMatch=usb:046d:c081
+DeviceMatch=usb:046d:c081;usb:046d:4053
 Svg=logitech-g900.svg
 
 [Logitech G900, G903, G603, G403]


### PR DESCRIPTION
The removal of lightspeed shared device prevents duplicate entries. G603 and G903 need their device WPIDs added to their respective areas.