### PR TITLE
Add Support for G502 X over USB

### DIFF
--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -50,6 +50,10 @@ Svg=logitech-g500s.svg
 DeviceMatch=usb:046d:c098
 Svg=logitech-g502-x.svg
 
+[Logitech G502 X]
+DeviceMatch=usb:046d:c099
+Svg=logitech-g502-x.svg
+
 [Logitech G502 Hero Wireless]
 DeviceMatch=usb:046d:407f;usb:046d:c08d
 Svg=logitech-g502.svg


### PR DESCRIPTION
Just received my G502 X and saw it is not yet supported. Luckily https://github.com/libratbag/piper/pull/788 already added the image, so this trivial change made the mouse usable in Piper.