### PR TITLE
flake8 fix + arch CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ piper_references:
   build_dependencies: &build_dependencies
     FEDORA_RPMS: meson gettext python3 pygobject3-devel python3-lxml libratbag-ratbagd python3-cairo python3-evdev python3-flake8 gtk-update-icon-cache
     UBUNTU_DEBS: meson pkg-config gettext python3 python-gi-dev python3-lxml python3-evdev gir1.2-rsvg-2.0 python3-gi-cairo flake8 ratbagd gtk-update-icon-cache
-    ARCH_PKGS: meson libratbag  python-cairo python-evdev python-gobject python-lxml gtk-update-icon-cache
+    ARCH_PKGS: meson libratbag python-cairo python-evdev python-gobject python-lxml gtk-update-icon-cache flake8
 
   default_settings: &default_settings
     working_directory: ~/piper

--- a/meson.build
+++ b/meson.build
@@ -123,7 +123,7 @@ configure_file(input: 'piper.in',
 meson.add_install_script('meson_install.sh')
 
 if enable_tests
-    flake8 = find_program('flake8', required: false)
+    flake8 = find_program('flake8')
     if flake8.found()
         test('flake8', flake8,
              args: ['--ignore=E501,W504',

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -195,7 +195,7 @@ class _RatbagdDBus(GObject.GObject):
         # args to .Set are "interface name", "function name",  value-variant
         val = GLib.Variant("{}".format(type), value)
         if readwrite:
-            pval = GLib.Variant("(ssv)".format(type), (self._interface, property, val))
+            pval = GLib.Variant("(ssv)", (self._interface, property, val))
             self._proxy.call_sync("org.freedesktop.DBus.Properties.Set",
                                   pval, Gio.DBusCallFlags.NO_AUTO_START,
                                   2000, None)


### PR DESCRIPTION
Fix for https://github.com/libratbag/libratbag/issues/1017.

Looking at the code, the documentation is thankfully very helpful. First we want to know the type to convert it into a variant, to then send a `string+string+variant` via DBus, so the second format is useless.
Regarding the other commits, see #548.