### PR TITLE
Add second second USB ID for Logitech MX Vertical

### DIFF
--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -175,7 +175,7 @@ DeviceMatch=usb:046d:4041;bluetooth:046d:b012;usb:046d:4060;bluetooth:046d:b017;
 Svg=logitech-mx-master.svg
 
 [Logitech MX Vertical]
-DeviceMatch=bluetooth:046d:b020;usb:046d:407b
+DeviceMatch=bluetooth:046d:b020;usb:046d:407b;usb:046d:c08a
 Svg=logitech-mx-vertical.svg
 
 [Roccat Kone Pure]


### PR DESCRIPTION
The Logitech MX vertical can also be identified by this USB ID

Output of `lsusb`: 
```
Bus 001 Device 006: ID 046d:c08a Logitech, Inc. MX Vertical Advanced Ergonomic Mouse
```