### PR TITLE
ci: bump the test image to Ubuntu 22.04

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ env:
 
 jobs:
   build-and-dist:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         meson_args:


### PR DESCRIPTION
Might as well use something recent


May or may not help with the flake8 issues in #769 