### PR TITLE
tests: check-svg: have no minimum required button count

### DIFF
--- a/data/svgs/check-svg.py
+++ b/data/svgs/check-svg.py
@@ -100,7 +100,7 @@ def check_leds(root):
 
 
 def check_buttons(root):
-    check_elements(root, "button", 3)
+    check_elements(root, "button")
 
 
 def check_svg(path):


### PR DESCRIPTION
I was hoping to be able to come around to this and refactor the test to introduce device types, but I haven't been able to. So just disable the minimum button count so that we can move #555 forward.