### PR TITLE
check-svg: adjust width and height ranges

### DIFF
--- a/data/svgs/check-svg.py
+++ b/data/svgs/check-svg.py
@@ -31,9 +31,9 @@ class SVGLogger(logging.Logger):
 def check_size(root):
     width = float(root.attrib['width'])
     height = float(root.attrib['height'])
-    if not 400 < width < 500:
+    if not 400 <= width <= 500:
         logger.error("Width is outside of range: {}".format(width))
-    if not 400 < height < 500:
+    if not 400 <= height <= 500:
         logger.error("Height is outside of range: {}".format(height))
 
 


### PR DESCRIPTION
According to the readme height and width values from 400 to 500 are allowed, but `check-svg.py` only allows values between those to values. This PR fixes this behavior.

Signed-off-by: Stephan Lachnit <stephanlachnit@protonmail.com>