### PR TITLE
meson: remove runtime dependency checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,24 +14,22 @@ piper_references:
   build_default: &build_default
     name: Build
     command: |
-      rm -rf build
-      meson build ${MESON_PARAMS}
-      meson configure build
-      ninja -v -C build ${NINJA_ARGS}
-    environment:
-      MESON_PARAMS: --prefix=/usr
+      rm -rf builddir
+      meson builddir --prefix=/usr -Druntime-dependency-checks=false ${MESON_PARAMS}
+      meson configure builddir
+      ninja -v -C builddir ${NINJA_ARGS}
   build_buildtype_plain: &build_buildtype_plain
     run:
       <<: *build_default
       name: Build with buildtype plain
       environment:
-        MESON_PARAMS: --prefix=/usr -Dbuildtype=plain
+        MESON_PARAMS: -Dbuildtype=plain
   build_buildtype_release: &build_buildtype_release
     run:
       <<: *build_default
       name: Build with buildtype release
       environment:
-        MESON_PARAMS: --prefix=/usr -Dbuildtype=release
+        MESON_PARAMS: -Dbuildtype=release
   build_and_test: &build_and_test
     run:
       <<: *build_default
@@ -41,7 +39,7 @@ piper_references:
   install: &install
     run:
       name: Installing
-      command: ninja -C build install
+      command: ninja -C builddir install
   export_logs: &export_logs
     store_artifacts:
       path: ~/piper/build/meson-logs

--- a/meson.build
+++ b/meson.build
@@ -11,34 +11,52 @@ version_date='2020-06-22'
 ratbagd_api_version = 1
 
 
-# Dependencies
-dependency('pygobject-3.0', required: true)
-ratbagd = find_program('ratbagd', required: false)
-ratbagd_required_version='0.14'
+# Options
+enable_runtime_dependency_checks = get_option('runtime-dependency-checks')
+enable_tests = get_option('tests')
 
-if not ratbagd.found()
-    message('''
-    *********************** WARNING **********************
-    * _???_     Dependency libratbag not found in $PATH! *
-    *(_)_(_)    ratbagd must be installed and running    *
-    * (o o)     for Piper to work.                       *
-    *==\o/==                                             *
-    ******************************************************
-    ''')
-else
-    r = run_command(ratbagd, '--version')
-    if r.returncode() != 0 or r.stdout().version_compare('<' + ratbagd_required_version)
-    message('''
-    *********************** WARNING ****************************
-    *                 (   )(                                   *
-    *         (\-.     ) (  )    ratbagd found in $PATH is too *
-    *         / _`> .---------.  old and  will  not  work with *
-    * _)     / _)=  |'-------'|  this version of Piper. Please *
-    *(      / _/    |O   O   o|  update libratbag/ratbagd.     *
-    * `-.__(___)_   | o O . o |                                *
-    ************************************************************
-    ''')
+# Dependencies
+if enable_runtime_dependency_checks
+    ratbagd = find_program('ratbagd', required: true)
+    ratbagd_required_version='0.14'
+
+    if not ratbagd.found()
+        message('''
+        ************************ ERROR ***********************
+        * _???_     Dependency libratbag not found in $PATH! *
+        *(_)_(_)    ratbagd must be installed and running    *
+        * (o o)     for Piper to work.                       *
+        *==\o/==                                             *
+        ******************************************************
+        ''')
+    else
+        r = run_command(ratbagd, '--version')
+        if r.returncode() != 0 or r.stdout().version_compare('<' + ratbagd_required_version)
+        error('''
+        ************************ ERROR *****************************
+        *                 (   )(                                   *
+        *         (\-.     ) (  )    ratbagd found in $PATH is too *
+        *         / _`> .---------.  old and  will  not  work with *
+        * _)     / _)=  |'-------'|  this version of Piper. Please *
+        *(      / _/    |O   O   o|  update libratbag/ratbagd.     *
+        * `-.__(___)_   | o O . o |                                *
+        ************************************************************
+        ''')
+        endif
     endif
+
+    # external python modules that are required for running piper
+    python_modules = [
+        'lxml',
+        'evdev',
+        'cairo',
+        'gi',
+    ]
+
+    dependency('pygobject-3.0', required: true)
+else
+    # external python modules that are required for building piper
+    python_modules = ['lxml']
 endif
 
 # Gtk version required
@@ -52,8 +70,6 @@ pkgdatadir = join_paths(datadir, meson.project_name())
 bindir = join_paths(prefix, get_option('bindir'))
 podir = join_paths(meson.source_root(), 'po')
 mandir = join_paths(prefix, get_option('mandir'))
-
-enable_tests = get_option('tests')
 
 i18n = import('i18n')
 
@@ -71,13 +87,6 @@ if meson.version().version_compare('<0.48.0')
     endif
 else
     pymod = import('python')
-    # external python modules that are required for running piper
-    python_modules = [
-        'lxml',
-        'evdev',
-        'cairo',
-        'gi',
-    ]
     if meson.version().version_compare('>=0.51')
         py3 = pymod.find_installation(modules: python_modules)
     else

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -2,3 +2,8 @@ option('tests',
 	type: 'boolean',
 	value: true,
 	description: 'Run the tests (default=yes)')
+
+option('runtime-dependency-checks',
+	type: 'boolean',
+	value: true,
+	description: 'Check for runtime dependencies during installation (default=yes)')


### PR DESCRIPTION
I want to remove all runtime dependency checks for Piper in Meson, that aren't actually required to build/install Piper.
The reasoning is pretty obvious: the build environment might not be the use environment in a lot of scenarios. For example, in Debian the package is created from a build server, that never runs Piper, however it still needs the Python `gi` module etc, which consumes unnecessary build time and should be avoided.
It also reduces the CI runtimes.