### PR TITLE
ci: temporarily disable arch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -147,4 +147,4 @@ workflows:
     jobs:
       - ubuntu_20_04
       - fedora_31
-      - arch
+#      - arch


### PR DESCRIPTION
See https://github.com/libratbag/libratbag/commit/3f99446a1be984b78eac60e47bfd66e1c674e30c

Signed-off-by: Filipe Laíns <lains@riseup.net>