### PR TITLE
Fix PID Typo

### DIFF
--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -95,7 +95,7 @@ DeviceMatch=usb:046d:c539;usb:046d:c088
 Svg=logitech-g-pro-wireless.svg
 
 [Logitech MX Anywhere 2]
-DeviceMatch=usb:046d:404a;bluetooth:046d:b013;bluetooth:406d:b018
+DeviceMatch=usb:046d:404a;bluetooth:046d:b013;bluetooth:046d:b018
 Svg=logitech-mx-anywhere2.svg
 
 [Logitech MX Anywhere 2S]


### PR DESCRIPTION
The vendor ID I added had a typo; it should match the vendor portion of the other PIDs for this device.

See libratbag/libratbag#734