### PR TITLE
CI: bump some actions to newer versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
           - '-Druntime-dependency-checks=false -Dbuildtype=plain'
           - '-Druntime-dependency-checks=false -Dbuildtype=release'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: libratbag/libratbag/.github/actions/pkginstall@master
         with:
           apt: $UBUNTU_DEPS
@@ -39,7 +39,7 @@ jobs:
       - name: list any files left after uninstall
         run: (test -d _instdir && tree _instdir) || exit 0
       # Capture all the meson logs, even if we failed
-      - uses: actions/upload-artifact@v2
+      - uses: actions/upload-artifact@v3
         if: ${{ always() }}  # even if we fail
         with:
           name: meson test logs


### PR DESCRIPTION
Node 12 is deprecated so let's bump the actions to newer versions that use Node 16. See https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/