### PR TITLE
Make builds reproduceable

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -4,11 +4,8 @@ desktopdir = join_paths(datadir, 'applications')
 icondir = join_paths(datadir, 'icons', 'hicolor', 'scalable', 'apps')
 metainfodir = join_paths(datadir, 'metainfo')
 
-date = run_command('date', '+%Y')
-
 conf = configuration_data()
 conf.set('version', meson.project_version())
-conf.set('year', date.stdout().strip())
 conf.set('url', 'https://github.com/libratbag/piper')
 conf.set('version_date', version_date)
 

--- a/data/ui/AboutDialog.ui.in
+++ b/data/ui/AboutDialog.ui.in
@@ -8,7 +8,6 @@
     <property name="type_hint">normal</property>
     <property name="program_name">Piper</property>
     <property name="version">@version@</property>
-    <property name="copyright">Copyright © @year@ Piper Developers</property>
     <property name="website">@url@</property>
     <property name="website_label" translatable="yes">Visit Piper’s website</property>
     <property name="translator_credits" translatable="yes">translator-credits</property>


### PR DESCRIPTION
The Debian package tracker [noticed](https://tests.reproducible-builds.org/debian/rb-pkg/unstable/amd64/diffoscope-results/piper.html) that the builds are not reproduceable, meaning they can change under certain scenarios. I checked it and it is the copyright year in the AboutDialog, which was set to change dynamically in f2a9e5d8bbf30360ea207a4859573ef2f1b0470f. While it sounds like a good idea to not put it in the file, an old version shouldn't have a copyright note which is never than the actual release date in my opinion. I put the `copyright_years` variable below the `version_date` variable so it won't get forgotten in new releases.