### PR TITLE
Modern way to handle post-installation actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,7 +6,7 @@ env:
   UBUNTU_DEPS: |
       pkg-config gettext appstream
       python3 python-gi-dev python3-lxml python3-evdev
-      gir1.2-rsvg-2.0 python3-gi-cairo flake8 gtk-update-icon-cache
+      gir1.2-rsvg-2.0 python3-gi-cairo flake8 gtk-update-icon-cache desktop-file-utils
   PIP_PACKAGES: meson ninja
 
 jobs:

--- a/meson.build
+++ b/meson.build
@@ -109,7 +109,14 @@ configure_file(input: 'piper.in',
                output: 'piper.devel',
                configuration: config_piper_devel)
 
-meson.add_install_script('meson_install.sh')
+if meson.version().version_compare('>=0.59.0')
+    gnome.post_install(
+        gtk_update_icon_cache: true,
+        update_desktop_database: true
+    )
+else
+    meson.add_install_script('meson_install.sh')
+endif
 
 if enable_tests
     flake8 = find_program('flake8')

--- a/meson_install.sh
+++ b/meson_install.sh
@@ -5,6 +5,9 @@ if [ -z $DESTDIR ]; then
 
     # Update icon cache
     gtk-update-icon-cache -f -t $PREFIX/share/icons/hicolor
+    
+    # Update desktop database cache
+    update-desktop-database
 
     # Install new schemas
     #glib-compile-schemas $PREFIX/share/glib-2.0/schemas/


### PR DESCRIPTION
Introduced a new option `-Dscripts` for packaged builds.

Will be very useful in downstream packaging, because Koji/OBS shouldn't run `gtk-update-icon-cache` during the package build.