### PR TITLE
Add SVG for  G502X Plus Mouse

### DIFF
--- a/data/svgs/logitech-g502-x-plus.svg
+++ b/data/svgs/logitech-g502-x-plus.svg
@@ -32,7 +32,7 @@
      inkscape:cx="311.25"
      inkscape:cy="253.5"
      inkscape:document-units="px"
-     inkscape:current-layer="LEDs"
+     inkscape:current-layer="Device"
      inkscape:document-rotation="0"
      showgrid="false"
      units="px"
@@ -192,7 +192,7 @@
          sodipodi:nodetypes="cccc" />
       <path
          id="led0"
-         style="color:#000000;display:inline;overflow:visible;vector-effect:none;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         style="color:#000000;display:inline;overflow:visible;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
          d="m 699.83007,597.09532 c 0,0 -16.46015,85.54578 -25.31343,86.37773 -5.47204,7.62655 -75.2405,-7.05854 -83.35928,-8.86308 -4.4067,-3.00486 -10.28788,-1.54967 -13.42666,-11.03417 l -5.4313,1.54016 c 0,0 -4.44322,-4.39177 -3.4609,-2.01303 0.98232,2.37874 4.42788,9.92811 4.88135,10.60457 2.44642,3.64943 5.46761,4.77645 9.87336,6.69341 43.63132,14.22708 86.19514,10.28952 88.44796,19.97257 l 12.28811,52.81677 c 0.43306,-9.81325 9.12954,-1.78785 6.30456,-10.51417 -1.75087,-5.40843 -9.01324,-37.84197 -7.94408,-46.63044 2.13832,-17.57695 7.86233,-29.84721 13.51752,-49.89164 4.1949,-14.86858 8.0422,-47.11406 8.0422,-47.11406 z"
          inkscape:label="led0"
          sodipodi:nodetypes="cccccsscscssscc"

