### PR TITLE
Replace Quit buttons with normal close buttons

### DIFF
--- a/data/ui/ErrorPerspective.ui
+++ b/data/ui/ErrorPerspective.ui
@@ -68,15 +68,7 @@
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Uh Oh! Something went wrong…</property>
     <property name="has_subtitle">False</property>
-    <child>
-      <object class="GtkButton">
-        <property name="label" translatable="yes">Quit</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
-        <signal name="clicked" handler="_on_quit_button_clicked" swapped="no"/>
-      </object>
-    </child>
+    <property name="show_close_button">True</property>
     <style>
       <class name="titlebar"/>
     </style>

--- a/data/ui/WelcomePerspective.ui
+++ b/data/ui/WelcomePerspective.ui
@@ -118,15 +118,7 @@
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Select a Device</property>
     <property name="has_subtitle">False</property>
-    <child>
-      <object class="GtkButton">
-        <property name="label" translatable="yes">Quit</property>
-        <property name="visible">True</property>
-        <property name="can_focus">True</property>
-        <property name="receives_default">True</property>
-        <signal name="clicked" handler="_on_quit_button_clicked" swapped="no"/>
-      </object>
-    </child>
+    <property name="show_close_button">True</property>
     <style>
       <class name="titlebar"/>
     </style>

--- a/piper/errorperspective.py
+++ b/piper/errorperspective.py
@@ -61,8 +61,3 @@ class ErrorPerspective(Gtk.Box):
         @param message The detail message to display, as str.
         """
         self.label_detail.set_label(detail)
-
-    @GtkTemplate.Callback
-    def _on_quit_button_clicked(self, button):
-        window = button.get_toplevel()
-        window.destroy()

--- a/piper/welcomeperspective.py
+++ b/piper/welcomeperspective.py
@@ -5,7 +5,7 @@ from .gi_composites import GtkTemplate
 
 import gi
 gi.require_version("Gtk", "3.0")
-from gi.repository import GObject, Gtk, Gdk  # noqa
+from gi.repository import GObject, Gtk  # noqa
 
 
 @GtkTemplate(ui="/org/freedesktop/Piper/ui/WelcomePerspective.ui")
@@ -75,13 +75,6 @@ class WelcomePerspective(Gtk.Box):
     def can_shutdown(self):
         """Whether this perspective can safely shutdown."""
         return True
-
-    @GtkTemplate.Callback
-    def _on_quit_button_clicked(self, button):
-        window = button.get_toplevel()
-
-        if not window.emit("delete-event", Gdk.Event.new(Gdk.EventType.DELETE)):
-            window.destroy()
 
     @GtkTemplate.Callback
     def _on_device_row_activated(self, listbox, row):


### PR DESCRIPTION
Using a Quit button is an anti-pattern and might be confusing for users
expecting the quit button to be on the same position as of other apps'.

Note that the button is on the left and by default the close button is
on the right.

![image](https://user-images.githubusercontent.com/11528996/183034164-675755de-14ec-4da9-8604-ef7f53dced82.png)
