### PR TITLE
data: add G502 X Plus in wireless mode (usb:046d:4099)

### DIFF
--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -103,7 +103,7 @@ DeviceMatch=usb:046d:c099
 Svg=logitech-g502-x.svg
 
 [Logitech G502 X PLUS]
-DeviceMatch=usb:046d:c095;usb:046d:4099
+DeviceMatch=usb:046d:4099;usb:046d:c095
 Svg=logitech-g502-x-plus.svg
 
 [Logitech G502 Hero Wireless]


### PR DESCRIPTION
This PR adds device ID for G502 X PLUSE when it's used in wireless mode.
Support in libratbag:
https://github.com/libratbag/libratbag/pull/1728

Required kernel driver:
https://github.com/Kvalme/hid-logitech-dj