### PR TITLE
feature: Add profile renaming

### DIFF
--- a/data/ui/ProfileRow.ui
+++ b/data/ui/ProfileRow.ui
@@ -36,18 +36,68 @@
           </packing>
         </child>
         <child>
-          <object class="GtkLabel" id="title">
+          <object class="GtkButton" id="rename_button">
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="tooltip-text" translatable="yes">Rename this profile</property>
+            <property name="relief">none</property>
+            <signal name="clicked" handler="_on_rename_button_clicked" swapped="no"/>
+            <child>
+              <object class="GtkImage">
+                <property name="can-focus">False</property>
+                <property name="icon-name">document-edit-symbolic</property>
+                <property name="icon_size">1</property>
+              </object>
+            </child>
+            <style>
+              <class name="image-button"/>
+              <class name="circular"/>
+            </style>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="pack-type">end</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkStack" id="name_stack">
             <property name="visible">True</property>
             <property name="can-focus">False</property>
-            <property name="valign">baseline</property>
-            <property name="label">Profile 1</property>
-            <property name="single-line-mode">True</property>
-            <property name="track-visited-links">False</property>
+            <property name="transition-type">crossfade</property>
+            <property name="transition-duration">100</property>
+            <child>
+              <object class="GtkLabel" id="title">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="valign">baseline</property>
+                <property name="label">Profile 1</property>
+                <property name="single-line-mode">True</property>
+                <property name="track-visited-links">False</property>
+              </object>
+              <packing>
+                <property name="name">label</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="name_entry">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="max-length">100</property>
+                <signal name="activate" handler="_on_name_entry_activate" swapped="no"/>
+                <signal name="focus-out-event" handler="_on_name_entry_focus_out_event" swapped="no"/>
+                <signal name="key-press-event" handler="_on_name_entry_key_press_event" swapped="no"/>
+              </object>
+              <packing>
+                <property name="name">entry</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>

--- a/piper/mouseperspective.py
+++ b/piper/mouseperspective.py
@@ -95,6 +95,9 @@ class MousePerspective(Gtk.Overlay):
                 self, profile, "notify::dirty", self._on_profile_notify_dirty
             )
             row = ProfileRow(profile)
+            connect_signal_with_weak_ref(
+                self, row, "notify::name", self._on_profile_row_name_changed
+            )
             self.listbox_profiles.insert(row, profile.index)
 
         self._on_profile_notify_disabled(active_profile, None)
@@ -185,6 +188,12 @@ class MousePerspective(Gtk.Overlay):
                 continue
             profile.disabled = False
             break
+
+    def _on_profile_row_name_changed(
+        self, row: ProfileRow, pspec: Optional[GObject.ParamSpec]
+    ) -> None:
+        if row.profile is self._profile:
+            self.label_profile.set_label(row.name)
 
     def _on_profile_notify_disabled(
         self, profile: RatbagdProfile, pspec: Optional[GObject.ParamSpec]

--- a/piper/profilerow.py
+++ b/piper/profilerow.py
@@ -10,7 +10,7 @@ from piper.ratbagd import RatbagdProfile
 from .util.gobject import connect_signal_with_weak_ref
 
 gi.require_version("Gtk", "3.0")
-from gi.repository import GObject, Gtk  # noqa
+from gi.repository import Gdk, GObject, Gtk  # noqa
 
 
 @Gtk.Template(resource_path="/org/freedesktop/Piper/ui/ProfileRow.ui")
@@ -21,10 +21,14 @@ class ProfileRow(Gtk.ListBoxRow):
     __gtype_name__ = "ProfileRow"
 
     title: Gtk.Label = Gtk.Template.Child()  # type: ignore
+    name_stack: Gtk.Stack = Gtk.Template.Child()  # type: ignore
+    name_entry: Gtk.Entry = Gtk.Template.Child()  # type: ignore
+    rename_button: Gtk.Button = Gtk.Template.Child()  # type: ignore
 
     def __init__(self, profile: RatbagdProfile, *args, **kwargs) -> None:
         Gtk.ListBoxRow.__init__(self, *args, **kwargs)
         self._profile = profile
+        self._committing = False
         connect_signal_with_weak_ref(
             self, self._profile, "notify::disabled", self._on_profile_notify_disabled
         )
@@ -34,6 +38,9 @@ class ProfileRow(Gtk.ListBoxRow):
             name = f"Profile {profile.index}"
 
         self.title.set_text(name)
+        self.rename_button.set_visible(
+            RatbagdProfile.CAP_WRITABLE_NAME in profile.capabilities
+        )
         self.show_all()
         self.set_visible(not profile.disabled)
 
@@ -49,6 +56,44 @@ class ProfileRow(Gtk.ListBoxRow):
         else:
             # TODO: display this in the app
             print("Trying to disable the active profile", file=sys.stderr)
+
+    @Gtk.Template.Callback("_on_rename_button_clicked")
+    def _on_rename_button_clicked(self, button: Gtk.Button) -> None:
+        self.name_entry.set_text(self.title.get_text())
+        self.name_stack.set_visible_child_name("entry")
+        self.name_entry.grab_focus()
+
+    @Gtk.Template.Callback("_on_name_entry_activate")
+    def _on_name_entry_activate(self, entry: Gtk.Entry) -> None:
+        self._commit_rename()
+
+    @Gtk.Template.Callback("_on_name_entry_focus_out_event")
+    def _on_name_entry_focus_out_event(
+        self, entry: Gtk.Entry, event: Gdk.EventFocus
+    ) -> bool:
+        self._commit_rename()
+        return False
+
+    @Gtk.Template.Callback("_on_name_entry_key_press_event")
+    def _on_name_entry_key_press_event(
+        self, entry: Gtk.Entry, event: Gdk.EventKey
+    ) -> bool:
+        if event.keyval == Gdk.KEY_Escape:
+            self.name_stack.set_visible_child_name("label")
+            return True
+        return False
+
+    def _commit_rename(self) -> None:
+        if self._committing:
+            return
+        self._committing = True
+        new_name = self.name_entry.get_text().strip()
+        if new_name and new_name != self.title.get_text():
+            self._profile.name = new_name
+            self.title.set_text(new_name)
+            self.notify("name")
+        self.name_stack.set_visible_child_name("label")
+        self._committing = False
 
     def set_active(self) -> None:
         """Activates the profile paired with this row."""

--- a/piper/ratbagd.py
+++ b/piper/ratbagd.py
@@ -279,6 +279,7 @@ class Ratbagd(_RatbagdDBus):
     }
 
     def __init__(self, api_version):
+        self._devices = []
         super().__init__("Manager", None)
         result = self._get_dbus_property("Devices")
         if result is None and not self._proxy.get_cached_property_names():


### PR DESCRIPTION
Closes https://github.com/libratbag/piper/issues/85 and https://github.com/libratbag/piper/issues/1104

Adds the ability to rename profiles

a pencil button (document-edit-symbolic) appears next to each profile row on devices that support profile names. ratbagd has no capability flag for renaming, so a profile having a name is what indicates support.

Clicking it switches to an editable field. Enter / moving focus away chooses the new name. Esc cancels without saving. The header label updates as soon as teh profile is renamed.

Only works on older devices that use HID++ 1.0 (devices that support renaming): for example Logitech G5, G9/G9x, G500/G500s, G700/G700s, MX series, M705

Tested with the libratbag test device (rename persists in ratbagd). On devices without name support (tested with a G502 HERO), the button stays hidden

also fixed a possible crash where the `_on_properties_changed` handler could run on a partially initialized ratbagd if `__init__` raised (separate but minor issue in piper/ratbagd.py)