--- a/data/svgs/logitech-g502-x-plus.svg
+++ b/data/svgs/logitech-g502-x-plus.svg
@@ -1,0 +1,563 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="467.83105"
+   height="400.87393"
+   viewBox="0 0 467.83105 398.87393"
+   version="1.1"
+   id="svg8"
+   inkscape:version="1.4 (e7c3feb100, 2024-10-09)"
+   sodipodi:docname="logitech-g502-x-plus.svg"
+   inkscape:export-filename="/home/jimmac/logitech-g403.png"
+   inkscape:export-xdpi="96"
+   inkscape:export-ydpi="96"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
+  <defs
+     id="defs2" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="2"
+     inkscape:cx="311.25"
+     inkscape:cy="253.5"
+     inkscape:document-units="px"
+     inkscape:current-layer="LEDs"
+     inkscape:document-rotation="0"
+     showgrid="false"
+     units="px"
+     borderlayer="true"
+     inkscape:showpageshadow="false"
+     inkscape:pagecheckerboard="false"
+     showguides="false"
+     inkscape:window-width="2048"
+     inkscape:window-height="1211"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     fit-margin-top="20"
+     fit-margin-bottom="20"
+     fit-margin-left="0"
+     fit-margin-right="0"
+     inkscape:deskcolor="#d1d1d1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid956"
+       originx="-16.168953"
+       originy="-1.1260801"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata5">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:groupmode="layer"
+     id="Device"
+     inkscape:label="Device"
+     transform="translate(-16.168953,-400)"
+     style="display:inline">
+    <g
+       transform="translate(-374)"
+       id="g1170"
+       style="display:inline">
+      <path
+         inkscape:connector-curvature="0"
+         id="path981"
+         d="m 618.01948,461.30353 -43.40756,16.61713 c -2.22449,1.86937 -9.89196,5.52668 -10.73884,8.00148 -2.72978,17.00689 -4.95532,37.7841 -10.68613,60.82696 l -3.63304,10.8242 c -1.31838,10.14466 -1.35745,13.02311 -1.6215,20.49577 0,0 -9.25458,13.23407 -12.30377,16.15664 -3.17708,3.04514 -11.63158,73.43883 -8.3723,79.7235 3.25927,6.28467 27.55747,20.31437 30.6627,26.48716 3.10522,6.17279 18.69687,51.65064 25.55826,57.42954 16.34037,13.76242 28.28693,16.1415 28.28693,16.1415 11.17229,2.44441 30.24514,1.07162 39.85805,-1.0925 0,0 22.99271,-6.99651 34.8317,-22.83483 11.83899,-15.83832 17.68801,-34.09035 17.68801,-34.09035 4.26474,-13.18952 5.96862,-28.63873 5.68596,-43.39276 -0.21781,-11.36893 -5.62963,-26.06739 -6.9761,-35.20605 -1.34646,-9.13867 -0.51526,-36.12387 -0.51526,-36.12387 0,0 -4.72162,-66.844 -5.82442,-75.72956 -1.05243,-13.62799 -5.87771,-44.43232 -8.20795,-47.23223 l -40.37177,-24.81119 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#babdb6;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="ccccccsccsccscssccccc" />
+      <path
+         sodipodi:nodetypes="cccccccccc"
+         inkscape:connector-curvature="0"
+         id="path1014"
+         d="m 621.1765,608.93949 0.56913,15.96131 c 2.62858,0.8078 27.61141,-5.27122 27.61141,-5.27122 l 0.33872,-17.51303 50.97039,-12.88689 c 0,0 -16.64625,93.17389 -25.49954,94.00581 -5.47205,7.62657 -77.80091,-6.01406 -85.60718,-10.13108 -5.46919,-1.87988 -10.58371,-3.35469 -13.72252,-12.83918 l -7.46455,-32.35915 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d3d3ce;fill-opacity:1;stroke:#bfc2bb;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         sodipodi:nodetypes="cccsc"
+         inkscape:connector-curvature="0"
+         id="path1144"
+         d="m 684.3037,753.45974 -12.85124,-52.97089 c -1.84536,-9.76893 -47.4674,-6.4526 -91.09872,-20.67969 -3.87538,-1.38662 -4.59934,-2.69099 -7.04573,-6.34042 -0.90693,-1.35292 -4.96721,-11.80863 -4.96721,-11.80863"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         sodipodi:nodetypes="ccssc"
+         inkscape:connector-curvature="0"
+         id="path1030"
+         d="m 540.66953,588.7746 -13.10788,84.24229 c 0,0 -0.19659,5.08168 -3.37796,-4.61975 -2.21399,-6.75144 8.20556,-70.27846 10.81837,-73.76721 2.70718,-3.61475 5.66747,-5.85533 5.66747,-5.85533 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#d9dad7;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button0"
+         d="m 618.45939,461.52603 -44.51847,16.91374 c 0.36504,52.87754 -6.49824,96.39545 1.01001,147.09793 l 46.26742,-16.4844 c 0,0 -3.01333,-56.46772 -2.76309,-82.03474 0.16651,-21.17461 0.16433,-44.31808 0.004,-65.49253 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cccccc"
+         inkscape:label="button0" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button1"
+         d="m 647.96103,453.90927 c 0,0 0.21957,34.50449 1.11654,71.00382 0.89697,36.49932 0.60175,77.20425 0.60175,77.20425 l 50.91252,-12.22056 c 0,0 -3.92931,-42.2843 -5.33531,-61.40186 -1.4061,-19.11755 -5.76735,-47.16259 -8.15495,-50.69369 -2.3876,-3.5311 -39.14055,-23.89196 -39.14055,-23.89196 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:2;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cscccsc"
+         inkscape:label="button1" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button8"
+         d="m 628.04958,593.10024 0.49507,14.70392 12.83009,-3.38427 0.40624,-15.06815 z"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="button8"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="path1066"
+         d="m 627.90449,577.48074 0.0433,13.61229 13.8314,-3.62778 0.26977,-12.19815 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#eeeeec;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="ccccc" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="button2"
+         width="17.152637"
+         height="51.954956"
+         x="625.46503"
+         y="503.7612"
+         rx="8.5763187"
+         ry="8.5763187"
+         inkscape:label="button2" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button9"
+         d="m 571.71502,536.16159 -13.37348,-0.0202 6.35231,-51.77747 8.21575,-5.98232 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="button9"
+         sodipodi:nodetypes="ccccc" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 555.80382,560.27286 -0.30837,24.78125 c 0,0 -9.03682,-4.60654 -9.90319,-7.77545 0.0415,-3.60362 -0.18445,-19.91344 2.0354,-22.18465 1.67175,-1.71044 8.17616,5.17885 8.17616,5.17885 z"
+         id="button4"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccsc"
+         inkscape:label="button4" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button5"
+         d="m 557.26352,587.31588 9.66008,34.78358 -6.52394,1.18885 -2.64044,-3.13786 -5.42988,-24.0563 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         sodipodi:nodetypes="cccccc"
+         inkscape:label="button5" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button10"
+         d="m 571.49101,536.36645 -13.87865,3.19172 c 0,0 -2.16679,33.15285 -1.42167,41.4553 0.50637,5.64215 3.92974,21.91823 5.27494,27.02783 0.86112,3.27084 5.60182,14.75965 7.21442,18.80434 0.41801,1.04843 5.95904,-1.02691 5.95904,-1.02691 0,0 -4.24473,-33.04231 -3.72597,-51.74587 0.46644,-16.81736 0.57789,-37.70641 0.57789,-37.70641 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="button10"
+         sodipodi:nodetypes="ccssscsc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button3"
+         d="m 566.81358,621.91645 -6.28148,1.28687 -0.36451,5.59427 8.12985,32.77766 4.22971,3.66243 4.4326,-1.32559 z"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#ffffff;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="button3"
+         sodipodi:nodetypes="ccccccc" />
+      <path
+         inkscape:connector-curvature="0"
+         id="button7"
+         d="m 654.80262,526.99557 v 7.97553 l 3.83318,-3.83321 z"
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="button7" />
+      <path
+         style="color:#000000;display:inline;overflow:visible;opacity:1;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 612.84542,526.99557 v 7.97553 l -3.83318,-3.83321 z"
+         id="button6"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cccc" />
+      <path
+         id="led0"
+         style="color:#000000;display:inline;overflow:visible;vector-effect:none;fill:#babdb6;fill-opacity:1;stroke:none;stroke-width:0.999999;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 699.83007,597.09532 c 0,0 -16.46015,85.54578 -25.31343,86.37773 -5.47204,7.62655 -75.2405,-7.05854 -83.35928,-8.86308 -4.4067,-3.00486 -10.28788,-1.54967 -13.42666,-11.03417 l -5.4313,1.54016 c 0,0 -4.44322,-4.39177 -3.4609,-2.01303 0.98232,2.37874 4.42788,9.92811 4.88135,10.60457 2.44642,3.64943 5.46761,4.77645 9.87336,6.69341 43.63132,14.22708 86.19514,10.28952 88.44796,19.97257 l 12.28811,52.81677 c 0.43306,-9.81325 9.12954,-1.78785 6.30456,-10.51417 -1.75087,-5.40843 -9.01324,-37.84197 -7.94408,-46.63044 2.13832,-17.57695 7.86233,-29.84721 13.51752,-49.89164 4.1949,-14.86858 8.0422,-47.11406 8.0422,-47.11406 z"
+         inkscape:label="led0"
+         sodipodi:nodetypes="cccccsscscssscc"
+         transform="translate(-3.0906465e-6)" />
+    </g>
+    <path
+       sodipodi:nodetypes="ccsc"
+       inkscape:connector-curvature="0"
+       id="path1144-6"
+       d="m 316.8262,743.07934 c -3.32917,-8.73134 -10.57574,-41.72329 -8.38792,-48.64443 0,0 6.8191,-30.41972 12.47429,-50.46415 4.19492,-14.86859 6.44152,-43.37742 6.44152,-43.37742"
+       style="color:#000000;display:inline;overflow:visible;vector-effect:none;fill:none;fill-opacity:1;stroke:#babdb6;stroke-width:1;stroke-linecap:butt;stroke-linejoin:bevel;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal" />
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="Buttons"
+     inkscape:label="Buttons"
+     style="display:inline"
+     transform="translate(-16.168953)">
+    <g
+       id="button10-path"
+       inkscape:label="button10-path">
+      <path
+         sodipodi:nodetypes="cc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 16.647547,140.50615 H 189.32589"
+         id="path962"
+         inkscape:connector-curvature="0"
+         inkscape:label="path" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect972"
+         width="6.999999"
+         height="6.999999"
+         x="188"
+         y="137"
+         inkscape:label="end" />
+      <rect
+         inkscape:label="leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button10-leader"
+         width="1"
+         height="1"
+         x="16.160379"
+         y="140.00227" />
+    </g>
+    <g
+       id="button9-path"
+       inkscape:label="button9-path"
+       style="display:inline">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path914"
+         d="M 17.317611,102.62275 H 193.49717"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="path" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect912"
+         width="6.999999"
+         height="6.999999"
+         x="190.04652"
+         y="99.085022"
+         inkscape:label="end" />
+      <rect
+         inkscape:label="leader"
+         y="-103.12814"
+         x="-17.147846"
+         height="1"
+         width="1"
+         id="button9-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+    <g
+       id="button8-path"
+       inkscape:label="button8-path"
+       style="display:inline">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path1259"
+         d="M 483.53718,212.39827 H 270.9095 l -9.8103,-12.80072"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="path" />
+      <rect
+         y="-202.69656"
+         x="-264.28854"
+         height="6.999999"
+         width="6.999999"
+         id="rect1261"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)"
+         inkscape:label="end" />
+      <rect
+         inkscape:label="leader"
+         y="-212.96104"
+         x="-483.97687"
+         height="1"
+         width="1"
+         id="button8-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+    <g
+       id="button7-path"
+       inkscape:label="button7-path">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 483.77415,137.25495 H 276.84589 l -7.66607,-6.20924"
+         id="path902"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         inkscape:label="path" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect904"
+         width="6.999999"
+         height="6.999999"
+         x="265.22852"
+         y="126.95988"
+         inkscape:label="end" />
+      <rect
+         inkscape:label="leader"
+         y="-137.68253"
+         x="-484.03345"
+         height="1"
+         width="1"
+         id="button7-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+    <g
+       id="button6-path"
+       inkscape:label="button6-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path900"
+         d="M 483.46953,173.77617 H 290.44746 l -39.0389,-42.52242"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="path" />
+      <rect
+         y="126.89067"
+         x="247.91878"
+         height="6.999999"
+         width="6.999999"
+         id="rect906"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="end" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button6-leader"
+         width="1"
+         height="1"
+         x="-483.97461"
+         y="-174.29027"
+         inkscape:label="leader" />
+    </g>
+    <g
+       id="button5-path"
+       inkscape:label="button5-path"
+       style="display:inline">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 17.16895,216.72696 168.18509,0.0884"
+         id="path896"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="cc"
+         inkscape:label="path" />
+      <rect
+         y="-219.98177"
+         x="-189.36707"
+         height="6.999999"
+         width="6.999999"
+         id="rect1297"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)"
+         inkscape:label="end" />
+      <rect
+         inkscape:label="leader"
+         y="-217.22577"
+         x="-17.190804"
+         height="1"
+         width="1"
+         id="button5-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         transform="scale(-1)" />
+    </g>
+    <g
+       id="button4-path"
+       inkscape:label="button4-path"
+       style="display:inline">
+      <path
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="m 16.748599,180.50551 149.345511,-0.25 10.07296,-10.8079"
+         id="path890"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccc"
+         inkscape:label="path" />
+      <rect
+         y="-172.8806"
+         x="-179.9959"
+         height="6.999999"
+         width="6.999999"
+         id="rect894"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         transform="scale(-1)"
+         inkscape:label="end" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:end;display:inline;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button4-leader"
+         width="1"
+         height="1"
+         x="-17.207354"
+         y="-180.95628"
+         inkscape:label="leader" />
+    </g>
+    <g
+       id="button3-path"
+       inkscape:label="button3-path"
+       transform="translate(1.620071e-7,-12.676636)"
+       style="display:inline">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path1295"
+         d="m 17.294405,266.46958 177.305975,0.0407"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="path" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect1301"
+         width="6.999999"
+         height="6.999999"
+         x="-199.29643"
+         y="-269.40173"
+         inkscape:label="end" />
+      <rect
+         transform="scale(-1)"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1;stroke-linecap:round"
+         id="button3-leader"
+         width="1.1351269"
+         height="1"
+         x="-17.294409"
+         y="-266.98993"
+         inkscape:label="leader" />
+    </g>
+    <g
+       id="button2-path"
+       inkscape:label="button2-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path960"
+         d="M 483.15129,100.50615 H 266.97374 l -7.07445,7.07445"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="path" />
+      <rect
+         y="106.64424"
+         x="256.66013"
+         height="6.999999"
+         width="6.999999"
+         id="rect970"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="end" />
+      <rect
+         inkscape:label="leader"
+         y="100"
+         x="483"
+         height="1"
+         width="1"
+         id="button2-leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+    <g
+       id="button1-path"
+       inkscape:label="button1-path">
+      <path
+         sodipodi:nodetypes="ccc"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         d="M 293.33371,84.500026 315.07748,60.50615 h 167.97814"
+         id="path958"
+         inkscape:connector-curvature="0"
+         inkscape:label="path" />
+      <rect
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         id="rect968"
+         width="6.999999"
+         height="6.999999"
+         x="289.52002"
+         y="81.23011"
+         inkscape:label="end" />
+      <rect
+         inkscape:label="leader"
+         style="color:#000000;text-align:start;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round"
+         id="button1-leader"
+         width="1"
+         height="1"
+         x="483"
+         y="60" />
+    </g>
+    <g
+       id="button0-path"
+       inkscape:label="button0-path"
+       style="display:inline">
+      <path
+         sodipodi:nodetypes="ccc"
+         inkscape:connector-curvature="0"
+         id="path954"
+         d="M 222.23115,87.723183 183.47649,61.765111 H 16.886052"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:none;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="path" />
+      <rect
+         y="83.937393"
+         x="218.94106"
+         height="6.999999"
+         width="6.999999"
+         id="rect952"
+         style="color:#000000;overflow:visible;opacity:1;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:2;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;marker-start:none;marker-mid:none;marker-end:none;paint-order:normal"
+         inkscape:label="end" />
+      <rect
+         inkscape:label="leader"
+         y="61.23798"
+         x="16.126192"
+         height="1"
+         width="1"
+         id="button0-leader"
+         style="color:#000000;text-align:end;overflow:visible;vector-effect:none;fill:#888a85;fill-opacity:1;stroke:none;stroke-linecap:round" />
+    </g>
+  </g>
+  <g
+     inkscape:groupmode="layer"
+     id="LEDs"
+     inkscape:label="LEDs">
+    <g
+       id="led0-path"
+       inkscape:label="led0-path"
+       style="display:inline">
+      <path
+         sodipodi:nodetypes="cc"
+         inkscape:connector-curvature="0"
+         id="path1"
+         d="M 285.28098,291.5 H 467.36822"
+         style="vector-effect:none;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:1;stroke-linecap:square;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
+         inkscape:label="path" />
+      <rect
+         y="288"
+         x="283.03723"
+         height="7"
+         width="7"
+         id="rect1"
+         style="display:inline;vector-effect:none;fill:#2e3436;fill-opacity:1;stroke:none;stroke-width:0;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none"
+         inkscape:label="end" />
+      <rect
+         style="display:inline;text-align:start;fill:#888a85;fill-opacity:1;stroke:none;stroke-width:1"
+         id="led0-leader"
+         width="1"
+         height="1"
+         x="466.86823"
+         y="291"
+         inkscape:label="led0-leader" />
+    </g>
+  </g>
+</svg>

