### PR TITLE
Replace DPI labels with text boxes

### DIFF
--- a/data/ui/ResolutionRow.ui
+++ b/data/ui/ResolutionRow.ui
@@ -21,7 +21,7 @@
                 <property name="visible">True</property>
                 <property name="halign">start</property>
                 <signal name="activate" handler="_on_dpi_entry_activate" swapped="no"/>
-                <signal name="insert-text" handler="_on_insert_dpi_entry_text" swapped="no"/>
+                <signal name="insert-text" handler="_on_dpi_entry_insert_text" swapped="no"/>
               </object>
             </child>
             <child>

--- a/data/ui/ResolutionRow.ui
+++ b/data/ui/ResolutionRow.ui
@@ -20,7 +20,6 @@
               <object class="GtkEntry" id="dpi_entry">
                 <property name="visible">True</property>
                 <property name="halign">start</property>
-                <property name="width-chars">5</property>
                 <signal name="activate" handler="_on_dpi_entry_activate" swapped="no"/>
                 <signal name="insert-text" handler="_on_insert_dpi_entry_text" swapped="no"/>
               </object>

--- a/data/ui/ResolutionRow.ui
+++ b/data/ui/ResolutionRow.ui
@@ -17,11 +17,20 @@
             <property name="border-width">12</property>
             <property name="spacing">6</property>
             <child>
+              <object class="GtkEntry" id="dpi_entry">
+                <property name="visible">True</property>
+                <property name="halign">start</property>
+                <property name="width-chars">5</property>
+                <signal name="activate" handler="_on_dpi_entry_activate" swapped="no"/>
+                <signal name="insert-text" handler="_on_insert_dpi_entry_text" swapped="no"/>
+              </object>
+            </child>
+            <child>
               <object class="GtkLabel" id="dpi_label">
                 <property name="visible">True</property>
                 <property name="can-focus">False</property>
                 <property name="halign">start</property>
-                <property name="label">0 DPI</property>
+                <property name="label">DPI</property>
               </object>
               <packing>
                 <property name="expand">True</property>

--- a/piper/resolutionrow.py
+++ b/piper/resolutionrow.py
@@ -103,8 +103,8 @@ class ResolutionRow(Gtk.ListBoxRow):
 
         return True
 
-    @Gtk.Template.Callback("_on_insert_dpi_entry_text")
-    def _on_insert_dpi_entry_text(self, entry, text, _length, _position):
+    @Gtk.Template.Callback("_on_dpi_entry_insert_text")
+    def _on_dpi_entry_insert_text(self, entry, text, _length, _position):
         # Remove any non-numeric characters from the input
         if not text.isdigit():
             entry.stop_emission("insert-text")

--- a/piper/resolutionrow.py
+++ b/piper/resolutionrow.py
@@ -65,7 +65,7 @@ class ResolutionRow(Gtk.ListBoxRow):
         res_num_chars = len(str(maxres))
 
         # Set the max width and length for the DPI text boxes, based on the max res value.
-        self.dpi_entry.set_size_request(res_num_chars, 1)
+        self.dpi_entry.set_width_chars(res_num_chars)
         self.dpi_entry.set_max_length(res_num_chars)
 
         with self.scale.handler_block(self._scale_handler):
@@ -104,7 +104,7 @@ class ResolutionRow(Gtk.ListBoxRow):
         return True
 
     @Gtk.Template.Callback("_on_insert_dpi_entry_text")
-    def _on_insert_dpi_entry_text(self, entry, text, length, position):
+    def _on_insert_dpi_entry_text(self, entry, text, _length, _position):
         # Remove any non-numeric characters from the input
         if not text.isdigit():
             entry.stop_emission("insert-text")
@@ -117,8 +117,10 @@ class ResolutionRow(Gtk.ListBoxRow):
             # Get the resolution closest to what has been entered
             closest_res = min(self.resolutions, key=lambda x: abs(x - res))
             entry.set_text(str(closest_res))
+
             if closest_res != self.previous_dpi_entry_value:
                 self._on_dpi_values_changed(res=res)
+
             with self.scale.handler_block(self._scale_handler):
                 self.scale.set_value(res)
         except ValueError:
@@ -180,7 +182,7 @@ class ResolutionRow(Gtk.ListBoxRow):
 
     def _on_dpi_values_changed(self, res: Optional[int] = None) -> None:
         # Freeze the notify::resolution signal from firing and
-        # update dpi label and resolution values.
+        # update DPI text box and resolution values.
         if res is None:
             res = self._resolution.resolution[0]
         new_res = (res, res) if self.CAP_SEPARATE_XY_RESOLUTION else (res,)

--- a/piper/resolutionrow.py
+++ b/piper/resolutionrow.py
@@ -51,7 +51,6 @@ class ResolutionRow(Gtk.ListBoxRow):
         connect_signal_with_weak_ref(
             self, resolution, "notify::resolution", self._on_profile_resolution_changed
         )
-        self.dpi_entry.connect("focus-in-event", self._on_entry_focus_in)
 
         # Get resolution capabilities and update internal values.
         if RatbagdResolution.CAP_SEPARATE_XY_RESOLUTION in resolution.capabilities:
@@ -107,10 +106,8 @@ class ResolutionRow(Gtk.ListBoxRow):
     @Gtk.Template.Callback("_on_insert_dpi_entry_text")
     def _on_insert_dpi_entry_text(self, entry, text, length, position):
         # Remove any non-numeric characters from the input
-        new_text = "".join([c for c in text if c.isdigit()])
-        if new_text != text:
+        if not text.isdigit():
             entry.stop_emission("insert-text")
-            entry.insert_text(new_text, len(new_text))
 
     @Gtk.Template.Callback("_on_dpi_entry_activate")
     def _on_dpi_entry_activate(self, entry: Gtk.Entry) -> None:
@@ -127,11 +124,6 @@ class ResolutionRow(Gtk.ListBoxRow):
         except ValueError:
             # If the input is not a valid integer, reset to the current value.
             entry.set_text(str(self._resolution.resolution[0]))
-
-    def _on_entry_focus_in(self, entry, event):
-        # Store previous value
-        self.previous_dpi_entry_value = int(entry.get_text())
-        return False  # Continue handling the event
 
     def _on_disable_button_toggled(self, togglebutton: Gtk.Button) -> None:
         # The disable button has been toggled, update RatbagdResolution.


### PR DESCRIPTION
resolves #423

I've found clicking and dragging the sliders to set DPIs to be a bit finnicky, so I have added GtkEntry objects where the DPI labels would appear. It's a lot faster to change DPIs now (for me, at least).

### Changes

- Text boxes show DPIs that have been previously set
- Text boxes and sliders affect each others' values
- Text box is set to nearest supported DPI if a random value is set
- Text boxes only allow numerical input

### Considerations (things I might need to do?)

- Suppressing `Warning: g_value_get_int: assertion 'G_VALUE_HOLDS_INT (value)' failed` warnings
- Nice tab orders for these input fields?
