### PR TITLE
DeviceMatch updated for g502x wireless dongle

### DIFF
--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -91,7 +91,7 @@ DeviceMatch=usb:046d:c24e
 Svg=logitech-g500s.svg
 
 [Logitech G502 X Wireless]
-DeviceMatch=usb:046d:c098
+DeviceMatch=usb:046d:c098;usb:046d:c547
 Svg=logitech-g502-x.svg
 
 [Logitech G502 X]


### PR DESCRIPTION
Greetings!
A small PR to update the DeviceMatch used for Logitech G502X Wireless dongle.
Change is tested locally to be working. PR to libratbag/libratbag will follow shortly.
```
[kst@shoemaster ~]$ lsusb | grep Logitech
Bus 001 Device 008: ID 046d:c547 Logitech, Inc. USB Receiver
[kst@shoemaster ~]$ ratbagctl list
warbling-mara:       Logitech USB Receiver           
[kst@shoemaster ~]$ ratbagctl warbling-mara info
warbling-mara - Logitech USB Receiver
             Model: usb:046d:c547:0
[...]
```
