### PR TITLE
1-based button-numbers

### DIFF
--- a/piper/buttondialog.py
+++ b/piper/buttondialog.py
@@ -125,7 +125,7 @@ class ButtonDialog(Gtk.Dialog):
         # Shows the listbox to swap the primary buttons.
         self.stack.set_visible_child_name("handedness")
         # Left mouse button (index 0) is mapped to right mouse button, where
-        # mappings are 1-indexed and thus right mouse click has value 2.
+        # mappings are 1-based and thus right mouse click has value 2.
         # Or, right mouse button (index 1) is mapped to left mouse button,
         # which has value 1.
         if (
@@ -149,7 +149,8 @@ class ButtonDialog(Gtk.Dialog):
 
         i = 0
         for button in buttons:
-            key, name = self._get_button_name_and_description(button)
+            # again, index is 0-based and mapping is 1-based, so +1
+            name = RatbagdButton.get_description_by_mapping_number(button.index + 1)
             # Translators: section header for mapping one button's click to another.
             row = ButtonRow(
                 name,
@@ -248,18 +249,6 @@ class ButtonDialog(Gtk.Dialog):
         search = self.search_entry.get_text().casefold()
 
         return all(term in description for term in search.split(" "))
-
-    def _get_button_name_and_description(
-        self, button: RatbagdButton
-    ) -> Tuple[str, str]:
-        # Translators: the {} will be replaced with the button index, e.g.
-        # "Button 1 click".
-        name = _("Button {} click").format(button.index)
-        if button.index in RatbagdButton.BUTTON_DESCRIPTION:
-            description = _(RatbagdButton.BUTTON_DESCRIPTION[button.index])
-        else:
-            description = name
-        return name, description
 
     def _grab_seat(self) -> bool:
         """

--- a/piper/buttonspage.py
+++ b/piper/buttonspage.py
@@ -97,12 +97,7 @@ class ButtonsPage(Gtk.Box):
         # corresponding optionbutton has to be updated.
         action_type = ratbagd_button.action_type
         if action_type == RatbagdButton.ActionType.BUTTON:
-            if ratbagd_button.mapping - 1 in RatbagdButton.BUTTON_DESCRIPTION:
-                label = _(RatbagdButton.BUTTON_DESCRIPTION[ratbagd_button.mapping - 1])
-            else:
-                # Translators: the {} will be replaced with the button index, e.g.
-                # "Button 1 click".
-                label = _("Button {} click").format(ratbagd_button.mapping - 1)
+            label = RatbagdButton.get_description_by_mapping_number(ratbagd_button.mapping)
         elif action_type == RatbagdButton.ActionType.SPECIAL:
             label = _(RatbagdButton.SPECIAL_DESCRIPTION[ratbagd_button.special])
         elif action_type == RatbagdButton.ActionType.MACRO:
@@ -128,7 +123,8 @@ class ButtonsPage(Gtk.Box):
             ratbagd_button,
             buttons,
             device_type,
-            title=_("Configure button {}").format(ratbagd_button.index),
+            # + 1 because 1-based button numbers are more intuitive than 0-based.  Left-click = Button 1.
+            title=_("Configure button {}").format(ratbagd_button.index + 1),
             use_header_bar=True,
             transient_for=self.get_toplevel(),
         )
@@ -155,7 +151,7 @@ class ButtonsPage(Gtk.Box):
                     right = self._find_button_type(1)
                     if left is None or right is None:
                         return
-                    # Mappings are 1-indexed, so 1 is left mouse click and 2 is
+                    # Mappings are 1-based, so 1 is left mouse click and 2 is
                     # right mouse click.
                     if dialog.mapping == ButtonDialog.LEFT_HANDED_MODE:
                         left.mapping, right.mapping = 2, 1

--- a/po/be.po
+++ b/po/be.po
@@ -82,7 +82,7 @@ msgstr "Асобная прывязка"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:222 piper/buttonspage.py:90
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Клік кнопкі {}"
 

--- a/po/bg.po
+++ b/po/bg.po
@@ -84,7 +84,7 @@ msgstr "Специално съответствие"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:222 piper/buttonspage.py:90
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Щракване на бутон {}"
 

--- a/po/cs.po
+++ b/po/cs.po
@@ -78,7 +78,7 @@ msgstr "Speciální mapování"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:208 piper/buttonspage.py:76
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Kliknutí tlačítka {}"
 

--- a/po/de.po
+++ b/po/de.po
@@ -84,7 +84,7 @@ msgstr "Spezialfunktion"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:222 piper/buttonspage.py:90
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Klick mit Taste {}"
 

--- a/po/es.po
+++ b/po/es.po
@@ -83,7 +83,7 @@ msgstr "Mapeado especial"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:222 piper/buttonspage.py:90
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Pulsación del botón {}"
 

--- a/po/fr.po
+++ b/po/fr.po
@@ -83,7 +83,7 @@ msgstr "Autre"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:257 piper/buttonspage.py:105
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Clic du bouton {}"
 

--- a/po/hr.po
+++ b/po/hr.po
@@ -83,7 +83,7 @@ msgstr "Posebno mapiranje"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:222 piper/buttonspage.py:90
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Tipka {} klik"
 

--- a/po/it.po
+++ b/po/it.po
@@ -83,7 +83,7 @@ msgstr "Mappatura speciale"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:222 piper/buttonspage.py:90
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Click pulsante {}"
 

--- a/po/ka.po
+++ b/po/ka.po
@@ -79,7 +79,7 @@ msgstr "სპეციალური მიბმა"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:217 piper/buttonspage.py:79
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "ღილაკის {} წკაპი"
 

--- a/po/nl.po
+++ b/po/nl.po
@@ -85,7 +85,7 @@ msgstr "Overig"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:257 piper/buttonspage.py:105
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "{} muisklik"
 

--- a/po/pl.po
+++ b/po/pl.po
@@ -86,7 +86,7 @@ msgstr "Mapowanie specjalne"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:222 piper/buttonspage.py:90
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Kliknięcie {}. przyciskiem"
 

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -77,7 +77,7 @@ msgstr "Mapeamento especial"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:222 piper/buttonspage.py:90
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Clique com o botão {}"
 

--- a/po/ru.po
+++ b/po/ru.po
@@ -82,7 +82,7 @@ msgstr "Отдельная привязка"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:208 piper/buttonspage.py:76
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Клик кнопки {}"
 

--- a/po/sv.po
+++ b/po/sv.po
@@ -82,7 +82,7 @@ msgstr "Speciell bindning"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:222 piper/buttonspage.py:90
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Knapp {} klick"
 

--- a/po/uk_UA.po
+++ b/po/uk_UA.po
@@ -76,7 +76,7 @@ msgstr "Особлива прив'язка"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:208 piper/buttonspage.py:76
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "Клік клавіші {}"
 

--- a/po/zh_CN.po
+++ b/po/zh_CN.po
@@ -76,7 +76,7 @@ msgstr "特殊映射"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:208 piper/buttonspage.py:76
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "按钮 {} 点击"
 

--- a/po/zh_TW.po
+++ b/po/zh_TW.po
@@ -83,7 +83,7 @@ msgstr "其他"
 
 #. Translators: the {} will be replaced with the button index, e.g.
 #. "Button 1 click".
-#: piper/buttondialog.py:257 piper/buttonspage.py:105
+#: piper/ratbagd.py:898
 msgid "Button {} click"
 msgstr "按鈕 {} 點擊"
 


### PR DESCRIPTION
- appear in the header of Configure screens
- appear as button-names when selecting mappings
- appended to the Backward and Forward buttons mappings
- code for generating button descriptions consolidated into ratbagd.py
- move const docstrings to *below* the declaration where tools better-pick-up on them
- standardize on term "1-based" instead of less-common "1-indexed"