### PR TITLE
LedDialog: fix buggy effect duration slider

### DIFF
--- a/piper/leddialog.py
+++ b/piper/leddialog.py
@@ -68,10 +68,9 @@ class LedDialog(Gtk.Dialog):
     def _on_change_value(
         self, scale: Gtk.Scale, scroll: Gtk.ScrollType, value: float
     ) -> bool:
-        # Round the value resulting from a scroll event to the nearest multiple
-        # of 500. This is to work around the Gtk.Scale not snapping to its
-        # Gtk.Adjustment's step_increment.
-        scale.set_value(int(value - (value % 500)))
+        # Work around the Gtk.Scale not snapping to its step increment.
+        step = scale.get_adjustment().get_step_increment()
+        scale.set_value(int(round(value / step) * step))
         return True
 
     def _get_led_color_as_rgba(self) -> Gdk.RGBA:


### PR DESCRIPTION
Get the step increment from the Gtk.Adjustment instead of relying on a magic number (500), which was wrong to begin with (actual value is 100).

Round the received float value to the nearest multiple of the step increment, instead of rounding it down.

This fixes control of the slider through the arrow keys and improves the accuracy of the "step snapping" when clicking the slider.

As a result, the UI now allows the user to pass values with a step (100) instead of page (500) resolution to libratbag but that shouldn't be an issue as drivers are expected to support any integer value within the range 0-10000; see ratbag_led_set_effect_duration().