### PR TITLE
feature: Add support for ASUS TUF GAMING M4 AIR

### DIFF
--- a/data/svgs/asus-tuf-gaming-m4-air.svg
+++ b/data/svgs/asus-tuf-gaming-m4-air.svg
@@ -1,0 +1,1 @@
+asus-generic-8btn.svg

--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -38,6 +38,10 @@ Svg=asus-rog-strix-impact2.svg
 DeviceMatch=usb:0b05:1949;usb:0b05:1947
 Svg=asus-rog-strix-impact2-wireless.svg
 
+[ASUS TUF GAMING M4 AIR]
+DeviceMatch=usb:0b05:1a03
+Svg=asus-tuf-gaming-m4-air.svg
+
 [Etekcity Scroll Alpha]
 DeviceMatch=usb:1ea7:4011
 Svg=fallback.svg


### PR DESCRIPTION
This commit adds support for the TUF GAMING M4 AIR mouse manufactured by ASUS/ASUSTek.
Corresponding libratbag PR: https://github.com/libratbag/libratbag/pull/1821.