### PR TITLE
data: add Logitech M720 bluetooth ID from libratbagd to svg

### DIFF
--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -127,7 +127,7 @@ DeviceMatch=usb:046d:c088;usb:046d:4079
 Svg=logitech-g-pro-wireless.svg
 
 [Logitech M720]
-DeviceMatch=usb:046d:405e
+DeviceMatch=usb:046d:405e;bluetooth:046d:b015
 Svg=logitech-m720.svg
 
 [Logitech MX518]


### PR DESCRIPTION
This allows the svg to show up when the M720 is connected via bluetooth