### PR TITLE
Don't show report rate selection box if the device doesn't support it

### DIFF
--- a/data/ui/ResolutionsPage.ui
+++ b/data/ui/ResolutionsPage.ui
@@ -54,7 +54,7 @@
                       </packing>
                     </child>
                     <child>
-                      <object class="GtkButtonBox">
+                      <object class="GtkButtonBox" id="rate_button_box">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="tooltip_text" translatable="yes">Change the profile’s report rate</property>

--- a/piper/resolutionspage.py
+++ b/piper/resolutionspage.py
@@ -73,10 +73,10 @@ class ResolutionsPage(Gtk.Box):
             row = ResolutionRow(self._device, resolution)
             self.listbox.insert(row, resolution.index)
 
-        self.rate_125.set_visible(125 in profile.report_rates)
-        self.rate_250.set_visible(250 in profile.report_rates)
-        self.rate_500.set_visible(500 in profile.report_rates)
-        self.rate_1000.set_visible(1000 in profile.report_rates)
+        self.rate_125.set_sensitive(125 in profile.report_rates)
+        self.rate_250.set_sensitive(250 in profile.report_rates)
+        self.rate_500.set_sensitive(500 in profile.report_rates)
+        self.rate_1000.set_sensitive(1000 in profile.report_rates)
 
         # Set the report rate through a manual callback invocation.
         self._on_active_profile_changed(self._device, profile)

--- a/piper/resolutionspage.py
+++ b/piper/resolutionspage.py
@@ -32,6 +32,7 @@ class ResolutionsPage(Gtk.Box):
     rate_250 = GtkTemplate.Child()
     rate_500 = GtkTemplate.Child()
     rate_1000 = GtkTemplate.Child()
+    rate_button_box = GtkTemplate.Child()
     listbox = GtkTemplate.Child()
     add_resolution_row = GtkTemplate.Child()
 
@@ -73,6 +74,9 @@ class ResolutionsPage(Gtk.Box):
             row = ResolutionRow(self._device, resolution)
             self.listbox.insert(row, resolution.index)
 
+        are_report_rates_supported = profile.report_rate != 0 \
+            and len(profile.report_rates) != 0
+        self.rate_button_box.set_sensitive(are_report_rates_supported)
         self.rate_125.set_sensitive(125 in profile.report_rates)
         self.rate_250.set_sensitive(250 in profile.report_rates)
         self.rate_500.set_sensitive(500 in profile.report_rates)


### PR DESCRIPTION
Fixes #834.

FIXME: I also noticed that if active report rate is not one of [125, 250, 500, 1000], the button for 125 would still be active. None should be active if possible.