### PR TITLE
meson.build: use a custom message for a missing python3 dependency

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project('piper',
 	version: '0.3',
 	license: 'GPLv2',
-	meson_version: '>= 0.42.0')
+	meson_version: '>= 0.50.0')
 # The tag date of the project_version(), update when the version bumps.
 version_date='2019-08-02'
 
@@ -12,7 +12,8 @@ ratbagd_api_version = 1
 
 
 # Dependencies
-dependency('python3', required: true)
+dependency('python3', required: true,
+           not_found_message: 'python3 development package missing (try python3-devel or python3-dev)')
 dependency('pygobject-3.0', required: true)
 ratbagd = find_program('ratbagd', required: false)
 ratbagd_required_version='0.10'


### PR DESCRIPTION
It's confusing to users because our dependency is the python3 development
package, not the normal python3 package. Let's use a custom message here to
avoid further bug reports about this.