### PR TITLE
data: add Logitech G502 X Wireless through LS dongle (046d:409f)

### DIFF
--- a/data/svgs/svg-lookup.ini
+++ b/data/svgs/svg-lookup.ini
@@ -99,7 +99,7 @@ DeviceMatch=usb:046d:c24e
 Svg=logitech-g500s.svg
 
 [Logitech G502 X Wireless]
-DeviceMatch=usb:046d:c098
+DeviceMatch=usb:046d:c098;usb:046d:409f
 Svg=logitech-g502-x.svg
 
 [Logitech G502 X]


### PR DESCRIPTION
Added USB ID 046d:409f, this is the ID when connected through the LS dongle. USB ID 046d:c098 is the ID when wired.