### PR TITLE
AboutDialog: miscm improvements

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -6,7 +6,6 @@ metainfodir = join_paths(datadir, 'metainfo')
 
 conf = configuration_data()
 conf.set('version', meson.project_version())
-conf.set('url', 'https://github.com/libratbag/piper')
 conf.set('version_date', version_date)
 
 about_dialog = configure_file(input: 'ui/AboutDialog.ui.in',

--- a/data/ui/AboutDialog.ui.in
+++ b/data/ui/AboutDialog.ui.in
@@ -7,9 +7,9 @@
     <property name="modal">True</property>
     <property name="type_hint">normal</property>
     <property name="program_name">Piper</property>
-    <property name="version">@version@</property>
-    <property name="website">@url@</property>
-    <property name="website_label" translatable="yes">Visit Piper’s website</property>
+    <property name="version" translatable="yes">Version: @version@</property>
+    <property name="website">https://github.com/libratbag/piper</property>
+    <property name="website_label" translatable="yes">Visit Piper on GitHub</property>
     <property name="translator_credits" translatable="yes">translator-credits</property>
     <property name="logo_icon_name">org.freedesktop.Piper</property>
     <property name="license_type">gpl-2-0</property>


### PR DESCRIPTION
Adds more readable version string.
More representative website label.
Also fixes translations against commit b02460028568c9f03b752e095264af87450badae.