### PR TITLE
Add developer tag to appdata

### DIFF
--- a/data/org.freedesktop.Piper.appdata.xml.in.in
+++ b/data/org.freedesktop.Piper.appdata.xml.in.in
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <component type="desktop-application">
   <id>org.freedesktop.Piper</id>
+  <developer id="io.github.libratbag">
+    <name>The libratbag Developers</name>
+  </developer>
   <metadata_license>FSFAP</metadata_license>
   <project_license>GPL-2.0-or-later</project_license>
   <content_rating type="oars-1.0" />


### PR DESCRIPTION
As discussed in #992 this adds the developer tag as to adhere to the Flathub guidelines to ensure that upstream Piper builds fine again.