### PR TITLE
data: fix some appstream warnings

### DIFF
--- a/data/org.freedesktop.Piper.appdata.xml.in.in
+++ b/data/org.freedesktop.Piper.appdata.xml.in.in
@@ -4,7 +4,7 @@
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-2.0+</project_license>
   <content_rating type="oars-1.0" />
-  <name>Piper</name>
+  <name translatable="no">Piper</name>
   <summary>Configurable mouse configuration utility</summary>
   <description>
     <p>
@@ -19,12 +19,6 @@
       installed and running when Piper is launched.
     </p>
   </description>
-
-  <kudos>
-    <kudo>AppMenu</kudo>
-    <kudo>HiDpiIcon</kudo>
-    <kudo>ModernToolkit</kudo>
-  </kudos>
 
   <launchable type="desktop-id">org.freedesktop.Piper.desktop</launchable>
 
@@ -46,7 +40,6 @@
   <url type="homepage">https://github.com/libratbag/piper/</url>
   <url type="bugtracker">https://github.com/libratbag/piper/issues</url>
   <url type="help">https://github.com/libratbag/piper/wiki</url>
-  <project_group>GNOME</project_group>
 
   <translation type="gettext">piper</translation>
 


### PR DESCRIPTION
Before:
```
appstreamcli validate --pedantic data/org.freedesktop.Piper.appdata.xml.in.in
I: org.freedesktop.Piper:23: nonstandard-gnome-extension kudos
I: org.freedesktop.Piper:3: cid-missing-affiliation-gnome org.freedesktop.Piper
W: org.freedesktop.Piper:58: invalid-iso8601-date @version_date@

Validation failed: warnings: 1, infos: 2
```

After:
```
appstreamcli validate --pedantic data/org.freedesktop.Piper.appdata.xml.in.in
W: org.freedesktop.Piper:51: invalid-iso8601-date @version_date@

Validation failed: warnings: 1
```

I also marked "Piper" as non-translatable.