### PR TITLE
Set prgname to application ID

### DIFF
--- a/piper/application.py
+++ b/piper/application.py
@@ -26,6 +26,7 @@ class Application(Gtk.Application):
             flags=Gio.ApplicationFlags.FLAGS_NONE,
         )
         GLib.set_application_name("Piper")
+        GLib.set_prgname("org.freedesktop.Piper")
         self._required_ratbagd_version = ratbagd_api_version
 
     def do_startup(self) -> None:


### PR DESCRIPTION
Using the application ID ensures that Wayland compositors could match the window with the application and show the appropriate icon for them.

References:
- https://honk.sigxcpu.org/con/GTK__and_the_application_id.html
- https://docs.gtk.org/gtk4/migrating-3to4.html#set-a-proper-application-id