### PR TITLE
Check ratbagd API version on startup

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -5,6 +5,12 @@ project('piper',
 # The tag date of the project_version(), update when the version bumps.
 version_date='2019-01-24'
 
+# The DBus API version of ratbagd that we are compatible with. Anything
+# higher or lower will not be compatible so make sure you bumpt that to the
+# latest released ratbagd version whenever a piper release is made.
+ratbagd_api_version = 1
+
+
 # Dependencies
 dependency('python3', required: true)
 dependency('pygobject-3.0', required: true)
@@ -75,6 +81,7 @@ config_piper.set('pkgdatadir', pkgdatadir)
 config_piper.set('localedir', localedir)
 config_piper.set('gtk_major_version', gtk_major_version)
 config_piper.set('gtk_minor_version', gtk_minor_version)
+config_piper.set('RATBAGD_API_VERSION', ratbagd_api_version)
 config_piper.set('devel', '')
 
 config_piper_devel = config_piper

--- a/piper.in
+++ b/piper.in
@@ -43,5 +43,5 @@ if __name__ == "__main__":
     gettext.textdomain('piper')
 
     signal.signal(signal.SIGINT, signal.SIG_DFL)
-    exit_status = Application().run(sys.argv)
+    exit_status = Application(@RATBAGD_API_VERSION@).run(sys.argv)
     sys.exit(exit_status)

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -62,6 +62,18 @@ class RatbagErrorCode(IntEnum):
     IMPLEMENTATION = -1004
 
 
+class RatbagdIncompatible(Exception):
+    """ratbagd is incompatible with this client"""
+    def __init__(self, ratbagd_version, required_version):
+        super().__init__()
+        self.ratbagd_version = ratbagd_version
+        self.required_version = required_version
+        self.message = "ratbagd API version is {} but we require {}".format(ratbagd_version, required_version)
+
+    def __str__(self):
+        return self.message
+
+
 class RatbagdUnavailable(Exception):
     """Signals DBus is unavailable or the ratbagd daemon is not available."""
     pass
@@ -196,7 +208,7 @@ class _RatbagdDBus(GObject.GObject):
         # Calls a method synchronously on the bus, using the given method name,
         # type signature and values.
         #
-        # It the result is valid, it is returned. Invalid results raise the
+        # If the result is valid, it is returned. Invalid results raise the
         # appropriate RatbagError* or RatbagdDBus* exception, or GLib.Error if
         # it is an unexpected exception that probably shouldn't be passed up to
         # the UI.
@@ -238,11 +250,13 @@ class Ratbagd(_RatbagdDBus):
             (GObject.SignalFlags.RUN_FIRST, None, ()),
     }
 
-    def __init__(self):
+    def __init__(self, api_version):
         super().__init__("Manager", None)
         result = self._get_dbus_property("Devices") or []
         self._devices = [RatbagdDevice(objpath) for objpath in result]
         self._proxy.connect("notify::g-name-owner", self._on_name_owner_changed)
+        if self.api_version != api_version:
+            raise RatbagdIncompatible(self.api_version or -1, api_version)
 
     def _on_name_owner_changed(self, *kwargs):
         self.emit("daemon-disappeared")
@@ -260,6 +274,10 @@ class Ratbagd(_RatbagdDBus):
                     self._devices.remove(device)
                     self.emit("device-removed", device)
             self.notify("devices")
+
+    @GObject.Property
+    def api_version(self):
+        return self._get_dbus_property("APIVersion")
 
     @GObject.Property
     def devices(self):


### PR DESCRIPTION
This should get rid of (or at least clarify) the many many issues we see where ratbagd and piper talk different APIs and then one of them gets confused or blows up. This is supposed to be a temporary fix until we have the stable DBus API but temporary has a new meaning when things take years.


This depends on https://github.com/libratbag/libratbag/pull/775