### PR TITLE
python development package not necessary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,8 +2,8 @@
 
 piper_references:
   build_dependencies: &build_dependencies
-    FEDORA_RPMS: meson gettext python3-devel pygobject3-devel python3-lxml libratbag-ratbagd python3-cairo python3-evdev python3-flake8 gtk-update-icon-cache
-    UBUNTU_DEBS: meson pkg-config gettext python3-dev python-gi-dev python3-lxml python3-evdev gir1.2-rsvg-2.0 python3-gi-cairo python3-flake8 ratbagd gtk-update-icon-cache
+    FEDORA_RPMS: meson gettext python3 pygobject3-devel python3-lxml libratbag-ratbagd python3-cairo python3-evdev python3-flake8 gtk-update-icon-cache
+    UBUNTU_DEBS: meson pkg-config gettext python3 python-gi-dev python3-lxml python3-evdev gir1.2-rsvg-2.0 python3-gi-cairo python3-flake8 ratbagd gtk-update-icon-cache
 
   default_settings: &default_settings
     working_directory: ~/piper

--- a/meson.build
+++ b/meson.build
@@ -12,7 +12,6 @@ ratbagd_api_version = 1
 
 
 # Dependencies
-dependency('python3', required: true)
 dependency('pygobject-3.0', required: true)
 ratbagd = find_program('ratbagd', required: false)
 ratbagd_required_version='0.10'


### PR DESCRIPTION
Package builds fine without development dependencies since the build process only runs ordinary python scripts. This would also make #421 unnecessary.