### PR TITLE
Add missing device id for MX Master

### DIFF
--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -111,7 +111,7 @@ DeviceMatch=bluetooth:046d:b019;usb:046d:4069
 Svg=logitech-mx-master-2s.svg
 
 [Logitech MX Master]
-DeviceMatch=usb:046d:4041;bluetooth:046d:b012;usb:046d:4060
+DeviceMatch=usb:046d:4041;bluetooth:046d:b012;usb:046d:4060;bluetooth:046d:b017
 Svg=logitech-mx-master.svg
 
 [Roccat Kone XTD]


### PR DESCRIPTION
Update `DeviceMatch` value for Logitech MX Master in according [with the libratbag device description](https://github.com/libratbag/libratbag/blob/master/data/devices/logitech-MX-Master.device).

It was first mentioned in [this issue](https://github.com/libratbag/libratbag/issues/439) and I also can confirm that my MX master has `bluetooth:046d:b017` id.