### PR TITLE
data: add SVG for ASUS ROG Keris II Origin (usb:0b05:1c0c)

### DIFF
--- a/data/svgs/asus-rog-keris-ii-origin.svg
+++ b/data/svgs/asus-rog-keris-ii-origin.svg
@@ -1,0 +1,1 @@
+asus-generic-8btn-dpibot.svg

--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -26,6 +26,10 @@ Svg=asus-rog-keris-wireless.svg
 DeviceMatch=usb:0b05:1a68
 Svg=asus-rog-keris-wireless-aimpoint.svg
 
+[ASUS ROG Keris II Origin]
+DeviceMatch=usb:0b05:1c0c;bluetooth:0b05:1c0f
+Svg=asus-rog-keris-ii-origin.svg
+
 [ASUS ROG Strix Carry]
 DeviceMatch=usb:0b05:18b4
 Svg=asus-rog-strix-carry.svg


### PR DESCRIPTION
- This is a relatively new mouse released earlier this year (2025)
- It supports Wired USB, Wireless RF, and Wireless BT
- The device ID here is from Wired USB mode