### PR TITLE
meson: add test for appdata file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,9 +2,9 @@
 
 piper_references:
   build_dependencies: &build_dependencies
-    FEDORA_RPMS: meson gettext python3 pygobject3-devel python3-lxml libratbag-ratbagd python3-cairo python3-evdev python3-flake8 gtk-update-icon-cache
-    UBUNTU_DEBS: meson pkg-config gettext python3 python-gi-dev python3-lxml python3-evdev gir1.2-rsvg-2.0 python3-gi-cairo flake8 ratbagd gtk-update-icon-cache
-    ARCH_PKGS: meson libratbag python-cairo python-evdev python-gobject python-lxml gtk-update-icon-cache flake8
+    FEDORA_RPMS: meson gettext python3 pygobject3-devel python3-lxml libratbag-ratbagd python3-cairo python3-evdev python3-flake8 gtk-update-icon-cache appstream
+    UBUNTU_DEBS: meson pkg-config gettext python3 python-gi-dev python3-lxml python3-evdev gir1.2-rsvg-2.0 python3-gi-cairo flake8 ratbagd gtk-update-icon-cache appstream
+    ARCH_PKGS: meson libratbag python-cairo python-evdev python-gobject python-lxml gtk-update-icon-cache flake8 appstream
 
   default_settings: &default_settings
     working_directory: ~/piper

--- a/data/meson.build
+++ b/data/meson.build
@@ -37,13 +37,21 @@ appdata = configure_file(input: 'org.freedesktop.Piper.appdata.xml.in.in',
                          output: 'org.freedesktop.Piper.appdata.xml.in',
                          configuration: conf)
 
-i18n.merge_file(input: appdata,
-                output: 'org.freedesktop.Piper.appdata.xml',
-                type: 'xml',
-                po_dir: podir,
-                install: true,
-                install_dir: metainfodir)
+appdata = i18n.merge_file(input: appdata,
+                          output: 'org.freedesktop.Piper.appdata.xml',
+                          type: 'xml',
+                          po_dir: podir,
+                          install: true,
+                          install_dir: metainfodir)
 
+if enable_tests
+    appstreamcli = find_program('appstreamcli')
+    if appstreamcli.found()
+        test('validate appdata file',
+            appstreamcli,
+            args: ['validate', '--no-net', '--pedantic', appdata])
+     endif
+endif
 
 # SVG files
 


### PR DESCRIPTION
Currently the test gives an informational warning (doesn't fail):
```
I: org.freedesktop.Piper:3: cid-contains-uppercase-letter org.freedesktop.Piper
    The component ID should only contain lowercase letters.
```

We might want to change the rDNS to `io.github.libratbag.piper`, as it is suggested by https://www.freedesktop.org/software/appstream/metainfocreator. Having a "wrong" url is a bad idea anyway since it might be possible some project on freedesktop.org will call itself Piper and use it as well (unlikely though).
I do heard that changing the component ID is potentially breaking so I'm not sure if we actually want to that (I have no idea though, but I can imagine something like ratings in the store).