### PR TITLE
Use SPDX 3.0 license identifiers

### DIFF
--- a/data/org.freedesktop.Piper.appdata.xml.in.in
+++ b/data/org.freedesktop.Piper.appdata.xml.in.in
@@ -2,7 +2,7 @@
 <component type="desktop-application">
   <id>org.freedesktop.Piper</id>
   <metadata_license>FSFAP</metadata_license>
-  <project_license>GPL-2.0+</project_license>
+  <project_license>GPL-2.0-or-later</project_license>
   <content_rating type="oars-1.0" />
   <name>Piper</name>
   <summary>Configurable mouse configuration utility</summary>

--- a/meson.build
+++ b/meson.build
@@ -1,6 +1,6 @@
 project('piper',
     version: '0.4',
-    license: 'GPLv2',
+    license: 'GPL-2.0-or-later',
     meson_version: '>= 0.42.0')
 # The tag date of the project_version(), update when the version bumps.
 version_date='2020-02-09'


### PR DESCRIPTION
`GPL-2.0+` is deprecated, the SPDX recommends using `GPL-2.0-or-later` instead. Reference: https://spdx.org/licenses/ (at the bottom).