### PR TITLE
data: add man page

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -3,10 +3,22 @@ gnome = import('gnome')
 desktopdir = join_paths(datadir, 'applications')
 icondir = join_paths(datadir, 'icons', 'hicolor', 'scalable', 'apps')
 metainfodir = join_paths(datadir, 'metainfo')
+man1dir = join_paths(mandir, 'man1')
 
 conf = configuration_data()
 conf.set('version', meson.project_version())
 conf.set('version_date', version_date)
+
+manpage = configure_file(
+     input: files('piper.1.in'),
+     output: 'piper.1',
+     configuration: conf,
+)
+
+install_man(
+     manpage,
+     install_dir: man1dir,
+)
 
 about_dialog = configure_file(input: 'ui/AboutDialog.ui.in',
                               output: 'AboutDialog.ui',

--- a/data/piper.1.in
+++ b/data/piper.1.in
@@ -1,0 +1,13 @@
+.TH PIPER 1 "@version_date@" "@version@" "User Commands"
+.SH NAME
+Piper \- GTK application to configure gaming devices
+.SH DESCRIPTION
+.SS "Usage:"
+.IP
+piper [OPTION]
+.SS "Help Options:"
+.TP
+\fB\-h\fR, \fB\-\-help\fR
+Show help options
+.SH "SEE ALSO"
+ratbagctl(1), ratbagd(8)

--- a/meson.build
+++ b/meson.build
@@ -51,6 +51,7 @@ localedir = join_paths(prefix, get_option('localedir'))
 pkgdatadir = join_paths(datadir, meson.project_name())
 bindir = join_paths(prefix, get_option('bindir'))
 podir = join_paths(meson.source_root(), 'po')
+mandir = join_paths(prefix, get_option('mandir'))
 
 i18n = import('i18n')
 


### PR DESCRIPTION
Every program should have a man page, even if it doesn't have a cli. ~~Theoretically I would add a "See also" section pointing to a man page for ratbagd, but it doesn't exist^^ (yet)~~

Can be tested with `man -l builddir/data/piper.1`.