--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -102,6 +102,14 @@ Svg=logitech-g502-x.svg
 DeviceMatch=usb:046d:c099
 Svg=logitech-g502-x.svg
 
+[Logitech G502 X PLUS]
+DeviceMatch=usb:046d:c095
+Svg=logitech-g502-x.svg
+
+[Logitech G502 X PLUS Wireless]
+DeviceMatch=usb:046d:4099;usb:046d:c547
+Svg=logitech-g502-x.svg
+
 [Logitech G502 Hero Wireless]
 DeviceMatch=usb:046d:407f;usb:046d:c08d
 Svg=logitech-g502.svg

--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -104,11 +104,11 @@ Svg=logitech-g502-x.svg
 
 [Logitech G502 X PLUS]
 DeviceMatch=usb:046d:c095
-Svg=logitech-g502-x.svg
+Svg=logitech-g502-x-plus.svg
 
 [Logitech G502 X PLUS Wireless]
-DeviceMatch=usb:046d:4099;usb:046d:c547
-Svg=logitech-g502-x.svg
+DeviceMatch=usb:046d:c547;usb:046d:c095
+Svg=logitech-g502-x-plus.svg
 
 [Logitech G502 Hero Wireless]
 DeviceMatch=usb:046d:407f;usb:046d:c08d


### PR DESCRIPTION
Complementing the following `libratbag/libratbag` pull request by @Sewer56:

- https://github.com/libratbag/libratbag/pull/1693/

Modifying the existing logitech-g502.svg file to match G502X Plus LEDs.

![01_Resolution](https://github.com/user-attachments/assets/5a7f1f73-88d3-4adc-92f5-b83ef620e1d3)
![02_Buttons](https://github.com/user-attachments/assets/7bf2edbb-6c38-43ec-8e92-fe494425d8c0)
![03_LEDs](https://github.com/user-attachments/assets/baafa23b-4da4-4981-aab8-75833c2f7441)
![04_Advanced](https://github.com/user-attachments/assets/f2445973-7b42-452b-9e7f-891c2bc1596f)


