### PR TITLE
dbus: more gracefully handle permission when connecting to the daemon

### DIFF
--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -252,11 +252,13 @@ class Ratbagd(_RatbagdDBus):
 
     def __init__(self, api_version):
         super().__init__("Manager", None)
-        result = self._get_dbus_property("Devices") or []
-        self._devices = [RatbagdDevice(objpath) for objpath in result]
-        self._proxy.connect("notify::g-name-owner", self._on_name_owner_changed)
+        result = self._get_dbus_property("Devices")
+        if result is None and not self._proxy.get_cached_property_names():
+            raise RatbagdUnavailable("Make sure it is running and your user is in the required groups.")
         if self.api_version != api_version:
             raise RatbagdIncompatible(self.api_version or -1, api_version)
+        self._devices = [RatbagdDevice(objpath) for objpath in result or []]
+        self._proxy.connect("notify::g-name-owner", self._on_name_owner_changed)
 
     def _on_name_owner_changed(self, *kwargs):
         self.emit("daemon-disappeared")

--- a/piper/window.py
+++ b/piper/window.py
@@ -52,7 +52,7 @@ class Window(Gtk.ApplicationWindow):
             ratbag = init_ratbagd_cb()
         except RatbagdUnavailable:
             self._present_error_perspective(_("Cannot connect to ratbagd"),
-                                            _("Please make sure ratbagd is running"))
+                                            _("Please make sure ratbagd is running and your user is in the required group"))
             return
         except RatbagdIncompatible as e:
             self._present_error_perspective(_("Incompatible ratbagd API version (required: {}, provided: {})".format(e.required_version, e.ratbagd_version)),


### PR DESCRIPTION
This addresses issue libratbag/libratbag/#802 reported for libratbag by porting over the solution implemented in libratbag and adjusting the UI error message to hint at the potential permission issue.