### PR TITLE
Fix running on wayland

### DIFF
--- a/piper/buttondialog.py
+++ b/piper/buttondialog.py
@@ -10,7 +10,7 @@ from .ratbagd import RatbagdButton, RatbagdMacro, RatbagDeviceType
 import gi
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import Gdk, GdkX11, GObject, Gtk  # noqa
+from gi.repository import Gdk, GObject, Gtk  # noqa
 
 
 @Gtk.Template(resource_path="/org/freedesktop/Piper/ui/ButtonRow.ui")


### PR DESCRIPTION
This is the only change needed to allow running under a Wayland-only system.

The `GdkX11` import was introduced in 21943b9 for type hinting, but the type has since been modified, so this import isn't used at all anymore.