### PR TITLE
data: drop Jente's name from the maintainers

### DIFF
--- a/data/ui/AboutDialog.ui.in
+++ b/data/ui/AboutDialog.ui.in
@@ -12,7 +12,6 @@
     <property name="website">@url@</property>
     <property name="website_label" translatable="yes">Visit Piper’s website</property>
     <property name="authors">Maintainers:
-    Jente Hidskes &lt;hjdskes@gmail.com&gt;
     Peter Hutterer &lt;peter.hutterer@who-t.net&gt;
 
     <!--  Contributor list: git log | git shortlog \-\-summary | cut -f2 -->


### PR DESCRIPTION
Jente has indicated that he doesn't find the time to keep maintaining piper.
Let's remove him from the maintainer list, primarily to save him some
misguided emails.