### PR TITLE
data: fix wrong name for the G403 Wireless

### DIFF
--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -26,7 +26,7 @@ Svg=logitech-g402.svg
 DeviceMatch=usb:046d:c083
 Svg=logitech-g403.svg
 
-[Logitech G403]
+[Logitech G403 Wireless]
 DeviceMatch=usb:046d:c082;usb:046d:405d
 Svg=logitech-g403.svg
 


### PR DESCRIPTION
Signed-off-by: Filipe Laíns <lains@archlinux.org>